### PR TITLE
refactor: PermissionHandler::fetch_and_store args as reference

### DIFF
--- a/core/main/src/firebolt/firebolt_ws.rs
+++ b/core/main/src/firebolt/firebolt_ws.rs
@@ -222,7 +222,7 @@ impl FireboltWs {
             return;
         }
 
-        if let Err(_) = PermissionHandler::fetch_and_store(state.clone(), app_id.clone()).await {
+        if let Err(_) = PermissionHandler::fetch_and_store(state.clone(), &app_id).await {
             error!("Couldnt pre cache permissions");
         }
 

--- a/core/main/src/firebolt/firebolt_ws.rs
+++ b/core/main/src/firebolt/firebolt_ws.rs
@@ -222,7 +222,7 @@ impl FireboltWs {
             return;
         }
 
-        if let Err(_) = PermissionHandler::fetch_and_store(state.clone(), &app_id).await {
+        if let Err(_) = PermissionHandler::fetch_and_store(&state, &app_id).await {
             error!("Couldnt pre cache permissions");
         }
 

--- a/core/main/src/firebolt/handlers/advertising_rpc.rs
+++ b/core/main/src/firebolt/handlers/advertising_rpc.rs
@@ -162,7 +162,7 @@ impl AdvertisingServer for AdvertisingImpl {
         let payload = AdvertisingRequest::GetAdIdObject(AdIdRequestParams {
             privacy_data: privacy_rpc::get_allow_app_content_ad_targeting_settings(&self.state)
                 .await,
-            app_id: ctx.clone().app_id,
+            app_id: ctx.app_id.to_owned(),
             dist_session: session,
         });
         let resp = self.state.get_client().send_extn_request(payload).await;

--- a/core/main/src/firebolt/handlers/capabilities_rpc.rs
+++ b/core/main/src/firebolt/handlers/capabilities_rpc.rs
@@ -141,7 +141,7 @@ impl CapabilityServer for CapabilityImpl {
         {
             return Ok(v);
         } else if let Ok(_) =
-            PermissionHandler::fetch_and_store(self.state.clone(), ctx.clone().app_id).await
+            PermissionHandler::fetch_and_store(self.state.clone(), &ctx.app_id).await
         {
             //successful fetch retry
             if let Ok(v) = self
@@ -302,9 +302,7 @@ pub async fn is_permitted(
         .check_cap_role(&ctx.app_id, cap.clone())
     {
         return Ok(v);
-    } else if let Ok(_) =
-        PermissionHandler::fetch_and_store(state.clone(), ctx.clone().app_id).await
-    {
+    } else if let Ok(_) = PermissionHandler::fetch_and_store(state.clone(), &ctx.app_id).await {
         //successful fetch retry
         if let Ok(v) = state
             .cap_state

--- a/core/main/src/firebolt/handlers/capabilities_rpc.rs
+++ b/core/main/src/firebolt/handlers/capabilities_rpc.rs
@@ -140,9 +140,7 @@ impl CapabilityServer for CapabilityImpl {
             .check_cap_role(&ctx.app_id, cap.clone())
         {
             return Ok(v);
-        } else if let Ok(_) =
-            PermissionHandler::fetch_and_store(self.state.clone(), &ctx.app_id).await
-        {
+        } else if let Ok(_) = PermissionHandler::fetch_and_store(&self.state, &ctx.app_id).await {
             //successful fetch retry
             if let Ok(v) = self
                 .state
@@ -302,7 +300,7 @@ pub async fn is_permitted(
         .check_cap_role(&ctx.app_id, cap.clone())
     {
         return Ok(v);
-    } else if let Ok(_) = PermissionHandler::fetch_and_store(state.clone(), &ctx.app_id).await {
+    } else if let Ok(_) = PermissionHandler::fetch_and_store(&state, &ctx.app_id).await {
         //successful fetch retry
         if let Ok(v) = state
             .cap_state

--- a/core/main/src/firebolt/handlers/device_rpc.rs
+++ b/core/main/src/firebolt/handlers/device_rpc.rs
@@ -640,16 +640,17 @@ impl DeviceServer for DeviceImpl {
             request,
         );
 
-        if let Err(_) = self
+        if self
             .state
             .get_client()
             .send_extn_request(DeviceEventRequest {
                 event: DeviceEvent::AudioChanged,
-                id: ctx.clone().app_id,
+                id: ctx.app_id.to_owned(),
                 subscribe: listen,
                 callback_type: DeviceEventCallback::FireboltAppEvent,
             })
             .await
+            .is_err()
         {
             error!("Error while registration");
         }

--- a/core/main/src/firebolt/handlers/voice_guidance_rpc.rs
+++ b/core/main/src/firebolt/handlers/voice_guidance_rpc.rs
@@ -171,15 +171,16 @@ pub async fn voice_guidance_settings_enabled_changed(
     let listen = request.listen;
 
     // Register for individual change events (no-op if already registered), handlers emit VOICE_GUIDANCE_SETTINGS_CHANGED_EVENT.
-    if let Err(_) = platform_state
+    if platform_state
         .get_client()
         .send_extn_request(DeviceEventRequest {
             event: DeviceEvent::VoiceGuidanceChanged,
-            id: ctx.clone().app_id,
+            id: ctx.app_id.to_owned(),
             subscribe: listen,
             callback_type: DeviceEventCallback::FireboltAppEvent,
         })
         .await
+        .is_err()
     {
         error!("Error while registration");
     }

--- a/core/main/src/processor/account_link_processor.rs
+++ b/core/main/src/processor/account_link_processor.rs
@@ -77,7 +77,7 @@ impl AccountLinkProcessor {
 
         let payload = DiscoveryRequest::SignIn(SignInRequestParams {
             session_info: SessionParams {
-                app_id: ctx.clone().app_id,
+                app_id: ctx.app_id.to_owned(),
                 dist_session: session,
             },
             is_signed_in,
@@ -285,7 +285,7 @@ impl AccountLinkProcessor {
                             ProgressUnit::Percent
                         },
                         watched_on: watched_info.watched_on.clone(),
-                        app_id: ctx.clone().app_id.to_owned(),
+                        app_id: ctx.app_id.to_owned(),
                     },
                     content_partner_id: Self::get_content_partner_id(state, &ctx)
                         .await

--- a/core/main/src/service/apps/delegated_launcher_handler.rs
+++ b/core/main/src/service/apps/delegated_launcher_handler.rs
@@ -479,9 +479,7 @@ impl DelegatedLauncherHandler {
         let app_id_c = app_id.clone();
         // Fetch permissions on separate thread
         tokio::spawn(async move {
-            if let Err(_) =
-                PermissionHandler::fetch_and_store(platform_state_c, app_id_c.clone()).await
-            {
+            if let Err(_) = PermissionHandler::fetch_and_store(platform_state_c, &app_id_c).await {
                 error!("Couldnt load permissions for app {}", app_id_c)
             }
         });

--- a/core/main/src/service/apps/delegated_launcher_handler.rs
+++ b/core/main/src/service/apps/delegated_launcher_handler.rs
@@ -479,7 +479,7 @@ impl DelegatedLauncherHandler {
         let app_id_c = app_id.clone();
         // Fetch permissions on separate thread
         tokio::spawn(async move {
-            if let Err(_) = PermissionHandler::fetch_and_store(platform_state_c, &app_id_c).await {
+            if let Err(_) = PermissionHandler::fetch_and_store(&platform_state_c, &app_id_c).await {
                 error!("Couldnt load permissions for app {}", app_id_c)
             }
         });

--- a/core/main/src/state/cap/permitted_state.rs
+++ b/core/main/src/state/cap/permitted_state.rs
@@ -112,7 +112,7 @@ fn get_permissions_path(saved_dir: String) -> String {
 pub struct PermissionHandler;
 
 impl PermissionHandler {
-    pub async fn fetch_and_store(state: PlatformState, app_id: &str) -> RippleResponse {
+    pub async fn fetch_and_store(state: &PlatformState, app_id: &str) -> RippleResponse {
         if state
             .cap_state
             .permitted_state
@@ -191,7 +191,7 @@ impl PermissionHandler {
             return Self::is_all_permitted(&permitted, request);
         } else {
             // check to retrieve it one more time
-            if let Ok(_) = Self::fetch_and_store(state.clone(), app_id).await {
+            if let Ok(_) = Self::fetch_and_store(&state, app_id).await {
                 // cache primed try again
                 if let Some(permitted) = state.cap_state.permitted_state.get_app_permissions(app_id)
                 {

--- a/core/main/src/state/cap/permitted_state.rs
+++ b/core/main/src/state/cap/permitted_state.rs
@@ -112,7 +112,7 @@ fn get_permissions_path(saved_dir: String) -> String {
 pub struct PermissionHandler;
 
 impl PermissionHandler {
-    pub async fn fetch_and_store(state: PlatformState, app_id: String) -> RippleResponse {
+    pub async fn fetch_and_store(state: PlatformState, app_id: &str) -> RippleResponse {
         if state
             .cap_state
             .permitted_state
@@ -125,14 +125,14 @@ impl PermissionHandler {
             if let Ok(extn_response) = state
                 .get_client()
                 .send_extn_request(PermissionRequest {
-                    app_id: app_id.clone(),
+                    app_id: app_id.to_owned(),
                     session,
                 })
                 .await
             {
                 if let Some(permission_response) = extn_response.payload.extract() {
                     let mut map = HashMap::new();
-                    map.insert(app_id.clone(), permission_response);
+                    map.insert(app_id.to_owned(), permission_response);
                     let mut permitted_state = state.cap_state.permitted_state.clone();
                     permitted_state.ingest(map);
                     info!("Permissions fetched for {}", app_id);
@@ -191,7 +191,7 @@ impl PermissionHandler {
             return Self::is_all_permitted(&permitted, request);
         } else {
             // check to retrieve it one more time
-            if let Ok(_) = Self::fetch_and_store(state.clone(), app_id.into()).await {
+            if let Ok(_) = Self::fetch_and_store(state.clone(), app_id).await {
                 // cache primed try again
                 if let Some(permitted) = state.cap_state.permitted_state.get_app_permissions(app_id)
                 {

--- a/device/thunder_ripple_sdk/src/processors/thunder_device_info.rs
+++ b/device/thunder_ripple_sdk/src/processors/thunder_device_info.rs
@@ -509,7 +509,7 @@ impl ThunderDeviceInfoRequestProcessor {
             .await;
         info!("{}", response.message);
         if response.message.get("success").is_none()
-            || !response.message["success"].as_bool().unwrap()
+            || !response.message["success"].as_bool().unwrap_or_default()
         {
             error!("{}", response.message);
             return HashMap::new();
@@ -696,7 +696,7 @@ impl ThunderDeviceInfoRequestProcessor {
         info!("{}", response.message);
 
         if response.message.get("success").is_none()
-            || !response.message["success"].as_bool().unwrap()
+            || !response.message["success"].as_bool().unwrap_or_default()
         {
             error!("{}", response.message);
             return Vec::new();
@@ -733,7 +733,7 @@ impl ThunderDeviceInfoRequestProcessor {
             })
             .await;
         if response.message.get("success").is_none()
-            || !response.message["success"].as_bool().unwrap()
+            || !response.message["success"].as_bool().unwrap_or_default()
         {
             error!("{}", response.message);
             return Vec::new();
@@ -911,7 +911,7 @@ impl ThunderDeviceInfoRequestProcessor {
             .await;
         info!("{}", response.message);
         if response.message.get("success").is_some()
-            && response.message["success"].as_bool().unwrap()
+            && response.message["success"].as_bool().unwrap_or_default()
         {
             if let Some(v) = response.message["freeRam"].as_u64() {
                 return Self::respond(state.get_client(), req, ExtnResponse::Value(json!(v)))
@@ -949,7 +949,7 @@ impl ThunderDeviceInfoRequestProcessor {
 
         info!("{}", response.message);
         if response.message.get("success").is_none()
-            || response.message["success"].as_bool().unwrap()
+            || response.message["success"].as_bool().unwrap_or_default()
         {
             if let Ok(v) = serde_json::from_value::<ThunderTimezoneResponse>(response.message) {
                 return Ok(v.time_zone);
@@ -999,7 +999,7 @@ impl ThunderDeviceInfoRequestProcessor {
             })
             .await;
         if response.message.get("success").is_some()
-            && response.message["success"].as_bool().unwrap()
+            && response.message["success"].as_bool().unwrap_or_default()
         {
             match serde_json::from_value::<ThunderAllTimezonesResponse>(response.message) {
                 Ok(timezones) => {
@@ -1048,7 +1048,7 @@ impl ThunderDeviceInfoRequestProcessor {
         info!("{}", response.message);
 
         if response.message.get("success").is_none()
-            || response.message["success"].as_bool().unwrap()
+            || response.message["success"].as_bool().unwrap_or_default()
         {
             return Self::respond(state.get_client(), request, ExtnResponse::None(()))
                 .await

--- a/device/thunder_ripple_sdk/src/processors/thunder_persistent_store.rs
+++ b/device/thunder_ripple_sdk/src/processors/thunder_persistent_store.rs
@@ -96,7 +96,7 @@ impl ThunderStorageRequestProcessor {
             })
             .await;
         if response.message.get("success").is_none()
-            || !response.message["success"].as_bool().unwrap()
+            || !response.message["success"].as_bool().unwrap_or_default()
         {
             error!("{}", response.message);
             return false;
@@ -122,7 +122,7 @@ impl ThunderStorageRequestProcessor {
             })
             .await;
         if response.message.get("success").is_none()
-            || !response.message["success"].as_bool().unwrap()
+            || !response.message["success"].as_bool().unwrap_or_default()
         {
             error!("{}", response.message);
             return false;
@@ -143,7 +143,7 @@ impl ThunderStorageRequestProcessor {
             .await;
 
         if response.message.get("success").is_none()
-            || !response.message["success"].as_bool().unwrap()
+            || !response.message["success"].as_bool().unwrap_or_default()
         {
             error!("{}", response.message);
             return false;


### PR DESCRIPTION
## What 

Improved memory efficiency when using `PermissionHandler::fetch_and_store`.

## Why

As @Karthick-Somasundaresan pointed out in the review for https://github.com/rdkcentral/Ripple/pull/194 there were several items being cloned that didn't really need to be and this means that memory is not being used as efficiently as possible.

## How

By taking the arguments for the associated function as references the need to clone data before passing in has been removed.