### PR TITLE
fix: Move the Extension starter to a new thread

### DIFF
--- a/core/main/src/state/extn_state.rs
+++ b/core/main/src/state/extn_state.rs
@@ -18,6 +18,7 @@
 use std::{
     collections::HashMap,
     sync::{Arc, RwLock},
+    thread,
 };
 
 use jsonrpsee::core::server::rpc_module::Methods;
@@ -34,7 +35,7 @@ use ripple_sdk::{
     },
     libloading::Library,
     log::info,
-    tokio::{self, sync::mpsc},
+    tokio::sync::mpsc,
     utils::error::RippleError,
 };
 
@@ -198,7 +199,7 @@ impl ExtnState {
         );
         let (extn_tx, extn_rx) = ChannelsState::get_crossbeam_channel();
         let extn_channel = channel.channel;
-        tokio::spawn(async move {
+        thread::spawn(move || {
             (extn_channel.start)(extn_sender, extn_rx);
         });
         client.add_extn_sender(extn_id, symbol, extn_tx);


### PR DESCRIPTION
## What
The current implementation of Ripple 2.0 starts the extension on the same thread as the Tokio Runtime. Move this process to a separate thread so the Main Application's Tokio Runtime doesn't get affected.

## Why
This sometimes causes unexpected behavior to the green threads doing other operations within the main application.

## How
Using std::thread create a separate new thread and pass on the Extn starting operation so the Memory container for the Extension executes on a different thread