### PR TITLE
fix: Hotfix for 1.58 based compilers

### DIFF
--- a/core/main/Cargo.toml
+++ b/core/main/Cargo.toml
@@ -30,7 +30,7 @@ path = "src/main.rs"
 
 [features]
 local_dev=[]
-sysd=["dep:sd-notify"]
+sysd=["sd-notify"]
 
 [dependencies]
 ripple_sdk = { path = "../sdk", features = ["full"] }

--- a/core/sdk/Cargo.toml
+++ b/core/sdk/Cargo.toml
@@ -24,7 +24,7 @@ repository = "https://github.com/rdkcentral/Ripple"
 
 [features]
 default=[]
-rpc=["dep:jsonrpsee-core"]
+rpc=["jsonrpsee-core"]
 full=["rpc"]
 sysd=[]
 


### PR DESCRIPTION
## What
Namespaced dependencies are not supported in older versions of rust. Change broke in Yocto as it has an older version of rust 1.58

```
| Caused by:

|   namespaced features with the `dep:` prefix are only allowed on the nightly channel and requires the `-Z namespaced-features` flag on the command-line

| WARNING: exit code 101 from a shell command.

| ERROR: Execution of '/home/jkuria217/skyxioneQ3/build-skyxione/tmp/work/armv7vet2hf-neon-rdk-linux-gnueabi/ripple/0.8.0-r0/temp/run.do_compile.467988' failed with exit code 101:

| error: failed to load manifest for workspace member
```

## Why
Yocto is yet to upgrade the older version of rust which has many deprecated features.

## How
By reverting the changes for namespaced dependency and more implicit definition of dependencies
