### PR TITLE
fix: user grant option evaluation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,4 @@ members = [
 
 [workspace.package]
 version = "0.8.0"
+resolver = "2"

--- a/core/launcher/Cargo.toml
+++ b/core/launcher/Cargo.toml
@@ -20,7 +20,6 @@ name = "launcher"
 version = "0.8.0"
 edition = "2021"
 repository = "https://github.com/rdkcentral/Ripple"
-resolver = "2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/core/launcher/Cargo.toml
+++ b/core/launcher/Cargo.toml
@@ -19,8 +19,10 @@
 name = "launcher"
 version = "0.8.0"
 edition = "2021"
+repository = "https://github.com/rdkcentral/Ripple"
+resolver = "2"
 
-# See more keys and their definitions at https:#doc.rust-lang.org/cargo/reference/manifest.html
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
 crate-type = ["cdylib"]

--- a/core/main/Cargo.toml
+++ b/core/main/Cargo.toml
@@ -21,6 +21,7 @@ version = "0.8.0"
 edition = "2021"
 repository = "https://github.com/rdkcentral/Ripple"
 build = "build.rs"
+resolver = "2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -29,8 +30,8 @@ name = "ripple"
 path = "src/main.rs"
 
 [features]
-local_dev=[]
-sysd=["sd-notify"]
+local_dev = []
+sysd = ["sd-notify"]
 
 [dependencies]
 ripple_sdk = { path = "../sdk", features = ["full"] }
@@ -48,3 +49,6 @@ sd-notify = { version = "0.4.1", optional = true }
 
 [build-dependencies]
 vergen = "1"
+
+[dev-dependencies]
+ripple_tdk = { path = "../tdk" }

--- a/core/main/Cargo.toml
+++ b/core/main/Cargo.toml
@@ -21,7 +21,6 @@ version = "0.8.0"
 edition = "2021"
 repository = "https://github.com/rdkcentral/Ripple"
 build = "build.rs"
-resolver = "2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/core/main/src/firebolt/firebolt_ws.rs
+++ b/core/main/src/firebolt/firebolt_ws.rs
@@ -137,7 +137,6 @@ impl tungstenite::handshake::server::Callback for ConnectionCallback {
 }
 
 impl FireboltWs {
-    #[allow(dead_code)]
     pub async fn start(
         server_addr: &str,
         state: PlatformState,
@@ -181,7 +180,6 @@ impl FireboltWs {
         }
     }
 
-    #[allow(dead_code)]
     async fn handle_connection(
         _client_addr: SocketAddr,
         ws_stream: WebSocketStream<TcpStream>,

--- a/core/main/src/firebolt/handlers/capabilities_rpc.rs
+++ b/core/main/src/firebolt/handlers/capabilities_rpc.rs
@@ -113,7 +113,7 @@ impl CapabilityServer for CapabilityImpl {
             .state
             .cap_state
             .generic
-            .check_supported(&vec![FireboltPermission {
+            .check_supported(&[FireboltPermission {
                 cap: FireboltCap::Full(cap.capability),
                 role: cap.role.unwrap_or(CapabilityRole::Use),
             }])

--- a/core/main/src/service/apps/provider_broker.rs
+++ b/core/main/src/service/apps/provider_broker.rs
@@ -50,12 +50,9 @@ use crate::{
 };
 
 #[cfg(test)]
-use ripple_sdk::{
-    api::firebolt::{
-        fb_pin::{PinChallengeResponse, PinChallengeResultReason},
-        provider::ChallengeResponse,
-    },
-    tokio,
+use ripple_sdk::api::firebolt::{
+    fb_pin::{PinChallengeResponse, PinChallengeResultReason},
+    provider::ChallengeResponse,
 };
 
 const REQUEST_QUEUE_CAPACITY: usize = 3;
@@ -105,7 +102,7 @@ impl ProviderBrokerState {
             state,
             ctx,
             PinChallengeResponse {
-                granted: true,
+                granted: false,
                 reason,
             },
         )

--- a/core/main/src/service/apps/provider_broker.rs
+++ b/core/main/src/service/apps/provider_broker.rs
@@ -51,8 +51,11 @@ use crate::{
 
 #[cfg(test)]
 use ripple_sdk::api::firebolt::{
-    fb_pin::{PinChallengeResponse, PinChallengeResultReason},
-    provider::ChallengeResponse,
+    fb_pin::{
+        PinChallengeResponse, PinChallengeResultReason, PIN_CHALLENGE_CAPABILITY,
+        PIN_CHALLENGE_EVENT,
+    },
+    provider::{ChallengeResponse, ACK_CHALLENGE_CAPABILITY, ACK_CHALLENGE_EVENT},
 };
 
 const REQUEST_QUEUE_CAPACITY: usize = 3;
@@ -116,7 +119,6 @@ impl ProviderBrokerState {
         ctx: &CallContext,
         response: PinChallengeResponse,
     ) {
-        use ripple_sdk::api::firebolt::fb_pin::{PIN_CHALLENGE_CAPABILITY, PIN_CHALLENGE_EVENT};
         ProviderBroker::register_provider(
             state,
             PIN_CHALLENGE_CAPABILITY.to_owned(),
@@ -126,7 +128,6 @@ impl ProviderBrokerState {
             ListenRequest { listen: true },
         )
         .await;
-
         self.send_challenge_response(
             state,
             ProviderResponsePayload::PinChallengeResponse(response),
@@ -154,8 +155,6 @@ impl ProviderBrokerState {
         ctx: &CallContext,
         response: ChallengeResponse,
     ) {
-        use ripple_sdk::api::firebolt::provider::{ACK_CHALLENGE_CAPABILITY, ACK_CHALLENGE_EVENT};
-
         ProviderBroker::register_provider(
             state,
             ACK_CHALLENGE_CAPABILITY.to_owned(),
@@ -165,7 +164,6 @@ impl ProviderBrokerState {
             ListenRequest { listen: true },
         )
         .await;
-
         self.send_challenge_response(
             state,
             ProviderResponsePayload::ChallengeResponse(response),

--- a/core/main/src/service/apps/provider_broker.rs
+++ b/core/main/src/service/apps/provider_broker.rs
@@ -110,22 +110,25 @@ impl ProviderBrokerState {
         response: PinChallengeResponse,
     ) {
         debug!("sending pinchallenge provider response = {:#?}", response);
-        let active_session = {
+        let active_c_id: String;
+        loop {
             let sessions = self.active_sessions.read().unwrap();
-            sessions.iter().next().map(|(c_id, _)| c_id.clone())
-        };
+            if let Some((c_id, _)) = sessions.iter().next() {
+                active_c_id = c_id.clone();
+                break;
+            }
+            debug!("waiting for active session for pinchallenge");
+        }
 
-        let c_id = active_session.unwrap();
-        debug!("pinchallenge session correlation id={}", c_id);
+        debug!("pinchallenge session correlation id={}", active_c_id);
         ProviderBroker::provider_response(
             state,
             ProviderResponse {
-                correlation_id: c_id.to_owned(),
+                correlation_id: active_c_id.to_owned(),
                 result: ProviderResponsePayload::PinChallengeResponse(response),
             },
         )
         .await;
-        debug!("pinchallenge provider response sent");
     }
 }
 

--- a/core/main/src/service/user_grants.rs
+++ b/core/main/src/service/user_grants.rs
@@ -1228,9 +1228,26 @@ mod tests {
             assert!(result.is_ok());
         }
 
-        #[test]
-        #[ignore = "not implemented"]
-        fn test_evaluate_options_check_all_denied() {}
+        #[tokio::test]
+
+        async fn test_evaluate_options_check_all_denied() {
+            let (state, ctx, _) = setup();
+            let perm = FireboltPermission {
+                cap: FireboltCap::Full("xrn:firebolt:capability:something:unknown".to_owned()),
+                role: CapabilityRole::Use,
+            };
+            let policy = GrantPolicy {
+                options: vec![GrantRequirements { steps: vec![] }],
+                ..Default::default()
+            };
+
+            let result = GrantPolicyEnforcer::evaluate_options(&state, &ctx, &perm, &policy).await;
+
+            assert!(result.is_err_and(|e| e.eq(&DenyReasonWithCap {
+                reason: DenyReason::GrantDenied,
+                caps: vec![perm.cap.clone()]
+            })));
+        }
 
         #[test]
         #[ignore = "not implemented"]

--- a/core/main/src/service/user_grants.rs
+++ b/core/main/src/service/user_grants.rs
@@ -1240,7 +1240,10 @@ mod tests {
         ) -> (PlatformState, CallContext, FireboltPermission, GrantPolicy) {
             let _ = init_logger("tests".into());
             let runtime = MockRuntime::new();
-            let perm = fb_perm("xrn:firebolt:capability:localization:postal-code", None);
+            let perm = fb_perm(
+                "xrn:firebolt:capability:localization:postal-code",
+                Some(CapabilityRole::Use),
+            );
             let policy = GrantPolicy {
                 options: policy_options,
                 ..Default::default()

--- a/core/main/src/service/user_grants.rs
+++ b/core/main/src/service/user_grants.rs
@@ -1207,10 +1207,8 @@ mod tests {
     use super::*;
 
     mod test_grant_policy_enforcer {
-        use std::str::FromStr;
-
         use super::*;
-        use crate::utils::test_utils::{cap_state_listener, fb_perm, MockRuntime};
+        use crate::utils::test_utils::{fb_perm, MockRuntime};
         use futures::FutureExt;
         use ripple_sdk::{
             api::{
@@ -1225,9 +1223,6 @@ mod tests {
                 time::{self, Duration},
             },
             utils::logger::init_logger,
-        };
-        use ripple_tdk::utils::test_utils::{
-            cap_jsonrpc_payload_granted, cap_jsonrpc_payload_revoked,
         };
         use serde_json::json;
 
@@ -1289,7 +1284,6 @@ mod tests {
                 reason: DenyReason::GrantDenied,
                 caps: vec![perm.cap.clone()]
             })));
-            // TODO check cap is unsupported
         }
 
         #[tokio::test]
@@ -1318,7 +1312,6 @@ mod tests {
             let (result, _) = join!(evaluate_options, pinchallenge_response);
 
             assert!(result.is_ok());
-            assert!(state.cap_state.generic.check_available(&vec![perm]).is_ok());
         }
 
         #[tokio::test]
@@ -1347,7 +1340,6 @@ mod tests {
             let (result, _) = join!(evaluate_options, pinchallenge_response);
 
             assert!(result.is_ok());
-            assert!(state.cap_state.generic.check_available(&vec![perm]).is_ok());
         }
 
         #[tokio::test]
@@ -1446,7 +1438,6 @@ mod tests {
                         .send_ackchallenge_failure(&state, &ctx)
                         .await;
                 });
-            let mut resp_rx = cap_state_listener(&state, &perm, CapEvent::OnRevoked).await;
 
             let evaluate_options =
                 GrantPolicyEnforcer::evaluate_options(&state, &ctx, &perm, &policy);
@@ -1457,11 +1448,6 @@ mod tests {
                 reason: DenyReason::GrantDenied,
                 caps: vec![FireboltCap::Full(ACK_CHALLENGE_CAPABILITY.to_owned())]
             })));
-            let cap_event = resp_rx.recv().await;
-            assert!(cap_event.is_some());
-            let value: serde_json::Value =
-                serde_json::Value::from_str(cap_event.unwrap().jsonrpc_msg.as_str()).unwrap();
-            assert_eq!(cap_jsonrpc_payload_revoked(perm.cap.as_str()), value);
         }
 
         #[tokio::test]
@@ -1489,18 +1475,12 @@ mod tests {
                         .send_ackchallenge_success(&state, &ctx)
                         .await;
                 });
-            let mut resp_rx = cap_state_listener(&state, &perm, CapEvent::OnGranted).await;
 
             let evaluate_options =
                 GrantPolicyEnforcer::evaluate_options(&state, &ctx, &perm, &policy);
             let (result, _) = join!(evaluate_options, challenge_responses);
 
             assert!(result.is_ok());
-            let cap_event = resp_rx.recv().await;
-            assert!(cap_event.is_some());
-            let value: serde_json::Value =
-                serde_json::Value::from_str(cap_event.unwrap().jsonrpc_msg.as_str()).unwrap();
-            assert_eq!(cap_jsonrpc_payload_granted(perm.cap.as_str()), value);
         }
     }
 }

--- a/core/main/src/service/user_grants.rs
+++ b/core/main/src/service/user_grants.rs
@@ -721,6 +721,7 @@ impl GrantPolicyEnforcer {
                 return result;
             }
         } else {
+            // TODO: This debug statement looks incorrect as it would trigger if all grants were successful
             debug!("No grant policies configured");
         }
         Self::update_privacy_settings_and_user_grants(

--- a/core/main/src/service/user_grants.rs
+++ b/core/main/src/service/user_grants.rs
@@ -898,17 +898,17 @@ impl GrantPolicyEnforcer {
         permission: &FireboltPermission,
         policy: &GrantPolicy,
     ) -> Result<(), DenyReasonWithCap> {
-        // TODO: is this check duplicated on line 997?
-        // if let Err(e) = platform_state
-        //     .cap_state
-        //     .generic
-        //     .check_all(&vec![permission.clone()])
-        // {
-        //     return Err(DenyReasonWithCap {
-        //         caps: e.caps,
-        //         reason: DenyReason::GrantDenied,
-        //     });
-        // }
+        // TODO: is this check duplicated on line 1032?
+        if let Err(e) = platform_state
+            .cap_state
+            .generic
+            .check_all(&vec![permission.clone()])
+        {
+            return Err(DenyReasonWithCap {
+                caps: e.caps,
+                reason: DenyReason::GrantDenied,
+            });
+        }
 
         if policy.options.is_empty() {
             return Ok(());

--- a/core/main/src/service/user_grants.rs
+++ b/core/main/src/service/user_grants.rs
@@ -1161,7 +1161,10 @@ mod tests {
             service::extn::ripple_client::RippleClient, state::bootstrap_state::ChannelsState,
         };
         use ripple_sdk::{
-            api::{gateway::rpc_gateway_api::ApiProtocol, manifest::extn_manifest::ExtnManifest},
+            api::{
+                device::device_user_grants_data::GrantRequirements,
+                gateway::rpc_gateway_api::ApiProtocol, manifest::extn_manifest::ExtnManifest,
+            },
             tokio,
         };
 
@@ -1212,9 +1215,18 @@ mod tests {
             assert!(result.is_ok());
         }
 
-        #[test]
-        #[ignore = "not implemented"]
-        fn test_evaluate_options_no_steps_for_option() {}
+        #[tokio::test]
+        async fn test_evaluate_options_no_steps_for_option() {
+            let (state, ctx, perm) = setup();
+            let policy = GrantPolicy {
+                options: vec![GrantRequirements { steps: vec![] }],
+                ..Default::default()
+            };
+
+            let result = GrantPolicyEnforcer::evaluate_options(&state, &ctx, &perm, &policy).await;
+
+            assert!(result.is_ok());
+        }
 
         #[test]
         #[ignore = "not implemented"]

--- a/core/main/src/service/user_grants.rs
+++ b/core/main/src/service/user_grants.rs
@@ -934,31 +934,30 @@ impl GrantPolicyEnforcer {
 
         if let Some(first_supported_option) = first_supported_option {
             for step in &first_supported_option.steps {
-                match GrantStepExecutor::execute(step, platform_state, call_ctx, permission).await {
-                    Ok(_) => {
-                        debug!("grant step execute OK. step={:?}", step);
-                        CapState::emit(
-                            platform_state,
-                            CapEvent::OnGranted,
-                            step.capability_as_fb_cap(),
-                            Some(permission.role),
-                        )
-                        .await;
-                        debug!("cap emitted");
-                    }
-                    Err(e) => {
-                        debug!("grant step execute Err. step={:?}", step);
-                        CapState::emit(
-                            platform_state,
-                            CapEvent::OnRevoked,
-                            step.capability_as_fb_cap(),
-                            Some(permission.role),
-                        )
-                        .await;
-                        return Err(e);
-                    }
+                if let Err(e) =
+                    GrantStepExecutor::execute(step, platform_state, call_ctx, permission).await
+                {
+                    debug!("grant step execute Err. step={:?}", step);
+                    CapState::emit(
+                        platform_state,
+                        CapEvent::OnRevoked,
+                        permission.cap.clone(),
+                        Some(permission.role),
+                    )
+                    .await;
+                    return Err(e);
+                } else {
+                    debug!("grant step execute OK. step={:?}", step);
                 }
             }
+
+            CapState::emit(
+                platform_state,
+                CapEvent::OnGranted,
+                permission.cap.clone(),
+                Some(permission.role),
+            )
+            .await;
 
             Ok(())
         } else {

--- a/core/main/src/service/user_grants.rs
+++ b/core/main/src/service/user_grants.rs
@@ -938,14 +938,6 @@ impl GrantPolicyEnforcer {
                     GrantStepExecutor::execute(step, platform_state, call_ctx, permission).await
                 {
                     debug!("grant step execute Err. step={:?}", step);
-
-                    // platform_state.cap_state.grant_state.update(
-                    //     permission,
-                    //     policy,
-                    //     false,
-                    //     call_ctx.app_id.as_str(),
-                    // );
-
                     CapState::emit(
                         platform_state,
                         CapEvent::OnRevoked,

--- a/core/main/src/state/cap/cap_state.rs
+++ b/core/main/src/state/cap/cap_state.rs
@@ -189,6 +189,7 @@ impl CapState {
                 if let Ok(r) = Self::get_cap_info(ps, cc, request).await {
                     if let Some(cap_info) = r.get(0) {
                         if let Ok(data) = serde_json::to_value(cap_info) {
+                            debug!("data={:?}", data);
                             // Step 4: Send exclusive cap info data for each listener
                             AppEvents::send_event(ps, &listener, &data).await;
                         }
@@ -226,6 +227,8 @@ impl CapState {
         if let Err(e) = GrantState::get_info(state, &call_context, &cap_set) {
             let _ = grant_errors.insert(e);
         }
+
+        debug!("grant errors {:?}", grant_errors);
 
         let cap_infos: Vec<CapabilityInfo> = generic_caps
             .into_iter()

--- a/core/main/src/state/cap/generic_cap_state.rs
+++ b/core/main/src/state/cap/generic_cap_state.rs
@@ -20,9 +20,14 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use ripple_sdk::api::{
-    firebolt::fb_capabilities::{DenyReason, DenyReasonWithCap, FireboltCap, FireboltPermission},
-    manifest::device_manifest::DeviceManifest,
+use ripple_sdk::{
+    api::{
+        firebolt::fb_capabilities::{
+            DenyReason, DenyReasonWithCap, FireboltCap, FireboltPermission,
+        },
+        manifest::device_manifest::DeviceManifest,
+    },
+    log::debug,
 };
 
 #[derive(Clone, Debug, Default)]
@@ -69,17 +74,19 @@ impl GenericCapState {
         result
     }
 
-    pub fn check_supported(
-        &self,
-        request: &Vec<FireboltPermission>,
-    ) -> Result<(), DenyReasonWithCap> {
+    pub fn check_supported(&self, request: &[FireboltPermission]) -> Result<(), DenyReasonWithCap> {
         let supported = self.supported.read().unwrap();
-        let mut not_supported: Vec<FireboltCap> = Vec::new();
-        for fb_perm in request {
-            if !supported.contains(&fb_perm.cap.as_str()) {
-                not_supported.push(fb_perm.cap.clone());
-            }
-        }
+        let not_supported: Vec<FireboltCap> = request
+            .iter()
+            .filter(|fb_perm| !supported.contains(&fb_perm.cap.as_str()))
+            .map(|fb_perm| fb_perm.cap.clone())
+            .collect();
+
+        debug!(
+            "checking supported caps request={:?}, not_supported={:?}",
+            request, not_supported
+        );
+
         if !not_supported.is_empty() {
             return Err(DenyReasonWithCap::new(
                 DenyReason::Unsupported,
@@ -106,9 +113,11 @@ impl GenericCapState {
         Ok(())
     }
 
-    pub fn check_all(&self, caps: &Vec<FireboltPermission>) -> Result<(), DenyReasonWithCap> {
-        self.check_supported(caps)?;
-
-        self.check_available(caps)
+    pub fn check_all(
+        &self,
+        permissions: &Vec<FireboltPermission>,
+    ) -> Result<(), DenyReasonWithCap> {
+        self.check_supported(permissions)?;
+        self.check_available(permissions)
     }
 }

--- a/core/main/src/state/cap/permitted_state.rs
+++ b/core/main/src/state/cap/permitted_state.rs
@@ -63,6 +63,13 @@ impl PermittedState {
         perms.sync();
     }
 
+    #[cfg(test)]
+    pub fn set_permissions(&mut self, permissions: HashMap<String, Vec<FireboltPermission>>) {
+        let mut perms = self.permitted.write().unwrap();
+        perms.value = permissions;
+        perms.sync();
+    }
+
     fn get_all_permissions(&self) -> HashMap<String, Vec<FireboltPermission>> {
         self.permitted.read().unwrap().clone().value
     }

--- a/core/main/src/state/platform_state.rs
+++ b/core/main/src/state/platform_state.rs
@@ -153,3 +153,30 @@ impl PlatformState {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ripple_tdk::utils::test_utils::Mockable;
+
+    impl Mockable for PlatformState {
+        fn mock() -> Self {
+            use crate::state::bootstrap_state::ChannelsState;
+
+            let channels_state = ChannelsState::new();
+            let client = RippleClient::new(channels_state.clone());
+            let (_, manifest) = DeviceManifest::load_from_content(
+                include_str!("../../../../examples/manifest/device-manifest-example.json")
+                    .to_string(),
+            )
+            .unwrap();
+            let (_, extn_manifest) = ExtnManifest::load_from_content(
+                include_str!("../../../../examples/manifest/extn-manifest-example.json")
+                    .to_string(),
+            )
+            .unwrap();
+
+            Self::new(extn_manifest, manifest, client, vec![])
+        }
+    }
+}

--- a/core/main/src/utils/mod.rs
+++ b/core/main/src/utils/mod.rs
@@ -17,3 +17,6 @@
 
 pub mod rpc_utils;
 pub mod serde_utils;
+
+#[cfg(test)]
+pub mod test_utils;

--- a/core/main/src/utils/test_utils.rs
+++ b/core/main/src/utils/test_utils.rs
@@ -1,0 +1,50 @@
+// Copyright 2023 Comcast Cable Communications Management, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+use ripple_sdk::api::{
+    firebolt::fb_capabilities::{CapabilityRole, FireboltCap, FireboltPermission},
+    gateway::rpc_gateway_api::CallContext,
+};
+use ripple_tdk::utils::test_utils::Mockable;
+
+use crate::state::platform_state::PlatformState;
+
+pub struct MockRuntime {
+    pub platform_state: PlatformState,
+    pub call_context: CallContext,
+}
+
+impl MockRuntime {
+    pub fn new() -> Self {
+        Self {
+            platform_state: PlatformState::mock(),
+            call_context: CallContext::mock(),
+        }
+    }
+}
+
+impl Default for MockRuntime {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub fn fb_perm(cap: &str, role: Option<CapabilityRole>) -> FireboltPermission {
+    FireboltPermission {
+        cap: FireboltCap::Full(cap.to_owned()),
+        role: role.unwrap_or(CapabilityRole::Use),
+    }
+}

--- a/core/sdk/Cargo.toml
+++ b/core/sdk/Cargo.toml
@@ -20,13 +20,16 @@ name = "ripple_sdk"
 version = "0.8.0"
 edition = "2021"
 repository = "https://github.com/rdkcentral/Ripple"
+resolver = "2"
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default=[]
-rpc=["jsonrpsee-core"]
-full=["rpc"]
-sysd=[]
+default = []
+rpc = ["jsonrpsee-core"]
+full = ["rpc"]
+sysd = []
+test = []
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
@@ -39,7 +42,13 @@ chrono = "0.4"
 async-trait = "^0.1.57"
 libloading = "0.7.4"
 crossbeam = "0.8.2"
-tokio = { version = "1.16.1", features = ["macros", "sync", "rt-multi-thread", "signal", "time"] }
+tokio = { version = "1.16.1", features = [
+    "macros",
+    "sync",
+    "rt-multi-thread",
+    "signal",
+    "time",
+] }
 uuid = { version = "1.1.2", features = ["serde", "v5", "v4"] }
 futures = "0.3.21"
 jsonrpsee-core = { version = "0.9.0", features = ["server"], optional = true }

--- a/core/sdk/Cargo.toml
+++ b/core/sdk/Cargo.toml
@@ -20,7 +20,6 @@ name = "ripple_sdk"
 version = "0.8.0"
 edition = "2021"
 repository = "https://github.com/rdkcentral/Ripple"
-resolver = "2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/core/sdk/src/api/device/device_user_grants_data.rs
+++ b/core/sdk/src/api/device/device_user_grants_data.rs
@@ -147,7 +147,7 @@ impl Default for GrantPolicy {
 #[derive(Deserialize, Debug, Clone)]
 pub struct GrantPolicies {
     #[serde(rename = "use")]
-    pub _use: Option<GrantPolicy>,
+    pub use_: Option<GrantPolicy>,
     pub manage: Option<GrantPolicy>,
     pub provide: Option<GrantPolicy>,
 }
@@ -156,8 +156,8 @@ impl GrantPolicies {
     pub fn get_policy(&self, permission: &FireboltPermission) -> Option<GrantPolicy> {
         match permission.role {
             CapabilityRole::Use => {
-                if self._use.is_some() {
-                    return Some(self._use.clone().unwrap());
+                if self.use_.is_some() {
+                    return Some(self.use_.clone().unwrap());
                 }
             }
             CapabilityRole::Manage => {

--- a/core/sdk/src/api/device/device_user_grants_data.rs
+++ b/core/sdk/src/api/device/device_user_grants_data.rs
@@ -33,6 +33,12 @@ pub struct GrantStep {
     pub configuration: Option<Value>,
 }
 
+impl GrantStep {
+    pub fn capability_as_fb_cap(&self) -> FireboltCap {
+        FireboltCap::Full(self.capability.clone())
+    }
+}
+
 #[derive(Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct GrantRequirements {

--- a/core/sdk/src/api/firebolt/fb_capabilities.rs
+++ b/core/sdk/src/api/firebolt/fb_capabilities.rs
@@ -56,6 +56,7 @@ impl Hash for FireboltCap {
 }
 
 impl FireboltCap {
+    // TODO: refactor this to use ToString trait instead of confusingly named function
     pub fn as_str(&self) -> String {
         let prefix = "xrn:firebolt:capability:";
         match self {

--- a/core/sdk/src/api/firebolt/fb_capabilities.rs
+++ b/core/sdk/src/api/firebolt/fb_capabilities.rs
@@ -341,7 +341,7 @@ impl RpcError for DenyReason {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct DenyReasonWithCap {
     pub reason: DenyReason,
     pub caps: Vec<FireboltCap>,

--- a/core/tdk/Cargo.toml
+++ b/core/tdk/Cargo.toml
@@ -20,7 +20,6 @@ name = "ripple_tdk"
 version = "0.8.0"
 edition = "2021"
 repository = "https://github.com/rdkcentral/Ripple"
-resolver = "2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/core/tdk/Cargo.toml
+++ b/core/tdk/Cargo.toml
@@ -28,3 +28,4 @@ default = []
 
 [dependencies]
 ripple_sdk = { path = "../sdk", features = ["full"] }
+serde_json = "1.0"

--- a/core/tdk/Cargo.toml
+++ b/core/tdk/Cargo.toml
@@ -22,7 +22,7 @@ edition = "2021"
 repository = "https://github.com/rdkcentral/Ripple"
 resolver = "2"
 
-# See more keys and their definitions at https:#doc.rust-lang.org/cargo/reference/manifest.html
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
 default = []

--- a/core/tdk/Cargo.toml
+++ b/core/tdk/Cargo.toml
@@ -15,17 +15,17 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-[workspace]
-members = [
-    "core/sdk",
-    "core/tdk",
-    "device/thunder_ripple_sdk",
-    "core/main",
-    "core/launcher",
-    "device/thunder",
-    "distributor/general",
-    "examples/rpc_extn",
-]
-
-[workspace.package]
+[package]
+name = "ripple_tdk"
 version = "0.8.0"
+edition = "2021"
+repository = "https://github.com/rdkcentral/Ripple"
+resolver = "2"
+
+# See more keys and their definitions at https:#doc.rust-lang.org/cargo/reference/manifest.html
+
+[features]
+default = []
+
+[dependencies]
+ripple_sdk = { path = "../sdk", features = ["full"] }

--- a/core/tdk/src/gateway/mod.rs
+++ b/core/tdk/src/gateway/mod.rs
@@ -1,0 +1,1 @@
+pub mod rpc_gateway_api;

--- a/core/tdk/src/gateway/mod.rs
+++ b/core/tdk/src/gateway/mod.rs
@@ -1,1 +1,18 @@
+// Copyright 2023 Comcast Cable Communications Management, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
 pub mod rpc_gateway_api;

--- a/core/tdk/src/gateway/rpc_gateway_api.rs
+++ b/core/tdk/src/gateway/rpc_gateway_api.rs
@@ -15,15 +15,18 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use ripple_sdk::api::gateway::rpc_gateway_api::{ApiProtocol, CallContext};
+use ripple_sdk::{
+    api::gateway::rpc_gateway_api::{ApiProtocol, CallContext},
+    uuid::Uuid,
+};
 
 use crate::utils::test_utils::Mockable;
 
 impl Mockable for CallContext {
     fn mock() -> Self {
         Self::new(
-            "sess_id".to_owned(),
-            "1".to_owned(),
+            Uuid::new_v4().to_string(),
+            Uuid::new_v4().to_string(),
             "app_id".to_owned(),
             1,
             ApiProtocol::Extn,

--- a/core/tdk/src/gateway/rpc_gateway_api.rs
+++ b/core/tdk/src/gateway/rpc_gateway_api.rs
@@ -1,3 +1,20 @@
+// Copyright 2023 Comcast Cable Communications Management, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
 use ripple_sdk::api::gateway::rpc_gateway_api::{ApiProtocol, CallContext};
 
 use crate::utils::test_utils::Mockable;

--- a/core/tdk/src/gateway/rpc_gateway_api.rs
+++ b/core/tdk/src/gateway/rpc_gateway_api.rs
@@ -1,0 +1,18 @@
+use ripple_sdk::api::gateway::rpc_gateway_api::{ApiProtocol, CallContext};
+
+use crate::utils::test_utils::Mockable;
+
+impl Mockable for CallContext {
+    fn mock() -> Self {
+        Self::new(
+            "sess_id".to_owned(),
+            "1".to_owned(),
+            "app_id".to_owned(),
+            1,
+            ApiProtocol::Extn,
+            "method".to_owned(),
+            None,
+            false,
+        )
+    }
+}

--- a/core/tdk/src/lib.rs
+++ b/core/tdk/src/lib.rs
@@ -1,2 +1,19 @@
+// Copyright 2023 Comcast Cable Communications Management, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
 pub mod gateway;
 pub mod utils;

--- a/core/tdk/src/lib.rs
+++ b/core/tdk/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod gateway;
+pub mod utils;

--- a/core/tdk/src/utils/mod.rs
+++ b/core/tdk/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod test_utils;

--- a/core/tdk/src/utils/mod.rs
+++ b/core/tdk/src/utils/mod.rs
@@ -1,1 +1,18 @@
+// Copyright 2023 Comcast Cable Communications Management, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
 pub mod test_utils;

--- a/core/tdk/src/utils/test_utils.rs
+++ b/core/tdk/src/utils/test_utils.rs
@@ -15,6 +15,16 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use serde_json::json;
+
 pub trait Mockable {
     fn mock() -> Self;
+}
+
+pub fn cap_jsonrpc_payload_granted(cap: String) -> serde_json::Value {
+    json!({"id":1,"jsonrpc":"2.0","result":{"available":true,"capability":cap,"manage":{"granted":true,"permitted":true},"provide":{"granted":true,"permitted":true},"supported":true,"use":{"granted":true,"permitted":true}}})
+}
+
+pub fn cap_jsonrpc_payload_revoked(cap: String) -> serde_json::Value {
+    json!({"id":1,"jsonrpc":"2.0","result":{"available":true,"capability":cap,"details":["unpermitted"],"manage":{"granted":false,"permitted":false},"provide":{"granted":false,"permitted":false},"supported":true,"use":{"granted":false,"permitted":false}}})
 }

--- a/core/tdk/src/utils/test_utils.rs
+++ b/core/tdk/src/utils/test_utils.rs
@@ -1,0 +1,20 @@
+// Copyright 2023 Comcast Cable Communications Management, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+pub trait Mockable {
+    fn mock() -> Self;
+}

--- a/device/thunder/Cargo.toml
+++ b/device/thunder/Cargo.toml
@@ -20,6 +20,8 @@
 name = "thunder"
 version = "0.8.0"
 edition = "2021"
+repository = "https://github.com/rdkcentral/Ripple"
+resolver = "2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/device/thunder/Cargo.toml
+++ b/device/thunder/Cargo.toml
@@ -21,7 +21,6 @@ name = "thunder"
 version = "0.8.0"
 edition = "2021"
 repository = "https://github.com/rdkcentral/Ripple"
-resolver = "2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/device/thunder_ripple_sdk/Cargo.toml
+++ b/device/thunder_ripple_sdk/Cargo.toml
@@ -21,7 +21,6 @@ name = "thunder_ripple_sdk"
 version = "0.8.0"
 edition = "2021"
 repository = "https://github.com/rdkcentral/Ripple"
-resolver = "2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/device/thunder_ripple_sdk/Cargo.toml
+++ b/device/thunder_ripple_sdk/Cargo.toml
@@ -21,22 +21,32 @@ name = "thunder_ripple_sdk"
 version = "0.8.0"
 edition = "2021"
 repository = "https://github.com/rdkcentral/Ripple"
+resolver = "2"
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-contract_tests = ["pact_consumer", "reqwest", "expectest", "pact-plugin-driver", "pact_models", "maplit", "test-log"]
+contract_tests = [
+    "pact_consumer",
+    "reqwest",
+    "expectest",
+    "pact-plugin-driver",
+    "pact_models",
+    "maplit",
+    "test-log",
+]
 
 [dependencies]
 ripple_sdk = { path = "../../core/sdk" }
-jsonrpsee = { version = "0.9.0", features = ["macros", "ws-client"]}
+jsonrpsee = { version = "0.9.0", features = ["macros", "ws-client"] }
 serde = { version = "1.0", features = ["derive"] }
 url = "2.2.2"
 strum = "0.24"
 strum_macros = "0.24"
-pact_consumer = {version = "=0.10.4", optional = true}
-reqwest = {version = "0.11", optional = true}
-expectest = {version = "0.12.0", optional = true}
-pact-plugin-driver = {version = "0.4.1", optional = true}
-pact_models = {version = "1.0.9", optional = true}
-maplit = {version = "1.0.2", optional = true}
-test-log = {version = "0.2.11", optional = true}
+pact_consumer = { version = "=0.10.4", optional = true }
+reqwest = { version = "0.11", optional = true }
+expectest = { version = "0.12.0", optional = true }
+pact-plugin-driver = { version = "0.4.1", optional = true }
+pact_models = { version = "1.0.9", optional = true }
+maplit = { version = "1.0.2", optional = true }
+test-log = { version = "0.2.11", optional = true }

--- a/distributor/general/Cargo.toml
+++ b/distributor/general/Cargo.toml
@@ -21,7 +21,6 @@ name = "distributor_general"
 version = "0.8.0"
 edition = "2021"
 repository = "https://github.com/rdkcentral/Ripple"
-resolver = "2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/distributor/general/Cargo.toml
+++ b/distributor/general/Cargo.toml
@@ -20,6 +20,8 @@
 name = "distributor_general"
 version = "0.8.0"
 edition = "2021"
+repository = "https://github.com/rdkcentral/Ripple"
+resolver = "2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -125,7 +125,6 @@ Create a new rust repo and setup the cargo.toml like below
 name = "distributor_general"
 version = "0.1.0"
 edition = "2021"
-resolver = "2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -125,6 +125,7 @@ Create a new rust repo and setup the cargo.toml like below
 name = "distributor_general"
 version = "0.1.0"
 edition = "2021"
+resolver = "2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/manifest/device-manifest-example.json
+++ b/examples/manifest/device-manifest-example.json
@@ -6,7 +6,7 @@
     },
     "internal_ws_configuration": {
       "enabled": true,
-      "gateway": "127.0.0.1:3474"  
+      "gateway": "127.0.0.1:3474"
     },
     "platform": "Thunder",
     "platform_parameters": {

--- a/examples/rpc_extn/Cargo.toml
+++ b/examples/rpc_extn/Cargo.toml
@@ -20,8 +20,9 @@
 name = "rpc_extn"
 version = "0.8.0"
 edition = "2021"
+resolver = "2"
 
-# See more keys and their definitions at https:#doc.rust-lang.org/cargo/reference/manifest.html
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
 crate-type = ["cdylib"]
@@ -30,4 +31,4 @@ crate-type = ["cdylib"]
 ripple_sdk = { path = "../../core/sdk", features = ["full"] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-jsonrpsee = { version = "0.9.0", features = [ "macros", "jsonrpsee-core"] }
+jsonrpsee = { version = "0.9.0", features = ["macros", "jsonrpsee-core"] }

--- a/examples/rpc_extn/Cargo.toml
+++ b/examples/rpc_extn/Cargo.toml
@@ -20,7 +20,6 @@
 name = "rpc_extn"
 version = "0.8.0"
 edition = "2021"
-resolver = "2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/ripple
+++ b/ripple
@@ -87,7 +87,7 @@ case ${1} in
         sed -i "" "s@\"default_extension\": \"so\"@\"default_extension\": \"$default_extension\"@" ~/.ripple/firebolt-extn-manifest.json
 
         ## Update firebolt-device-manifest.json
-        sed -i "" "s@\"/etc/firebolt-app-library.json\"@\"library\": \"~/.ripple/firebolt-app-library.json\"@" ~/.ripple/firebolt-device-manifest.json
+        sed -i "" "s@\"library\": \"/etc/firebolt-app-library.json\"@\"library\": \"~/.ripple/firebolt-app-library.json\"@" ~/.ripple/firebolt-device-manifest.json
 
         echo "All Done!"
     ;;


### PR DESCRIPTION
## What

Fixed evaluation of user grant policy options. This addresses the issue raised [here](https://github.com/rdkcentral/Ripple/issues/199)

This is also the final warning/error detected by clippy which addresses the issue raised [here](https://github.com/rdkcentral/Ripple/issues/192)

## Why

The current implementation of the user grant options evaluation only looks at the first step in the first option of the grant policies set. This option has its first step executed even if the platform does not support it. The result of this execution is then used as the entire result of the options evaluation.

What should actually happen is the first option with all supported steps is executed and a grant/deny response produced from a combination of capability support and user actions.

## How

The evaluate options loop has been broken up into a multi step process where we first find the option which is supported by the platform. This option is then used to drive the execution of the grant steps, which prompts the user for the appropriate input. The outcome of this process is then used to generate an overall response as to whether or not the use of the capability is approved.

Unit test cases have been added to cover all of the combinations of cases to ensure that this process is followed correctly.
