### PR TITLE
Fixed Extn_Sender arg issue in contract test

### DIFF
--- a/device/thunder_ripple_sdk/src/tests/contracts/contract_utils.rs
+++ b/device/thunder_ripple_sdk/src/tests/contracts/contract_utils.rs
@@ -131,6 +131,7 @@ pub async fn get_pact_mock_server(async_build: PactBuilderAsync) -> Box<dyn Vali
 
 pub fn get_extn_client(s: Sender<CExtnMessage>, r: Receiver<CExtnMessage>) -> ExtnClient {
     // Creating extn client which will send back the data to the receiver(instead of callback)
+    let option_map: Option<HashMap<String, String>> = Some(HashMap::new());
     let extn_client = ExtnClient::new(
         r.clone(),
         ExtnSender::new(
@@ -138,6 +139,7 @@ pub fn get_extn_client(s: Sender<CExtnMessage>, r: Receiver<CExtnMessage>) -> Ex
             ExtnId::new_channel(ExtnClassId::Device, "pact".into()),
             Vec::new(),
             Vec::new(),
+            option_map,
         ),
     );
 


### PR DESCRIPTION
## Why
Recently ExtnSender has been modified to have one more param config and contract test util would need the modification to accommodate that change for request creation. 