### PR TITLE
fix: Scratch build errors for features

### DIFF
--- a/core/main/Cargo.toml
+++ b/core/main/Cargo.toml
@@ -29,6 +29,7 @@ name = "ripple"
 path = "src/main.rs"
 
 [features]
+default=[]
 local_dev=[]
 sysd=["sd-notify"]
 

--- a/device/thunder_ripple_sdk/Cargo.toml
+++ b/device/thunder_ripple_sdk/Cargo.toml
@@ -24,6 +24,7 @@ repository = "https://github.com/rdkcentral/Ripple"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+default = []
 contract_tests = ["pact_consumer", "reqwest", "expectest", "pact-plugin-driver", "pact_models", "maplit", "test-log"]
 
 [dependencies]


### PR DESCRIPTION
## What
Builds with Yocto are failing due to Pact dependencies added as part of Contract tests.

## Why
Yocto uses a meta rust which requires all the crates listed in the bb file prior to baking the firmware. Contract tests are not required for the actual firmware but are necessary during CI/CD and testing phase. So it was separated into a feature flag.


## How
A default feature was missing on these packages causing contract entries to be pulled as well.