### PR TITLE
fix: Exit with error code gracefully

### DIFF
--- a/core/main/Cargo.toml
+++ b/core/main/Cargo.toml
@@ -45,6 +45,8 @@ regex = "=1.7.3"
 serde_json = "1.0"
 base64 = "0.13.0"
 sd-notify = { version = "0.4.1", optional = true }
+exitcode = "1.1.2"
+
 
 [build-dependencies]
 vergen = "1"

--- a/core/main/src/bootstrap/boot.rs
+++ b/core/main/src/bootstrap/boot.rs
@@ -15,7 +15,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use ripple_sdk::framework::bootstrap::Bootstrap;
+use ripple_sdk::{
+    framework::{
+        bootstrap::{Bootstep, Bootstrap},
+        RippleResponse,
+    },
+    log::error,
+};
 
 use crate::state::bootstrap_state::BootstrapState;
 
@@ -51,38 +57,30 @@ use super::{
 /// 9. [FireboltGatewayStep] - Starts the firebolt gateway and blocks the thread to keep it alive till interruption.
 
 ///
-pub async fn boot(state: BootstrapState) {
-    let bootstrap = &Bootstrap::new(state);
-    bootstrap
-        .step(SetupExtnClientStep)
-        .await
-        .expect("Extn Client setup failure")
-        .step(LoadExtensionMetadataStep)
-        .await
-        .expect("Extn Metadata load failure")
-        .step(LoadExtensionsStep)
-        .await
-        .expect("Extn load failure")
-        .step(StartExtnChannelsStep)
-        .await
-        .expect("Start Extns failure")
-        .step(StartAppManagerStep)
-        .await
-        .expect("App Manager start")
-        .step(LoadDistributorValuesStep)
-        .await
-        .expect("Distributor values needs to be loaded")
-        .step(StartCloudSyncStep)
-        .await
-        .expect("Cloud Sync startup failed")
-        .step(CheckLauncherStep)
-        .await
-        .expect("if Launcher exists start")
-        .step(StartWsStep)
-        .await
-        .expect("Websocket startup failure")
-        .step(FireboltGatewayStep)
-        .await
-        .expect("Firebolt Gateway failure");
-    // -- User grant manager
+pub async fn boot(state: BootstrapState) -> RippleResponse {
+    let bootstrap = Bootstrap::new(state);
+    execute_step(SetupExtnClientStep, &bootstrap).await?;
+    execute_step(LoadExtensionMetadataStep, &bootstrap).await?;
+    execute_step(LoadExtensionsStep, &bootstrap).await?;
+    execute_step(StartExtnChannelsStep, &bootstrap).await?;
+    execute_step(StartAppManagerStep, &bootstrap).await?;
+    execute_step(LoadDistributorValuesStep, &bootstrap).await?;
+    execute_step(StartCloudSyncStep, &bootstrap).await?;
+    execute_step(CheckLauncherStep, &bootstrap).await?;
+    execute_step(StartWsStep, &bootstrap).await?;
+    execute_step(FireboltGatewayStep, &bootstrap).await?;
+    Ok(())
+}
+
+async fn execute_step<T: Bootstep<BootstrapState>>(
+    step: T,
+    state: &Bootstrap<BootstrapState>,
+) -> RippleResponse {
+    let name = step.get_name();
+    if let Err(e) = state.step(step).await {
+        error!("Failed at Bootstrap step {}", name);
+        Err(e)
+    } else {
+        Ok(())
+    }
 }

--- a/core/main/src/main.rs
+++ b/core/main/src/main.rs
@@ -16,7 +16,11 @@
 //
 
 use crate::bootstrap::boot::boot;
-use ripple_sdk::{tokio, utils::logger::init_logger};
+use ripple_sdk::{
+    log::{error, info},
+    tokio,
+    utils::logger::init_logger,
+};
 use state::bootstrap_state::BootstrapState;
 pub mod bootstrap;
 pub mod firebolt;
@@ -24,6 +28,7 @@ pub mod processor;
 pub mod service;
 pub mod state;
 pub mod utils;
+include!(concat!(env!("OUT_DIR"), "/version.rs"));
 
 #[tokio::main]
 async fn main() {
@@ -32,15 +37,17 @@ async fn main() {
         println!("{:?} logger init error", e);
         return;
     }
+    info!("version {} {}", SEMVER, SHA_SHORT);
     let bootstate = BootstrapState::build().expect("Failure to init state for bootstrap");
+
     // bootstrap
     match boot(bootstate).await {
         Ok(_) => {
-            println!("Done!");
+            info!("Ripple Exited gracefully!");
             std::process::exit(exitcode::OK);
         }
         Err(e) => {
-            eprintln!("Error: {:?}", e);
+            error!("Ripple failed with Error: {:?}", e);
             std::process::exit(exitcode::SOFTWARE);
         }
     }

--- a/core/main/src/main.rs
+++ b/core/main/src/main.rs
@@ -34,5 +34,14 @@ async fn main() {
     }
     let bootstate = BootstrapState::build().expect("Failure to init state for bootstrap");
     // bootstrap
-    boot(bootstate).await
+    match boot(bootstate).await {
+        Ok(_) => {
+            println!("Done!");
+            std::process::exit(exitcode::OK);
+        }
+        Err(e) => {
+            eprintln!("Error: {:?}", e);
+            std::process::exit(exitcode::SOFTWARE);
+        }
+    }
 }

--- a/core/main/src/service/telemetry_builder.rs
+++ b/core/main/src/service/telemetry_builder.rs
@@ -164,7 +164,7 @@ impl TelemetryBuilder {
         let ctx = req.ctx;
         let method = req.method;
         let params = if let Ok(mut p) = serde_json::from_str::<Vec<Value>>(&req.params_json) {
-            if p.len() > 0 {
+            if p.len() > 1 {
                 // remove call context
                 let _ = p.remove(0);
                 Some(serde_json::to_string(&p).unwrap())


### PR DESCRIPTION
## What?
Need better exit procedure during bootstrap failures


## Why?
Some devices have issues during bootstrap typically while connecting to underlying device API like Thunder. Current implementation in Ripple panics as a bootstrap error.
Better handling of Exit codes is required

## How?
1. Remove `expect` statements in bootstrap and replace with proper error handling procedures.
2. Add ExitCodes crate and provide a proper exit code during error scenarios.