### PR TITLE
fix: LCM Processor for non launcher contracts

### DIFF
--- a/core/main/src/bootstrap/extn/check_launcher_step.rs
+++ b/core/main/src/bootstrap/extn/check_launcher_step.rs
@@ -27,10 +27,7 @@ use ripple_sdk::{
     utils::error::RippleError,
 };
 
-use crate::{
-    processor::lifecycle_management_processor::LifecycleManagementProcessor,
-    state::bootstrap_state::BootstrapState,
-};
+use crate::state::bootstrap_state::BootstrapState;
 
 /// Bootstep which checks if the given run has the launcher channel and starts,
 /// This step calls the start method on the Launcher Channel and waits for a successful Status
@@ -44,9 +41,6 @@ impl Bootstep<BootstrapState> for CheckLauncherStep {
     }
     async fn setup(&self, state: BootstrapState) -> RippleResponse {
         if state.platform_state.has_internal_launcher() {
-            state.platform_state.get_client().add_request_processor(
-                LifecycleManagementProcessor::new(state.platform_state.get_client()),
-            );
             let app = state
                 .platform_state
                 .app_library_state

--- a/core/main/src/bootstrap/start_app_manager_step.rs
+++ b/core/main/src/bootstrap/start_app_manager_step.rs
@@ -18,6 +18,7 @@
 use ripple_sdk::async_trait::async_trait;
 use ripple_sdk::{framework::bootstrap::Bootstep, tokio, utils::error::RippleError};
 
+use crate::processor::lifecycle_management_processor::LifecycleManagementProcessor;
 use crate::{
     service::apps::delegated_launcher_handler::DelegatedLauncherHandler,
     state::bootstrap_state::BootstrapState,
@@ -33,6 +34,12 @@ impl Bootstep<BootstrapState> for StartAppManagerStep {
     }
 
     async fn setup(&self, state: BootstrapState) -> Result<(), RippleError> {
+        state
+            .platform_state
+            .get_client()
+            .add_request_processor(LifecycleManagementProcessor::new(
+                state.platform_state.get_client(),
+            ));
         let mut app_manager =
             DelegatedLauncherHandler::new(state.channels_state, state.platform_state);
         tokio::spawn(async move {

--- a/core/main/src/firebolt/handlers/lcm_rpc.rs
+++ b/core/main/src/firebolt/handlers/lcm_rpc.rs
@@ -26,7 +26,7 @@ use ripple_sdk::{
                 LCM_EVENT_ON_REQUEST_FINISHED, LCM_EVENT_ON_REQUEST_LAUNCH,
                 LCM_EVENT_ON_REQUEST_READY, LCM_EVENT_ON_SESSION_TRANSITION_CANCELED,
                 LCM_EVENT_ON_SESSION_TRANSITION_COMPLETED,
-            },
+            }, fb_capabilities::FireboltCap,
         },
         gateway::rpc_gateway_api::CallContext,
     },
@@ -110,8 +110,7 @@ impl LifecycleManagementImpl {
         let listen = request.listen;
         ProviderBroker::register_or_unregister_provider(
             &self.state,
-            // TODO update with Firebolt Cap in later effort
-            "xrn::firebolt::app:lifecycle".into(),
+            FireboltCap::short("app:lifecycle").as_str(),
             method.into(),
             event_name,
             ctx,

--- a/core/main/src/firebolt/handlers/lcm_rpc.rs
+++ b/core/main/src/firebolt/handlers/lcm_rpc.rs
@@ -20,13 +20,14 @@ use ripple_sdk::{
     api::{
         apps::{AppManagerResponse, AppMethod, AppRequest, AppResponse},
         firebolt::{
+            fb_capabilities::FireboltCap,
             fb_general::{ListenRequest, ListenerResponse},
             fb_lifecycle_management::{
                 AppSessionRequest, SessionResponse, SetStateRequest, LCM_EVENT_ON_REQUEST_CLOSE,
                 LCM_EVENT_ON_REQUEST_FINISHED, LCM_EVENT_ON_REQUEST_LAUNCH,
                 LCM_EVENT_ON_REQUEST_READY, LCM_EVENT_ON_SESSION_TRANSITION_CANCELED,
                 LCM_EVENT_ON_SESSION_TRANSITION_COMPLETED,
-            }, fb_capabilities::FireboltCap,
+            },
         },
         gateway::rpc_gateway_api::CallContext,
     },


### PR DESCRIPTION
Lifecycle management processor is right now only available for Builds with launcher contract.

Change:
Lifecycle management processor can be used by proprietary protocol apis during app handling process. 