### PR TITLE
feat: Metric Upgrades

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,8 @@ members = [
     "core/launcher",
     "device/thunder",
     "distributor/general",
-    "examples/rpc_extn"
+    "examples/rpc_extn",
+    "examples/tm_extn"
 ]
 
 [workspace.package]

--- a/core/main/src/bootstrap/boot.rs
+++ b/core/main/src/bootstrap/boot.rs
@@ -65,7 +65,7 @@ pub async fn boot(state: BootstrapState) {
         .expect("Extn load failure")
         .step(StartExtnChannelsStep)
         .await
-        .expect("Start Device channel failure")
+        .expect("Start Extns failure")
         .step(StartAppManagerStep)
         .await
         .expect("App Manager start")

--- a/core/main/src/bootstrap/extn/load_extn_step.rs
+++ b/core/main/src/bootstrap/extn/load_extn_step.rs
@@ -103,6 +103,7 @@ impl Bootstep<BootstrapState> for LoadExtensionsStep {
                                 extn_id,
                                 extension.clone().uses,
                                 extension.clone().fulfills,
+                                extension.clone().config,
                             );
                             if let Some(open_rpc) = (builder.get_extended_capabilities)() {
                                 match serde_json::from_str(&open_rpc) {

--- a/core/main/src/bootstrap/extn/load_extn_step.rs
+++ b/core/main/src/bootstrap/extn/load_extn_step.rs
@@ -118,7 +118,6 @@ impl Bootstep<BootstrapState> for LoadExtensionsStep {
                         }
                     }
                 }
-                debug!("loading symbols from {}", extn.get_metadata().name);
             }
         }
 

--- a/core/main/src/bootstrap/extn/start_extn_channel_step.rs
+++ b/core/main/src/bootstrap/extn/start_extn_channel_step.rs
@@ -77,14 +77,14 @@ impl Bootstep<BootstrapState> for StartExtnChannelsStep {
                 }
             }
         }
-
+        let t = state.platform_state.get_manifest().get_timeout();
         for extn_id in extn_ids {
             let (tx, mut tr) = mpsc::channel(1);
             if !state
                 .extn_state
                 .add_extn_status_listener(extn_id.clone(), tx)
             {
-                match timeout(Duration::from_millis(10000), tr.recv()).await {
+                match timeout(Duration::from_millis(t), tr.recv()).await {
                     Ok(Some(v)) => {
                         state.extn_state.clear_status_listener(extn_id);
                         match v {

--- a/core/main/src/bootstrap/setup_extn_client_step.rs
+++ b/core/main/src/bootstrap/setup_extn_client_step.rs
@@ -20,6 +20,7 @@ use ripple_sdk::{
 };
 
 use crate::processor::account_link_processor::AccountLinkProcessor;
+use crate::processor::metrics_processor::{MetricsProcessor, OpMetricsProcessor};
 use crate::processor::settings_processor::SettingsProcessor;
 use crate::processor::{
     store_privacy_settings_processor::StorePrivacySettingsProcessor,
@@ -61,6 +62,8 @@ impl Bootstep<BootstrapState> for SetupExtnClientStep {
         client.add_request_processor(AuthorizedInfoProcessor::new(state.clone().platform_state));
         client.add_request_processor(AccountLinkProcessor::new(state.clone().platform_state));
         client.add_request_processor(SettingsProcessor::new(state.platform_state.clone()));
+        client.add_request_processor(MetricsProcessor::new(state.platform_state.clone()));
+        client.add_request_processor(OpMetricsProcessor::new(state.platform_state.clone()));
         Ok(())
     }
 }

--- a/core/main/src/bootstrap/start_fbgateway_step.rs
+++ b/core/main/src/bootstrap/start_fbgateway_step.rs
@@ -35,6 +35,7 @@ use crate::{
         rpc::RippleRPCProvider,
     },
     processor::rpc_gateway_processor::RpcGatewayProcessor,
+    service::telemetry_builder::TelemetryBuilder,
     state::{bootstrap_state::BootstrapState, platform_state::PlatformState},
 };
 use jsonrpsee::core::{async_trait, server::rpc_module::Methods};
@@ -104,7 +105,7 @@ impl Bootstep<BootstrapState> for FireboltGatewayStep {
         {
             return Err(RippleError::BootstrapError);
         }
-
+        TelemetryBuilder::send_ripple_telemetry(&state.platform_state);
         gateway.start().await;
         Ok(())
     }

--- a/core/main/src/bootstrap/start_fbgateway_step.rs
+++ b/core/main/src/bootstrap/start_fbgateway_step.rs
@@ -25,7 +25,8 @@ use crate::{
             closed_captions_rpc::ClosedcaptionsRPCProvider, device_rpc::DeviceRPCProvider,
             discovery_rpc::DiscoveryRPCProvider, keyboard_rpc::KeyboardRPCProvider,
             lcm_rpc::LifecycleManagementProvider, lifecycle_rpc::LifecycleRippleProvider,
-            localization_rpc::LocalizationRPCProvider, metrics_rpc::MetricsRPCProvider,
+            localization_rpc::LocalizationRPCProvider,
+            metrics_management_rpc::MetricsManagementProvider, metrics_rpc::MetricsRPCProvider,
             parameters_rpc::ParametersRPCProvider, pin_rpc::PinRPCProvider,
             privacy_rpc::PrivacyProvider, profile_rpc::ProfileRPCProvider,
             second_screen_rpc::SecondScreenRPCProvider,
@@ -68,6 +69,7 @@ impl FireboltGatewayStep {
         let _ = methods.merge(DiscoveryRPCProvider::provide_with_alias(state.clone()));
         let _ = methods.merge(AuthRPCProvider::provide_with_alias(state.clone()));
         let _ = methods.merge(AccountRPCProvider::provide_with_alias(state.clone()));
+        let _ = methods.merge(MetricsManagementProvider::provide_with_alias(state.clone()));
 
         // LCM Api(s) not required for internal launcher
         if !state.has_internal_launcher() {

--- a/core/main/src/firebolt/handlers/metrics_management_rpc.rs
+++ b/core/main/src/firebolt/handlers/metrics_management_rpc.rs
@@ -1,0 +1,120 @@
+// Copyright 2023 Comcast Cable Communications Management, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+use jsonrpsee::{core::RpcResult, proc_macros::rpc, RpcModule};
+use ripple_sdk::{api::gateway::rpc_gateway_api::CallContext, async_trait::async_trait};
+use serde::{Deserialize, Deserializer, Serialize};
+
+use crate::{firebolt::rpc::RippleRPCProvider, state::platform_state::PlatformState};
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct MetricsContextParams {
+    context: MetricsContext,
+}
+
+#[derive(Deserialize, Serialize, Default, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct MetricsContext {
+    pub device_session_id: Option<String>,
+}
+
+impl MetricsContext {
+    fn is_valid_key(&self, key: &str) -> bool {
+        let metrics_context_fields = match serde_json::to_value(self) {
+            Ok(val) => {
+                let field_map = val.as_object().unwrap();
+                field_map.keys().map(|x| x.to_string()).collect::<Vec<_>>()
+            }
+            Err(_) => return false,
+        };
+        metrics_context_fields.contains(&key.to_string())
+    }
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct MetricsContextKeys {
+    #[serde(deserialize_with = "validate_metrics_context_keys")]
+    pub keys: Vec<String>,
+}
+
+fn validate_metrics_context_keys<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let keys: Vec<String> = Vec::deserialize(deserializer)?;
+    let metics_context = MetricsContext::default();
+    for key in &keys {
+        if !metics_context.is_valid_key(key.as_str()) {
+            return Err(serde::de::Error::custom(format!("Invalid key : {}", key)));
+        }
+    }
+    Ok(keys)
+}
+
+#[rpc(server)]
+pub trait MetricsManagement {
+    #[method(name = "metricsmanagement.addContext")]
+    async fn add_context(
+        &self,
+        ctx: CallContext,
+        context_params: MetricsContextParams,
+    ) -> RpcResult<()>;
+    #[method(name = "metricsmanagement.removeContext")]
+    async fn remove_context(&self, ctx: CallContext, request: MetricsContextKeys) -> RpcResult<()>;
+}
+
+pub struct MetricsManagementImpl {
+    pub state: PlatformState,
+}
+
+#[async_trait]
+impl MetricsManagementServer for MetricsManagementImpl {
+    async fn add_context(
+        &self,
+        _ctx: CallContext,
+        context_params: MetricsContextParams,
+    ) -> RpcResult<()> {
+        // check if device_session_id is available
+        if let Some(device_session_id) = context_params.context.device_session_id {
+            self.state
+                .metrics
+                .update_session_id(Some(device_session_id));
+        }
+        Ok(())
+    }
+
+    async fn remove_context(
+        &self,
+        _ctx: CallContext,
+        request: MetricsContextKeys,
+    ) -> RpcResult<()> {
+        for key in request.keys {
+            // currently handling only one key which is deviceSessionId
+            if key.as_str() == "deviceSessionId" {
+                self.state.metrics.update_session_id(None);
+            }
+        }
+        Ok(())
+    }
+}
+
+pub struct MetricsManagementProvider;
+impl RippleRPCProvider<MetricsManagementImpl> for MetricsManagementProvider {
+    fn provide(state: PlatformState) -> RpcModule<MetricsManagementImpl> {
+        (MetricsManagementImpl { state }).into_rpc()
+    }
+}

--- a/core/main/src/firebolt/mod.rs
+++ b/core/main/src/firebolt/mod.rs
@@ -31,6 +31,7 @@ pub mod handlers {
     pub mod lcm_rpc;
     pub mod lifecycle_rpc;
     pub mod localization_rpc;
+    pub mod metrics_management_rpc;
     pub mod metrics_rpc;
     pub mod parameters_rpc;
     pub mod pin_rpc;

--- a/core/main/src/firebolt/rpc_router.rs
+++ b/core/main/src/firebolt/rpc_router.rs
@@ -142,6 +142,7 @@ impl RpcRouter {
             let start = Utc::now().timestamp_millis();
             if let Ok(msg) = resolve_route(methods, resources, req.clone()).await {
                 let now = Utc::now().timestamp_millis();
+                let success = !msg.is_error();
                 info!(
                     "Sending Firebolt response to app_id={} method={} fbtt={} {} {}",
                     app_id,
@@ -150,7 +151,7 @@ impl RpcRouter {
                     session_id,
                     msg.jsonrpc_msg
                 );
-                TelemetryBuilder::send_fb_tt(&state, req.clone(), now - start);
+                TelemetryBuilder::send_fb_tt(&state, req.clone(), now - start, success);
                 match session.get_transport() {
                     EffectiveTransport::Websocket => {
                         if let Err(e) = session.send_json_rpc(msg).await {

--- a/core/main/src/service/extn/ripple_client.rs
+++ b/core/main/src/service/extn/ripple_client.rs
@@ -65,8 +65,13 @@ pub struct RippleClient {
 impl RippleClient {
     pub fn new(state: ChannelsState) -> RippleClient {
         let capability = ExtnId::get_main_target("main".into());
-        let extn_sender =
-            ExtnSender::new(state.get_extn_sender(), capability, Vec::new(), Vec::new());
+        let extn_sender = ExtnSender::new(
+            state.get_extn_sender(),
+            capability,
+            Vec::new(),
+            Vec::new(),
+            None,
+        );
         let extn_client = ExtnClient::new(state.get_extn_receiver(), extn_sender);
         RippleClient {
             gateway_sender: state.get_gateway_sender(),

--- a/core/main/src/service/telemetry_builder.rs
+++ b/core/main/src/service/telemetry_builder.rs
@@ -1,0 +1,161 @@
+// Copyright 2023 Comcast Cable Communications Management, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use ripple_sdk::{
+    api::{
+        firebolt::{
+            fb_metrics::{ErrorParams, InternalInitializeParams},
+            fb_telemetry::{
+                AppLoadStart, AppLoadStop, InternalInitialize, TelemetryAppError, TelemetryPayload,
+                TelemetrySignIn, TelemetrySignOut,
+            },
+        },
+        gateway::rpc_gateway_api::CallContext,
+    },
+    chrono::{DateTime, Utc},
+    framework::RippleResponse,
+    log::error,
+};
+
+use crate::state::platform_state::PlatformState;
+
+pub struct TelemetryBuilder;
+include!(concat!(env!("OUT_DIR"), "/version.rs"));
+
+impl TelemetryBuilder {
+    pub fn send_app_load_start(
+        ps: &PlatformState,
+        app_id: String,
+        app_version: Option<String>,
+        start_time: Option<DateTime<Utc>>,
+    ) {
+        if let Err(e) = Self::send_telemetry(
+            ps,
+            TelemetryPayload::AppLoadStart(AppLoadStart {
+                app_id,
+                app_version,
+                start_time: start_time.unwrap_or_default().timestamp_millis(),
+                ripple_session_id: ps.metrics.get_context().device_session_id,
+                ripple_version: String::from(SEMVER),
+                ripple_context: None,
+            }),
+        ) {
+            error!("send_telemetry={:?}", e)
+        }
+    }
+
+    pub fn send_app_load_stop(ps: &PlatformState, app_id: String, success: bool) {
+        if let Err(e) = Self::send_telemetry(
+            ps,
+            TelemetryPayload::AppLoadStop(AppLoadStop {
+                app_id,
+                stop_time: Utc::now().timestamp_millis(),
+                app_session_id: None,
+                ripple_session_id: ps.metrics.get_context().device_session_id,
+                success,
+            }),
+        ) {
+            error!("send_telemetry={:?}", e)
+        }
+    }
+
+    pub fn update_session_id_and_send_telemetry(
+        ps: &PlatformState,
+        mut t: TelemetryPayload,
+    ) -> RippleResponse {
+        let session_id = ps.metrics.get_context().device_session_id;
+        t.update_session_id(session_id);
+        Self::send_telemetry(ps, t)
+    }
+
+    fn send_telemetry(ps: &PlatformState, t: TelemetryPayload) -> RippleResponse {
+        let listeners = ps.metrics.get_listeners();
+        let client = ps.get_client().get_extn_client();
+        let mut result = Ok(());
+        for id in listeners {
+            if let Err(e) = client.send_event_with_id(&id, t.clone()) {
+                error!("telemetry_send_error target={} event={:?}", id, t.clone());
+                result = Err(e)
+            }
+        }
+        result
+    }
+
+    pub fn send_ripple_telemetry(ps: &PlatformState) {
+        Self::send_app_load_start(
+            ps,
+            "ripple".to_string(),
+            Some(String::from(SEMVER)),
+            Some(ps.metrics.start_time),
+        );
+        Self::send_app_load_stop(ps, "ripple".to_string(), true);
+    }
+
+    pub fn send_error(ps: &PlatformState, app_id: String, error_params: ErrorParams) {
+        let mut app_error: TelemetryAppError = error_params.into();
+        app_error.ripple_session_id = ps.metrics.get_context().device_session_id;
+        app_error.app_id = app_id;
+
+        if let Err(e) = Self::send_telemetry(ps, TelemetryPayload::AppError(app_error)) {
+            error!("send_telemetry={:?}", e)
+        }
+    }
+
+    pub fn send_sign_in(ps: &PlatformState, ctx: &CallContext) {
+        if let Err(e) = Self::send_telemetry(
+            ps,
+            TelemetryPayload::SignIn(TelemetrySignIn {
+                app_id: ctx.app_id.to_owned(),
+                ripple_session_id: ps.metrics.get_context().device_session_id,
+                app_session_id: Some(ctx.session_id.to_owned()),
+            }),
+        ) {
+            error!("send_telemetry={:?}", e)
+        }
+    }
+
+    pub fn send_sign_out(ps: &PlatformState, ctx: &CallContext) {
+        if let Err(e) = Self::send_telemetry(
+            ps,
+            TelemetryPayload::SignOut(TelemetrySignOut {
+                app_id: ctx.app_id.to_owned(),
+                ripple_session_id: ps.metrics.get_context().device_session_id,
+                app_session_id: Some(ctx.session_id.to_owned()),
+            }),
+        ) {
+            error!("send_telemetry={:?}", e)
+        }
+    }
+
+    pub fn internal_initialize(
+        ps: &PlatformState,
+        ctx: &CallContext,
+        params: &InternalInitializeParams,
+    ) {
+        if let Err(e) = Self::send_telemetry(
+            ps,
+            TelemetryPayload::InternalInitialize(InternalInitialize {
+                app_id: ctx.app_id.to_owned(),
+                ripple_session_id: ps.metrics.get_context().device_session_id,
+                app_session_id: Some(ctx.session_id.to_owned()),
+                semantic_version: params.value.to_string(),
+            }),
+        ) {
+            error!("send_telemetry={:?}", e)
+        }
+    }
+}

--- a/core/main/src/service/telemetry_builder.rs
+++ b/core/main/src/service/telemetry_builder.rs
@@ -160,7 +160,7 @@ impl TelemetryBuilder {
         }
     }
 
-    pub fn send_fb_tt(ps: &PlatformState, req: RpcRequest, tt: i64) {
+    pub fn send_fb_tt(ps: &PlatformState, req: RpcRequest, tt: i64, success: bool) {
         let ctx = req.ctx;
         let method = req.method;
         let params = if let Ok(mut p) = serde_json::from_str::<Vec<Value>>(&req.params_json) {
@@ -183,6 +183,7 @@ impl TelemetryBuilder {
                 tt,
                 method,
                 params,
+                success
             }),
         ) {
             error!("send_telemetry={:?}", e)

--- a/core/main/src/service/telemetry_builder.rs
+++ b/core/main/src/service/telemetry_builder.rs
@@ -164,7 +164,7 @@ impl TelemetryBuilder {
         let ctx = req.ctx;
         let method = req.method;
         let params = if let Ok(mut p) = serde_json::from_str::<Vec<Value>>(&req.params_json) {
-            if p.len()>0 {
+            if p.len() > 0 {
                 // remove call context
                 let _ = p.remove(0);
                 Some(serde_json::to_string(&p).unwrap())
@@ -183,7 +183,7 @@ impl TelemetryBuilder {
                 tt,
                 method,
                 params,
-                success
+                success,
             }),
         ) {
             error!("send_telemetry={:?}", e)

--- a/core/main/src/service/telemetry_builder.rs
+++ b/core/main/src/service/telemetry_builder.rs
@@ -20,11 +20,11 @@ use ripple_sdk::{
         firebolt::{
             fb_metrics::{ErrorParams, InternalInitializeParams},
             fb_telemetry::{
-                AppLoadStart, AppLoadStop, InternalInitialize, TelemetryAppError, TelemetryPayload,
-                TelemetrySignIn, TelemetrySignOut,
+                AppLoadStart, AppLoadStop, FireboltInteraction, InternalInitialize,
+                TelemetryAppError, TelemetryPayload, TelemetrySignIn, TelemetrySignOut,
             },
         },
-        gateway::rpc_gateway_api::CallContext,
+        gateway::rpc_gateway_api::{CallContext, RpcRequest},
     },
     chrono::{DateTime, Utc},
     framework::RippleResponse,
@@ -153,6 +153,25 @@ impl TelemetryBuilder {
                 ripple_session_id: ps.metrics.get_context().device_session_id,
                 app_session_id: Some(ctx.session_id.to_owned()),
                 semantic_version: params.value.to_string(),
+            }),
+        ) {
+            error!("send_telemetry={:?}", e)
+        }
+    }
+
+    pub fn send_fb_tt(ps: &PlatformState, req: RpcRequest, tt: i64) {
+        let ctx = req.ctx;
+        let method = req.method;
+        let params = req.params_json;
+        if let Err(e) = Self::send_telemetry(
+            ps,
+            TelemetryPayload::FireboltInteraction(FireboltInteraction {
+                app_id: ctx.app_id.to_owned(),
+                ripple_session_id: ps.metrics.get_context().device_session_id,
+                app_session_id: Some(ctx.session_id),
+                tt,
+                method,
+                params,
             }),
         ) {
             error!("send_telemetry={:?}", e)

--- a/core/main/src/state/extn_state.rs
+++ b/core/main/src/state/extn_state.rs
@@ -193,6 +193,7 @@ impl ExtnState {
             extn_id.clone(),
             symbol.clone().uses,
             symbol.clone().fulfills,
+            symbol.clone().config,
         );
         let (extn_tx, extn_rx) = ChannelsState::get_crossbeam_channel();
         let extn_channel = channel.channel;

--- a/core/main/src/state/extn_state.rs
+++ b/core/main/src/state/extn_state.rs
@@ -64,7 +64,6 @@ impl LoadedLibrary {
     }
 
     pub fn get_channels(&self) -> Vec<ExtnSymbol> {
-        info!("getting channels {}", self.metadata.symbols.len());
         let extn_ids: Vec<String> = self
             .metadata
             .symbols
@@ -72,6 +71,12 @@ impl LoadedLibrary {
             .filter(|x| x.id.is_channel())
             .map(|x| x.id.clone().to_string())
             .collect();
+        info!(
+            "getting channels {} lib_metadata={:?} extn_metadata={:?}",
+            self.metadata.symbols.len(),
+            extn_ids,
+            self.entry
+        );
         self.entry
             .clone()
             .symbols

--- a/core/main/src/state/metrics_state.rs
+++ b/core/main/src/state/metrics_state.rs
@@ -157,4 +157,10 @@ impl MetricsState {
             .map(|x| x.to_owned())
             .collect()
     }
+
+    pub fn update_session_id(&self, value: Option<String>) {
+        let value = value.unwrap_or_default();
+        let mut context = self.context.write().unwrap();
+        context.device_session_id = value;
+    }
 }

--- a/core/main/src/state/metrics_state.rs
+++ b/core/main/src/state/metrics_state.rs
@@ -15,7 +15,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use std::sync::{Arc, RwLock};
+use std::{
+    collections::HashSet,
+    sync::{Arc, RwLock},
+};
 
 use ripple_sdk::{
     api::{
@@ -23,6 +26,7 @@ use ripple_sdk::{
         firebolt::{fb_metrics::MetricsContext, fb_openrpc::FireboltSemanticVersion},
         storage_property::StorageProperty,
     },
+    chrono::{DateTime, Utc},
     extn::extn_client_message::ExtnResponse,
 };
 
@@ -32,7 +36,9 @@ use super::platform_state::PlatformState;
 
 #[derive(Debug, Clone, Default)]
 pub struct MetricsState {
+    pub start_time: DateTime<Utc>,
     pub context: Arc<RwLock<MetricsContext>>,
+    operational_telemetry_listeners: Arc<RwLock<HashSet<String>>>,
 }
 
 impl MetricsState {
@@ -131,5 +137,24 @@ impl MetricsState {
         if let Some(t) = timezone {
             context.device_timezone = t;
         }
+    }
+
+    pub fn operational_telemetry_listener(&self, target: &str, listen: bool) {
+        let mut listeners = self.operational_telemetry_listeners.write().unwrap();
+        if listen {
+            listeners.insert(target.to_string());
+        } else {
+            listeners.remove(target);
+        }
+    }
+
+    pub fn get_listeners(&self) -> Vec<String> {
+        self.operational_telemetry_listeners
+            .read()
+            .unwrap()
+            .clone()
+            .iter()
+            .map(|x| x.to_owned())
+            .collect()
     }
 }

--- a/core/sdk/src/api/firebolt/fb_telemetry.rs
+++ b/core/sdk/src/api/firebolt/fb_telemetry.rs
@@ -129,6 +129,16 @@ pub struct InternalInitialize {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct FireboltInteraction {
+    pub app_id: String,
+    pub method: String,
+    pub params: String,
+    pub tt: i64,
+    pub ripple_session_id: String,
+    pub app_session_id: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum TelemetryPayload {
     AppLoadStart(AppLoadStart),
     AppLoadStop(AppLoadStop),
@@ -138,6 +148,7 @@ pub enum TelemetryPayload {
     SignIn(TelemetrySignIn),
     SignOut(TelemetrySignOut),
     InternalInitialize(InternalInitialize),
+    FireboltInteraction(FireboltInteraction), // External Service failures (service, error)
 }
 
 impl TelemetryPayload {
@@ -151,6 +162,7 @@ impl TelemetryPayload {
             Self::SignIn(s) => s.ripple_session_id = session_id,
             Self::SignOut(s) => s.ripple_session_id = session_id,
             Self::InternalInitialize(i) => i.ripple_session_id = session_id,
+            Self::FireboltInteraction(f) => f.ripple_session_id = session_id,
         }
     }
 }

--- a/core/sdk/src/api/firebolt/fb_telemetry.rs
+++ b/core/sdk/src/api/firebolt/fb_telemetry.rs
@@ -132,7 +132,7 @@ pub struct InternalInitialize {
 pub struct FireboltInteraction {
     pub app_id: String,
     pub method: String,
-    pub params: String,
+    pub params: Option<String>,
     pub tt: i64,
     pub ripple_session_id: String,
     pub app_session_id: Option<String>,

--- a/core/sdk/src/api/firebolt/fb_telemetry.rs
+++ b/core/sdk/src/api/firebolt/fb_telemetry.rs
@@ -134,6 +134,7 @@ pub struct FireboltInteraction {
     pub method: String,
     pub params: Option<String>,
     pub tt: i64,
+    pub success: bool,
     pub ripple_session_id: String,
     pub app_session_id: Option<String>,
 }

--- a/core/sdk/src/api/gateway/rpc_gateway_api.rs
+++ b/core/sdk/src/api/gateway/rpc_gateway_api.rs
@@ -96,6 +96,11 @@ impl ApiMessage {
             request_id,
         }
     }
+
+    pub fn is_error(&self) -> bool {
+        // currently only these json rpsee errors are used in Ripple
+        self.jsonrpc_msg.contains("Custom error:") || self.jsonrpc_msg.contains("Method not found")
+    }
 }
 
 #[derive(Deserialize)]

--- a/core/sdk/src/api/manifest/extn_manifest.rs
+++ b/core/sdk/src/api/manifest/extn_manifest.rs
@@ -31,6 +31,7 @@ pub struct ExtnManifest {
     pub extns: Vec<ExtnManifestEntry>,
     pub required_contracts: Vec<String>,
     pub rpc_aliases: HashMap<String, Vec<String>>,
+    pub timeout: Option<u64>,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -155,5 +156,9 @@ impl ExtnManifest {
             })
         });
         map
+    }
+
+    pub fn get_timeout(&self) -> u64 {
+        self.timeout.unwrap_or(10000)
     }
 }

--- a/core/sdk/src/api/manifest/extn_manifest.rs
+++ b/core/sdk/src/api/manifest/extn_manifest.rs
@@ -53,6 +53,7 @@ pub struct ExtnSymbol {
     pub id: String,
     pub uses: Vec<String>,
     pub fulfills: Vec<String>,
+    pub config: Option<HashMap<String, String>>,
 }
 
 impl ExtnSymbol {

--- a/core/sdk/src/extn/client/extn_client.rs
+++ b/core/sdk/src/extn/client/extn_client.rs
@@ -592,4 +592,9 @@ impl ExtnClient {
     pub fn check_contract_fulfillment(&self, contract: RippleContract) -> bool {
         self.sender.check_contract_fulfillment(contract)
     }
+
+    // Method to check if contract is permitted
+    pub fn check_contract_permitted(&self, contract: RippleContract) -> bool {
+        self.sender.check_contract_permission(contract)
+    }
 }

--- a/core/sdk/src/extn/client/extn_client.rs
+++ b/core/sdk/src/extn/client/extn_client.rs
@@ -325,8 +325,8 @@ impl ExtnClient {
         let id_c = msg.clone().target.into();
         let mut gc_sender_indexes: Vec<usize> = Vec::new();
         let mut sender: Option<MSender<ExtnMessage>> = None;
+        let read_processor = processor.clone();
         {
-            let read_processor = processor.clone();
             let processors = read_processor.read().unwrap();
             let v = processors.get(&id_c).cloned();
             if let Some(v) = v {
@@ -562,5 +562,34 @@ impl ExtnClient {
         let id = uuid::Uuid::new_v4().to_string();
         let other_sender = self.get_extn_sender_with_contract(payload.get_contract());
         self.sender.send_request(id, payload, other_sender, None)
+    }
+
+    /// Method to get configurations on the manifest per extension
+    pub fn get_config(&self, key: &str) -> Option<String> {
+        self.sender.get_config(key)
+    }
+
+    /// Method to get configurations on the manifest per extension
+    pub fn get_bool_config(&self, key: &str) -> bool {
+        if let Some(s) = self.sender.get_config(key) {
+            if let Ok(v) = s.parse() {
+                return v;
+            }
+        }
+        false
+    }
+
+    /// Method to send event to an extension based on its Id
+    pub fn send_event_with_id(&self, id: &str, event: impl ExtnPayloadProvider) -> RippleResponse {
+        if let Some(sender) = self.get_extn_sender_with_extn_id(id) {
+            self.sender.send_event(event, Some(sender))
+        } else {
+            Err(RippleError::SendFailure)
+        }
+    }
+
+    /// Method to get configurations on the manifest per extension
+    pub fn check_contract_fulfillment(&self, contract: RippleContract) -> bool {
+        self.sender.check_contract_fulfillment(contract)
     }
 }

--- a/core/sdk/src/extn/client/extn_sender.rs
+++ b/core/sdk/src/extn/client/extn_sender.rs
@@ -15,6 +15,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use std::collections::HashMap;
+
 use chrono::Utc;
 use crossbeam::channel::Sender as CSender;
 use log::{error, trace};
@@ -44,6 +46,7 @@ pub struct ExtnSender {
     id: ExtnId,
     permitted: Vec<String>,
     fulfills: Vec<String>,
+    config: Option<HashMap<String, String>>,
 }
 
 impl ExtnSender {
@@ -56,12 +59,14 @@ impl ExtnSender {
         id: ExtnId,
         context: Vec<String>,
         fulfills: Vec<String>,
+        config: Option<HashMap<String, String>>,
     ) -> Self {
         ExtnSender {
             tx,
             id,
             permitted: context,
             fulfills,
+            config,
         }
     }
     fn check_contract_permission(&self, contract: RippleContract) -> bool {
@@ -78,6 +83,15 @@ impl ExtnSender {
         } else {
             self.fulfills.contains(&contract.as_clear_string())
         }
+    }
+
+    pub fn get_config(&self, key: &str) -> Option<String> {
+        if let Some(c) = self.config.clone() {
+            if let Some(v) = c.get(key) {
+                return Some(v.clone());
+            }
+        }
+        None
     }
 
     pub fn send_request(

--- a/core/sdk/src/extn/client/extn_sender.rs
+++ b/core/sdk/src/extn/client/extn_sender.rs
@@ -69,7 +69,7 @@ impl ExtnSender {
             config,
         }
     }
-    fn check_contract_permission(&self, contract: RippleContract) -> bool {
+    pub fn check_contract_permission(&self, contract: RippleContract) -> bool {
         if self.id.is_main() {
             true
         } else {

--- a/core/sdk/src/extn/extn_client_message.rs
+++ b/core/sdk/src/extn/extn_client_message.rs
@@ -45,9 +45,10 @@ use crate::{
             fb_authentication::TokenResult,
             fb_keyboard::{KeyboardSessionRequest, KeyboardSessionResponse},
             fb_lifecycle_management::LifecycleManagementRequest,
-            fb_metrics::BehavioralMetricRequest,
+            fb_metrics::{BehavioralMetricRequest, MetricsRequest},
             fb_pin::{PinChallengeRequestWithContext, PinChallengeResponse},
             fb_secure_storage::{SecureStorageRequest, SecureStorageResponse},
+            fb_telemetry::{OperationalMetricRequest, TelemetryPayload},
         },
         gateway::rpc_gateway_api::RpcRequest,
         manifest::device_manifest::AppLibraryEntry,
@@ -262,6 +263,8 @@ pub enum ExtnRequest {
     UserGrantsStore(UserGrantsStoreRequest),
     PrivacySettingsStore(PrivacySettingsStoreRequest),
     AuthorizedInfo(CapsRequest),
+    Metrics(MetricsRequest),
+    OperationalMetricsRequest(OperationalMetricRequest),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -318,6 +321,7 @@ pub enum ExtnEvent {
     Status(ExtnStatus),
     AppEvent(AppEventRequest),
     PowerState(SystemPowerState),
+    OperationalMetrics(TelemetryPayload),
 }
 
 impl ExtnPayloadProvider for ExtnEvent {

--- a/core/sdk/src/framework/ripple_contract.rs
+++ b/core/sdk/src/framework/ripple_contract.rs
@@ -15,7 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use crate::utils::error::RippleError;
+use crate::utils::{error::RippleError, serde_utils::SerdeClearString};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -92,6 +92,10 @@ pub enum RippleContract {
     PrivacySettingsLocalStore,
     Caps,
     Encoder,
+    /// Contract for Main to forward behavior and operational metrics to processors
+    Metrics,
+    /// Contract for Extensions to recieve Telemetry events from Main
+    OperationalMetricListener,
 }
 
 impl TryFrom<String> for RippleContract {
@@ -117,8 +121,7 @@ impl RippleContract {
     /// This method gets the clear string of the contract without the quotes added
     /// by serde deserializer.
     pub fn as_clear_string(self) -> String {
-        let s: String = self.into();
-        s[1..s.len() - 1].into()
+        SerdeClearString::as_clear_string(&self)
     }
 }
 

--- a/core/sdk/src/utils/serde_utils.rs
+++ b/core/sdk/src/utils/serde_utils.rs
@@ -258,3 +258,15 @@ where
         Ok(value)
     }
 }
+
+pub struct SerdeClearString;
+
+impl SerdeClearString {
+    pub fn as_clear_string<T>(t: &T) -> String
+    where
+        T: ?Sized + serde::ser::Serialize,
+    {
+        let s: String = serde_json::to_string(t).unwrap();
+        s[1..s.len() - 1].into()
+    }
+}

--- a/device/thunder_ripple_sdk/src/bootstrap/setup_thunder_processors.rs
+++ b/device/thunder_ripple_sdk/src/bootstrap/setup_thunder_processors.rs
@@ -15,6 +15,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use ripple_sdk::framework::ripple_contract::RippleContract;
+
+use crate::processors::thunder_telemetry::ThunderTelemetryProcessor;
 use crate::thunder_state::ThunderBootstrapStateWithClient;
 
 use crate::processors::{
@@ -47,6 +50,12 @@ impl SetupThunderProcessor {
         extn_client.add_request_processor(ThunderRemoteAccessoryRequestProcessor::new(
             state.clone().state,
         ));
-        extn_client.add_request_processor(ThunderOpenEventsProcessor::new(state.state));
+        extn_client.add_request_processor(ThunderOpenEventsProcessor::new(state.clone().state));
+
+        if extn_client.check_contract_fulfillment(RippleContract::OperationalMetricListener)
+            && extn_client.get_bool_config("rdk_telemetry")
+        {
+            extn_client.add_event_processor(ThunderTelemetryProcessor::new(state.state))
+        }
     }
 }

--- a/device/thunder_ripple_sdk/src/bootstrap/setup_thunder_processors.rs
+++ b/device/thunder_ripple_sdk/src/bootstrap/setup_thunder_processors.rs
@@ -16,7 +16,6 @@
 //
 
 use ripple_sdk::api::firebolt::fb_telemetry::OperationalMetricRequest;
-use ripple_sdk::framework::ripple_contract::RippleContract;
 use ripple_sdk::log::error;
 
 use crate::processors::thunder_telemetry::ThunderTelemetryProcessor;
@@ -54,9 +53,7 @@ impl SetupThunderProcessor {
         ));
         extn_client.add_request_processor(ThunderOpenEventsProcessor::new(state.clone().state));
 
-        if extn_client.check_contract_fulfillment(RippleContract::OperationalMetricListener)
-            && extn_client.get_bool_config("rdk_telemetry")
-        {
+        if extn_client.get_bool_config("rdk_telemetry") {
             match extn_client
                 .request(OperationalMetricRequest::Subscribe)
                 .await

--- a/device/thunder_ripple_sdk/src/client/thunder_plugin.rs
+++ b/device/thunder_ripple_sdk/src/client/thunder_plugin.rs
@@ -33,6 +33,7 @@ pub enum ThunderPlugin {
     Wifi,
     TextToSpeech,
     Hdcp,
+    Telemetry,
 }
 const CONTROLLER_CFG: Cfg = Cfg::new("Controller", false, true);
 const DEVICE_INFO_CFG: Cfg = Cfg::new("DeviceInfo", true, false);
@@ -46,6 +47,7 @@ const SYSTEM_CFG: Cfg = Cfg::new("org.rdk.System", true, false);
 const WIFI_CFG: Cfg = Cfg::new("org.rdk.Wifi", false, false);
 const LOCATION_SYNC: Cfg = Cfg::new("LocationSync", false, false);
 const TTS_CFG: Cfg = Cfg::new("org.rdk.TextToSpeech", false, true);
+const TELEMETRY_CFG: Cfg = Cfg::new("org.rdk.Telemetry", true, true);
 
 impl ThunderPlugin {
     pub fn cfg(&self) -> Cfg {
@@ -63,6 +65,7 @@ impl ThunderPlugin {
             Wifi => WIFI_CFG,
             LocationSync => LOCATION_SYNC,
             TextToSpeech => TTS_CFG,
+            Telemetry => TELEMETRY_CFG,
         }
     }
     pub fn callsign(&self) -> &str {
@@ -95,6 +98,10 @@ impl ThunderPlugin {
     }
     pub fn method_version(&self, method_name: &str, version: u32) -> String {
         format!("{}.{}.{}", self.callsign(), version, method_name)
+    }
+
+    pub fn unversioned_method(&self, method_name: &str) -> String {
+        format!("{}.{}", self.callsign(), method_name)
     }
 }
 

--- a/device/thunder_ripple_sdk/src/lib.rs
+++ b/device/thunder_ripple_sdk/src/lib.rs
@@ -43,6 +43,7 @@ pub mod processors {
     }
     pub mod thunder_persistent_store;
     pub mod thunder_remote;
+    pub mod thunder_telemetry;
     pub mod thunder_wifi;
     pub mod thunder_window_manager;
 }

--- a/device/thunder_ripple_sdk/src/processors/thunder_telemetry.rs
+++ b/device/thunder_ripple_sdk/src/processors/thunder_telemetry.rs
@@ -1,0 +1,150 @@
+// Copyright 2023 Comcast Cable Communications Management, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use ripple_sdk::{
+    api::{
+        device::device_operator::{DeviceCallRequest, DeviceChannelParams, DeviceOperator},
+        firebolt::fb_telemetry::TelemetryPayload,
+    },
+    async_trait::async_trait,
+    extn::{
+        client::extn_processor::{
+            DefaultExtnStreamer, ExtnEventProcessor, ExtnStreamProcessor, ExtnStreamer,
+        },
+        extn_client_message::ExtnMessage,
+    },
+    serde_json::json,
+    tokio::sync::{mpsc::Receiver as MReceiver, mpsc::Sender as MSender},
+    utils::error::RippleError,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{client::thunder_plugin::ThunderPlugin, thunder_state::ThunderState};
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ThunderTelemetryEvent {
+    event_name: String,
+    event_value: String,
+}
+impl From<ThunderTelemetryEvent> for DeviceChannelParams {
+    fn from(event: ThunderTelemetryEvent) -> Self {
+        DeviceChannelParams::Json(json!(event).to_string())
+    }
+}
+
+fn strip_crlf(bytes: Vec<u8>) -> Result<String, RippleError> {
+    if let Ok(v) = String::from_utf8(bytes) {
+        return Ok(v.trim().to_owned());
+    }
+    Err(RippleError::ParseError)
+}
+
+fn writer() -> csv::Writer<Vec<u8>> {
+    csv::WriterBuilder::new()
+        .has_headers(false)
+        .from_writer(vec![])
+}
+fn serialize<T: Serialize>(event: &T) -> Result<String, RippleError> {
+    let mut wri = writer();
+    if wri.serialize(event).is_err() {
+        return Err(RippleError::ParseError);
+    }
+    if let Ok(v) = wri.into_inner() {
+        return strip_crlf(v);
+    }
+    Err(RippleError::ParseError)
+}
+fn render_event_data(event: &TelemetryPayload) -> Result<String, RippleError> {
+    serialize(event)
+}
+
+fn telemetry_event(event_name: &str, event_payload: String) -> DeviceChannelParams {
+    ThunderTelemetryEvent {
+        event_name: String::from(event_name),
+        event_value: event_payload,
+    }
+    .into()
+}
+
+fn get_event_name(event: &TelemetryPayload) -> &'static str {
+    match event {
+        TelemetryPayload::AppLoadStart(_) => "app_load_start_split",
+        TelemetryPayload::AppLoadStop(_) => "app_load_stop_split",
+        TelemetryPayload::AppSDKLoaded(_) => "app_sdk_loaded_split",
+        TelemetryPayload::AppError(_) => "app_error_split",
+        TelemetryPayload::SystemError(_) => "ripple_system_error_split",
+        TelemetryPayload::SignIn(_) => "app_sign_in_split",
+        TelemetryPayload::SignOut(_) => "app_sign_out_split",
+        TelemetryPayload::InternalInitialize(_) => "app_internal_initialize_split",
+    }
+}
+
+#[derive(Debug)]
+pub struct ThunderTelemetryProcessor {
+    state: ThunderState,
+    streamer: DefaultExtnStreamer,
+}
+
+/// Event processor used for cases where a certain Extension Capability is required to be ready.
+/// Bootstrap uses the [WaitForStatusReadyEventProcessor] to await during Device Connnection before starting the gateway.
+impl ThunderTelemetryProcessor {
+    pub fn new(state: ThunderState) -> ThunderTelemetryProcessor {
+        ThunderTelemetryProcessor {
+            state,
+            streamer: DefaultExtnStreamer::new(),
+        }
+    }
+}
+
+impl ExtnStreamProcessor for ThunderTelemetryProcessor {
+    type VALUE = TelemetryPayload;
+    type STATE = ThunderState;
+
+    fn get_state(&self) -> Self::STATE {
+        self.state.clone()
+    }
+
+    fn sender(&self) -> MSender<ExtnMessage> {
+        self.streamer.sender()
+    }
+
+    fn receiver(&mut self) -> MReceiver<ExtnMessage> {
+        self.streamer.receiver()
+    }
+}
+
+#[async_trait]
+impl ExtnEventProcessor for ThunderTelemetryProcessor {
+    async fn process_event(
+        state: Self::STATE,
+        _msg: ExtnMessage,
+        extracted_message: Self::VALUE,
+    ) -> Option<bool> {
+        if let Ok(data) = render_event_data(&extracted_message) {
+            state
+                .get_thunder_client()
+                .call(DeviceCallRequest {
+                    method: ThunderPlugin::Telemetry.unversioned_method("logApplicationEvent"),
+                    params: Some(telemetry_event(get_event_name(&extracted_message), data)),
+                })
+                .await;
+        }
+
+        None
+    }
+}

--- a/device/thunder_ripple_sdk/src/processors/thunder_telemetry.rs
+++ b/device/thunder_ripple_sdk/src/processors/thunder_telemetry.rs
@@ -91,6 +91,7 @@ fn get_event_name(event: &TelemetryPayload) -> &'static str {
         TelemetryPayload::SignIn(_) => "app_sign_in_split",
         TelemetryPayload::SignOut(_) => "app_sign_out_split",
         TelemetryPayload::InternalInitialize(_) => "app_internal_initialize_split",
+        TelemetryPayload::FireboltInteraction(_) => "app_firebolt_split",
     }
 }
 

--- a/examples/manifest/extn-manifest-example.json
+++ b/examples/manifest/extn-manifest-example.json
@@ -1,6 +1,7 @@
 {
     "default_path": "/usr/lib/rust/",
     "default_extension": "so",
+    "timeout": 2000,
     "extns": [
         {
             "path": "libthunder",

--- a/examples/manifest/extn-manifest-tm-example.json
+++ b/examples/manifest/extn-manifest-tm-example.json
@@ -1,6 +1,7 @@
 {
     "default_path": "/usr/lib/rust/",
     "default_extension": "so",
+    "timeout": 2000,
     "extns": [
         {
             "path": "libthunder",

--- a/examples/manifest/extn-manifest-tm-example.json
+++ b/examples/manifest/extn-manifest-tm-example.json
@@ -1,0 +1,86 @@
+{
+    "default_path": "/usr/lib/rust/",
+    "default_extension": "so",
+    "extns": [
+        {
+            "path": "libthunder",
+            "symbols": [
+                {
+                    "id": "ripple:channel:device:thunder",
+                    "uses": [
+                        "config"
+                    ],
+                    "fulfills": [
+                        "device_info",
+                        "window_manager",
+                        "browser",
+                        "wifi",
+                        "device_events",
+                        "device_persistence",
+                        "remote_accessory"
+                    ]
+                }
+            ]
+        },
+        {
+            "path": "libdistributor_general",
+            "symbols": [
+                {
+                    "id": "ripple:channel:distributor:general",
+                    "uses": [
+                        "config"
+                    ],
+                    "fulfills": [
+                        "permissions",
+                        "account_session",
+                        "secure_storage",
+                        "advertising",
+                        "privacy_settings",
+                        "metrics",
+                        "session_token",
+                        "discovery",
+                        "media_events"
+                    ]
+                }
+            ]
+        },
+        {
+            "path": "libtm_extn",
+            "symbols": [
+                {
+                    "id": "ripple:channel:distributor:tm",
+                    "uses": [
+                        "operational_metric_listener"
+                    ],
+                    "fulfills": [],
+                    "config": {
+                        "ws_url": "ws://127.0.0.1:2658/"
+                    }
+                }
+            ]
+        }
+    ],
+    "required_contracts": [
+        "rpc",
+        "lifecycle_management",
+        "device_info",
+        "window_manager",
+        "browser",
+        "permissions",
+        "account_session",
+        "wifi",
+        "device_events",
+        "device_persistence",
+        "remote_accessory",
+        "secure_storage",
+        "advertising",
+        "privacy_settings",
+        "session_token",
+        "metrics",
+        "discovery",
+        "media_events"
+    ],
+    "rpc_aliases": {
+        "device.model": ["custom.model"]
+    }
+}

--- a/examples/tm_extn/Cargo.toml
+++ b/examples/tm_extn/Cargo.toml
@@ -17,27 +17,18 @@
 
 
 [package]
-name = "thunder_ripple_sdk"
+name = "tm_extn"
 version = "0.8.0"
 edition = "2021"
-repository = "https://github.com/rdkcentral/Ripple"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[features]
-contract_tests = ["pact_consumer", "reqwest", "expectest", "pact-plugin-driver", "pact_models", "maplit", "test-log"]
+# See more keys and their definitions at https:#doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+crate-type = ["cdylib"]
 
 [dependencies]
 ripple_sdk = { path = "../../core/sdk" }
-jsonrpsee = { version = "0.9.0", features = ["macros", "ws-client"]}
+serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
+tokio-tungstenite = "0.17.1"
 url = "2.2.2"
-strum = "0.24"
-strum_macros = "0.24"
-pact_consumer = {version = "=0.10.4", optional = true}
-reqwest = {version = "0.11", optional = true}
-expectest = {version = "0.12.0", optional = true}
-pact-plugin-driver = {version = "0.4.1", optional = true}
-pact_models = {version = "1.0.9", optional = true}
-maplit = {version = "1.0.2", optional = true}
-test-log = {version = "0.2.11", optional = true}
-csv = "=1.1.5"

--- a/examples/tm_extn/src/lib.rs
+++ b/examples/tm_extn/src/lib.rs
@@ -15,8 +15,5 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-pub mod apps;
-pub mod data_governance;
-pub mod extn;
-pub mod telemetry_builder;
-pub mod user_grants;
+pub mod telemetry_processor;
+pub mod tm_ffi;

--- a/examples/tm_extn/src/telemetry_processor.rs
+++ b/examples/tm_extn/src/telemetry_processor.rs
@@ -1,0 +1,80 @@
+// Copyright 2023 Comcast Cable Communications Management, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use ripple_sdk::{
+    api::firebolt::fb_telemetry::TelemetryPayload,
+    async_trait::async_trait,
+    extn::{
+        client::extn_processor::{
+            DefaultExtnStreamer, ExtnEventProcessor, ExtnStreamProcessor, ExtnStreamer,
+        },
+        extn_client_message::ExtnMessage,
+    },
+    log::error,
+    tokio::sync::{mpsc::Receiver as MReceiver, mpsc::Sender as MSender},
+};
+
+#[derive(Debug)]
+pub struct TelemetryProcessor {
+    sender: MSender<String>,
+    streamer: DefaultExtnStreamer,
+}
+
+/// Event processor used for cases where a certain Extension Capability is required to be ready.
+/// Bootstrap uses the [WaitForStatusReadyEventProcessor] to await during Device Connnection before starting the gateway.
+impl TelemetryProcessor {
+    pub fn new(sender: MSender<String>) -> TelemetryProcessor {
+        TelemetryProcessor {
+            sender,
+            streamer: DefaultExtnStreamer::new(),
+        }
+    }
+}
+
+impl ExtnStreamProcessor for TelemetryProcessor {
+    type VALUE = TelemetryPayload;
+    type STATE = MSender<String>;
+
+    fn get_state(&self) -> Self::STATE {
+        self.sender.clone()
+    }
+
+    fn sender(&self) -> MSender<ExtnMessage> {
+        self.streamer.sender()
+    }
+
+    fn receiver(&mut self) -> MReceiver<ExtnMessage> {
+        self.streamer.receiver()
+    }
+}
+
+#[async_trait]
+impl ExtnEventProcessor for TelemetryProcessor {
+    async fn process_event(
+        state: Self::STATE,
+        _msg: ExtnMessage,
+        extracted_message: Self::VALUE,
+    ) -> Option<bool> {
+        if let Err(e) = state
+            .send(serde_json::to_string(&extracted_message).unwrap())
+            .await
+        {
+            error!("error forwarding {:?}", e);
+        }
+        None
+    }
+}

--- a/examples/tm_extn/src/tm_ffi.rs
+++ b/examples/tm_extn/src/tm_ffi.rs
@@ -1,0 +1,119 @@
+// Copyright 2023 Comcast Cable Communications Management, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use ripple_sdk::{
+    api::status_update::ExtnStatus,
+    crossbeam::channel::Receiver as CReceiver,
+    export_channel_builder, export_extn_metadata,
+    extn::{
+        client::{extn_client::ExtnClient, extn_sender::ExtnSender},
+        extn_id::{ExtnClassId, ExtnId},
+        ffi::{
+            ffi_channel::{ExtnChannel, ExtnChannelBuilder},
+            ffi_library::{CExtnMetadata, ExtnMetadata, ExtnSymbolMetadata},
+            ffi_message::CExtnMessage,
+        },
+    },
+    framework::ripple_contract::{ContractFulfiller, RippleContract},
+    log::{debug, error, info},
+    semver::Version,
+    tokio::{self, runtime::Runtime, sync::mpsc::channel},
+    utils::{error::RippleError, logger::init_logger},
+};
+use tokio_tungstenite::tungstenite::{connect, Message};
+use url::Url;
+
+use crate::telemetry_processor::TelemetryProcessor;
+
+fn init_library() -> CExtnMetadata {
+    let _ = init_logger("tm".into());
+
+    let dist_meta = ExtnSymbolMetadata::get(
+        ExtnId::new_channel(ExtnClassId::Distributor, "tm".into()),
+        ContractFulfiller::new(vec![RippleContract::OperationalMetricListener]),
+        Version::new(1, 1, 0),
+    );
+
+    debug!("Returning tm builder");
+    let extn_metadata = ExtnMetadata {
+        name: "tm".into(),
+        symbols: vec![dist_meta],
+    };
+    extn_metadata.into()
+}
+
+export_extn_metadata!(CExtnMetadata, init_library);
+
+fn start_launcher(sender: ExtnSender, receiver: CReceiver<CExtnMessage>) {
+    let _ = init_logger("tm".into());
+    info!("Starting tm channel");
+    let mut client = ExtnClient::new(receiver, sender);
+
+    if !client.check_contract_fulfillment(RippleContract::OperationalMetricListener) {
+        let _ = client.event(ExtnStatus::Error);
+        return;
+    }
+    if let Some(ws_url) = client.get_config("ws_url") {
+        let runtime = Runtime::new().unwrap();
+
+        runtime.block_on(async move {
+            let client_c = client.clone();
+            tokio::spawn(async move {
+                if let Ok((mut socket, _r)) = connect(Url::parse(&ws_url).unwrap()) {
+                    let (tx, mut tr) = channel(3);
+                    client.add_event_processor(TelemetryProcessor::new(tx));
+                    while let Some(v) = tr.recv().await {
+                        if let Err(e) = socket.write_message(Message::Text(v)) {
+                            error!("Error sending to socket {:?}", e);
+                        }
+                    }
+                }
+
+                // Lets Main know that the distributor channel is ready
+                let _ = client.event(ExtnStatus::Ready);
+            });
+            client_c.initialize().await;
+        });
+    } else {
+        let _ = client.event(ExtnStatus::Error);
+    }
+}
+
+fn build(extn_id: String) -> Result<Box<ExtnChannel>, RippleError> {
+    if let Ok(id) = ExtnId::try_from(extn_id) {
+        let current_id = ExtnId::new_channel(ExtnClassId::Distributor, "tm".into());
+
+        if id.eq(&current_id) {
+            Ok(Box::new(ExtnChannel {
+                start: start_launcher,
+            }))
+        } else {
+            Err(RippleError::ExtnError)
+        }
+    } else {
+        Err(RippleError::InvalidInput)
+    }
+}
+
+fn init_extn_builder() -> ExtnChannelBuilder {
+    ExtnChannelBuilder {
+        build,
+        service: "tm".into(),
+    }
+}
+
+export_channel_builder!(ExtnChannelBuilder, init_extn_builder);


### PR DESCRIPTION
## What
Metrics upgrades to support
1. Extensions to send metrics and telemetry information
2. Example extension for developers to create their own telemetry listener
3. Provide support for extensions to create their own Proprietary Metrics schema for consumption.
4. Implement metrics management Ripple RPC Api

## Why
To offer better metrics support for extensions and better encapsulation of Ripple state information.
Extensions should be agnostic to the internal state of the Main application but offer enough metadata for Metrics.
Proprietary extensions should also have the ability to create their own Metrics schema using RawMetric enumeration.

## How
1. Contracts for Operational Telemetry listeners and Metrics Forwarder
2. Operational Telemetry Support using Telemetry Builder for extensions to receive telemetry events
3. Sample extension for receiving the telemetry events and forwarding them to a WebSocket
4. Proprietary Metrics support using `serde_json::Value`, where Main will populate Ripple State information as it passes through.
5. Add RPC handler for MetricsManagement
