### PR TITLE
feat: Adding features for SystemD and RPC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,4 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"

--- a/core/launcher/Cargo.toml
+++ b/core/launcher/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "launcher"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 
 # See more keys and their definitions at https:#doc.rust-lang.org/cargo/reference/manifest.html

--- a/core/main/Cargo.toml
+++ b/core/main/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "main"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 repository = "https://github.com/rdkcentral/Ripple"
 build = "build.rs"
@@ -28,8 +28,12 @@ build = "build.rs"
 name = "ripple"
 path = "src/main.rs"
 
+[features]
+local_dev=[]
+sysd=["dep:sd-notify"]
+
 [dependencies]
-ripple_sdk = { path = "../sdk" }
+ripple_sdk = { path = "../sdk", features = ["full"] }
 jsonrpsee = { version = "0.9.0", features = ["macros", "ws-server"] }
 futures-channel = "0.3.21"
 futures = "0.3.21"
@@ -40,6 +44,7 @@ arrayvec = "0.7.2"
 regex = "=1.7.3"
 serde_json = "1.0"
 base64 = "0.13.0"
+sd-notify = { version = "0.4.1", optional = true }
 
 [build-dependencies]
 vergen = "1"

--- a/core/main/src/bootstrap/start_fbgateway_step.rs
+++ b/core/main/src/bootstrap/start_fbgateway_step.rs
@@ -100,8 +100,14 @@ impl Bootstep<BootstrapState> for FireboltGatewayStep {
             .get_client()
             .add_request_processor(RpcGatewayProcessor::new(state.platform_state.get_client()));
         debug!("Adding RPC gateway processor");
+        #[cfg(feature = "sysd")]
+        if let Ok(_) = sd_notify::booted() {
+            if let Err(_) = sd_notify::notify(false, &[sd_notify::NotifyState::Ready]) {
+                return Err(RippleError::BootstrapError);
+            }
+        }
+
         gateway.start().await;
-        debug!("Handlers initialized");
         Ok(())
     }
 }

--- a/core/sdk/Cargo.toml
+++ b/core/sdk/Cargo.toml
@@ -17,10 +17,16 @@
 
 [package]
 name = "ripple_sdk"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 repository = "https://github.com/rdkcentral/Ripple"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[features]
+default=[]
+rpc=["dep:jsonrpsee-core"]
+full=["rpc"]
+sysd=[]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
@@ -36,5 +42,5 @@ crossbeam = "0.8.2"
 tokio = { version = "1.16.1", features = ["macros", "sync", "rt-multi-thread", "signal", "time"] }
 uuid = { version = "1.1.2", features = ["serde", "v5", "v4"] }
 futures = "0.3.21"
-jsonrpsee-core = { version = "0.9.0", features = ["server"] }
+jsonrpsee-core = { version = "0.9.0", features = ["server"], optional = true }
 regex = "=1.7.3"

--- a/core/sdk/src/api/apps.rs
+++ b/core/sdk/src/api/apps.rs
@@ -199,12 +199,6 @@ pub enum AppError {
     AppNotReady,
 }
 
-impl From<AppError> for jsonrpsee_core::Error {
-    fn from(err: AppError) -> Self {
-        jsonrpsee_core::Error::Custom(format!("Internal failure: {:?}", err))
-    }
-}
-
 #[derive(Debug, Clone)]
 pub enum AppMethod {
     Launch(LaunchRequest),

--- a/core/sdk/src/api/device/device_peristence.rs
+++ b/core/sdk/src/api/device/device_peristence.rs
@@ -20,8 +20,7 @@ use crate::{
     framework::ripple_contract::RippleContract,
 };
 use chrono::Utc;
-use jsonrpsee_core::Serialize;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use super::device_request::DeviceRequest;

--- a/core/sdk/src/api/firebolt/fb_authentication.rs
+++ b/core/sdk/src/api/firebolt/fb_authentication.rs
@@ -15,8 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use jsonrpsee_core::Serialize;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     api::session::TokenType,

--- a/core/sdk/src/extn/ffi/ffi_jsonrpsee.rs
+++ b/core/sdk/src/extn/ffi/ffi_jsonrpsee.rs
@@ -15,7 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use crate::extn::client::extn_sender::ExtnSender;
+use crate::{api::apps::AppError, extn::client::extn_sender::ExtnSender};
 use crossbeam::channel::Receiver as CReceiver;
 use jsonrpsee_core::server::rpc_module::Methods;
 use libloading::{Library, Symbol};
@@ -56,4 +56,10 @@ pub unsafe fn load_jsonrpsee_methods(lib: &Library) -> Option<Box<JsonRpseeExtnB
         Err(e) => error!("Jsonrpsee Extn Builder symbol loading failed {:?}", e),
     }
     None
+}
+
+impl From<AppError> for jsonrpsee_core::Error {
+    fn from(err: AppError) -> Self {
+        jsonrpsee_core::Error::Custom(format!("Internal failure: {:?}", err))
+    }
 }

--- a/core/sdk/src/extn/ffi/mod.rs
+++ b/core/sdk/src/extn/ffi/mod.rs
@@ -16,6 +16,7 @@
 //
 
 pub mod ffi_channel;
+#[cfg(feature = "rpc")]
 pub mod ffi_jsonrpsee;
 pub mod ffi_library;
 pub mod ffi_message;

--- a/core/sdk/src/utils/logger.rs
+++ b/core/sdk/src/utils/logger.rs
@@ -23,15 +23,23 @@ pub fn init_logger(name: String) -> Result<(), fern::InitError> {
     let filter = log::LevelFilter::from_str(&log_string).unwrap_or(log::LevelFilter::Info);
     fern::Dispatch::new()
         .format(move |out, message, record| {
-            out.finish(format_args!(
-                "{}[{}][{}][{}][{}]-{}",
+            #[cfg(not(feature = "sysd"))]
+            return out.finish(format_args!(
+                "{}[{}][{}][{}]-{}",
                 chrono::Local::now().format("%Y-%m-%d-%H:%M:%S.%3f"),
-                std::thread::current().name().unwrap_or("none"),
                 record.level(),
                 record.target(),
                 name,
                 message
-            ))
+            ));
+            #[cfg(feature = "sysd")]
+            return out.finish(format_args!(
+                "[{}][{}][{}]-{}",
+                record.level(),
+                record.target(),
+                name,
+                message
+            ));
         })
         .level(filter)
         .chain(std::io::stdout())

--- a/device/thunder/Cargo.toml
+++ b/device/thunder/Cargo.toml
@@ -18,7 +18,7 @@
 
 [package]
 name = "thunder"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/device/thunder_ripple_sdk/Cargo.toml
+++ b/device/thunder_ripple_sdk/Cargo.toml
@@ -18,7 +18,7 @@
 
 [package]
 name = "thunder_ripple_sdk"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 repository = "https://github.com/rdkcentral/Ripple"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/distributor/general/Cargo.toml
+++ b/distributor/general/Cargo.toml
@@ -18,7 +18,7 @@
 
 [package]
 name = "distributor_general"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -133,7 +133,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 # Ripple sdk should be opensourced and available from crates.io at this point
-ripple_sdk = "0.7.0" 
+ripple_sdk = "0.8.0" 
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 ```

--- a/examples/rpc_extn/Cargo.toml
+++ b/examples/rpc_extn/Cargo.toml
@@ -27,7 +27,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-ripple_sdk = { path = "../../core/sdk" }
+ripple_sdk = { path = "../../core/sdk", features = ["full"] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 jsonrpsee = { version = "0.9.0", features = [ "macros", "jsonrpsee-core"] }

--- a/examples/rpc_extn/Cargo.toml
+++ b/examples/rpc_extn/Cargo.toml
@@ -18,7 +18,7 @@
 
 [package]
 name = "rpc_extn"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 
 # See more keys and their definitions at https:#doc.rust-lang.org/cargo/reference/manifest.html

--- a/systemd/ripple.service
+++ b/systemd/ripple.service
@@ -4,13 +4,13 @@ Requires=wpeframework.service
 After=wpeframework.service
 
 [Service]
-Type=simple
+Type=notify
 Environment="RUST_LOG=debug"
 EnvironmentFile=-/opt/ripple.conf
 ExecStart=/usr/bin/ripple
 ExecStop=/bin/kill -TERM $MAINPID
-Restart=always
-RestartSec=10
+Restart=on-failure
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## What

Rust supports conditional compilations using feature flags t
1. Build more light weight dependencies like adding jsonRpsee library and ffi only for required extensions.
2. Expand feature set like Running Ripple as a system d process.

## Why
1. Helps create more light weight dependencies for ripple-sdk
2. Helps Ripple abstract code for systemd specific and provides easy local development for non systemd runs.

## How
1. Addition of 2 feature flags `rpc` for sdk and `sysd` for Main
2. Addition of `sd_notify` library for notifying system d services when ripple is ready
3. Improve logging as time is redundant as sysd process already adds the timestamp. But for running as a binary or local development we need the timestamp in logging