### PR TITLE
178 launcher extension needs to pass on session

### DIFF
--- a/core/launcher/Cargo.toml
+++ b/core/launcher/Cargo.toml
@@ -30,3 +30,4 @@ ripple_sdk = { path = "../../core/sdk" }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 url = "2.2.2"
+urlencoding = "2.1.0"

--- a/core/launcher/src/launcher_state.rs
+++ b/core/launcher/src/launcher_state.rs
@@ -48,7 +48,7 @@ pub struct LauncherState {
     pub view_state: ViewState,
     pub container_state: ContainerState,
     pub app_launcher_state: AppLauncherState,
-    extn_client: ExtnClient,
+    pub extn_client: ExtnClient,
 }
 
 impl LauncherState {

--- a/core/launcher/src/manager/app_launcher.rs
+++ b/core/launcher/src/manager/app_launcher.rs
@@ -528,7 +528,7 @@ impl AppLauncher {
                 .any(|(key, _)| key == "__firebolt_endpoint")
             {
                 let firebolt_endpoint = String::from("127.0.0.1");
-                let appid = manifest.name.to_string();
+                let appid = manifest.name;
                 let value: String = format!(
                     "ws://{}:3473?appId={}&session={}",
                     firebolt_endpoint, appid, sessionid
@@ -539,7 +539,7 @@ impl AppLauncher {
             modified_url.set_query(Some(
                 &query_params
                     .iter()
-                    .map(|(key, value)| format!("{}={}", key, encode(value).to_string()))
+                    .map(|(key, value)| format!("{}={}", key, encode(value)))
                     .collect::<Vec<String>>()
                     .join("&"),
             ));
@@ -594,18 +594,12 @@ impl AppLauncher {
         if resp.is_err() {
             return Err(AppError::NotSupported);
         }
-
         match resp {
             Ok(response) => match response.payload.extract::<AppResponse>() {
-                Some(Ok(AppManagerResponse::Session(res))) => match res {
-                    SessionResponse::Pending(val) => {
-                        sessionid = val.session_id.unwrap();
-                        debug!("session id : {:?} ", sessionid);
-                    }
-                    _ => {
-                        return Err(AppError::NotFound);
-                    }
-                },
+                Some(Ok(AppManagerResponse::Session(SessionResponse::Pending(val)))) => {
+                    sessionid = val.session_id.unwrap();
+                    debug!("session id : {:?} ", sessionid);
+                }
                 _ => {
                     return Err(AppError::NotFound);
                 }
@@ -939,7 +933,7 @@ mod tests {
         let mut app_lib = AppManifest::default();
         app_lib.start_page = String::from("http://example.com/?param1=value1&__firebolt_endpoint=ws%3A%2F%2F192.168.1.9%3A3474%3FappId%3Drefui");
         let session_id = "my_session_id";
-        let modified_url = AppLauncher::get_modified_url(app_lib, session_id.clone());
+        let modified_url = AppLauncher::get_modified_url(app_lib, session_id);
         assert_eq!(modified_url, "http://example.com/?param1=value1&__firebolt_endpoint=ws%3A%2F%2F192.168.1.9%3A3474%3FappId%3Drefui");
     }
 

--- a/core/launcher/src/manager/app_launcher.rs
+++ b/core/launcher/src/manager/app_launcher.rs
@@ -902,3 +902,53 @@ impl AppLauncher {
         Err(AppError::General)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_modified_url_without_firebolt_endpoint_and_query() {
+        let mut app_lib = AppManifest::default();
+        app_lib.start_page = String::from("http://example.com");
+        let session_id = "my_session_id";
+        let modified_url = AppLauncher::get_modified_url(app_lib, session_id);
+        assert_eq!(modified_url, "http://example.com/?__firebolt_endpoint=ws%3A%2F%2F127.0.0.0%3A3473%26appId%3Dtest%3Fsession%3Dmy_session_id");
+    }
+
+    #[test]
+    fn test_get_modified_url_without_firebolt_endpoint() {
+        let mut app_lib = AppManifest::default();
+        app_lib.start_page = String::from("http://example.com/?param1=value1");
+        let session_id = "my_session_id";
+        let modified_url = AppLauncher::get_modified_url(app_lib, session_id);
+        assert_eq!(modified_url, "http://example.com/?param1=value1&__firebolt_endpoint=ws%3A%2F%2F127.0.0.0%3A3473%26appId%3Dtest%3Fsession%3Dmy_session_id");
+    }
+
+    #[test]
+    fn test_get_modified_url_without_firebolt_endpoint_with_fragment() {
+        let mut app_lib = AppManifest::default();
+        app_lib.start_page = String::from("http://example.com/?param1=value1#menu");
+        let session_id = "my_session_id";
+        let modified_url = AppLauncher::get_modified_url(app_lib, session_id);
+        assert_eq!(modified_url, "http://example.com/?param1=value1&__firebolt_endpoint=ws%3A%2F%2F127.0.0.0%3A3473%26appId%3Dtest%3Fsession%3Dmy_session_id#menu");
+    }
+
+    #[test]
+    fn test_get_modified_url_with_firebolt_endpoint() {
+        let mut app_lib = AppManifest::default();
+        app_lib.start_page = String::from("http://example.com/?param1=value1&__firebolt_endpoint=ws%253A%252F%252F127.0.0.0%253A3473%253FappId%253Dmy_app_id");
+        let session_id = "my_session_id";
+        let modified_url = AppLauncher::get_modified_url(app_lib, session_id);
+        assert_eq!(modified_url, modified_url);
+    }
+
+    #[test]
+    fn test_get_modified_url_invalid_url() {
+        let mut app_lib = AppManifest::default();
+        app_lib.start_page = String::from("test_url_example.com");
+        let session_id = "my_session_id";
+        let modified_url = AppLauncher::get_modified_url(app_lib, session_id);
+        assert_eq!(modified_url, "Invalid URL");
+    }
+}

--- a/core/launcher/src/manager/app_launcher.rs
+++ b/core/launcher/src/manager/app_launcher.rs
@@ -527,10 +527,10 @@ impl AppLauncher {
                 .iter()
                 .any(|(key, _)| key == "__firebolt_endpoint")
             {
-                let firebolt_endpoint = String::from("127.0.0.0");
+                let firebolt_endpoint = String::from("127.0.0.1");
                 let appid = manifest.name.to_string();
                 let value: String = format!(
-                    "ws://{}:3473&appId={}?session={}",
+                    "ws://{}:3473?appId={}&session={}",
                     firebolt_endpoint, appid, sessionid
                 );
                 query_params.push(("__firebolt_endpoint".to_string(), value));
@@ -913,7 +913,7 @@ mod tests {
         app_lib.start_page = String::from("http://example.com");
         let session_id = "my_session_id";
         let modified_url = AppLauncher::get_modified_url(app_lib, session_id);
-        assert_eq!(modified_url, "http://example.com/?__firebolt_endpoint=ws%3A%2F%2F127.0.0.0%3A3473%26appId%3Dtest%3Fsession%3Dmy_session_id");
+        assert_eq!(modified_url, "http://example.com/?__firebolt_endpoint=ws%3A%2F%2F127.0.0.1%3A3473%3FappId%3Dtest%26session%3Dmy_session_id");
     }
 
     #[test]
@@ -922,7 +922,7 @@ mod tests {
         app_lib.start_page = String::from("http://example.com/?param1=value1");
         let session_id = "my_session_id";
         let modified_url = AppLauncher::get_modified_url(app_lib, session_id);
-        assert_eq!(modified_url, "http://example.com/?param1=value1&__firebolt_endpoint=ws%3A%2F%2F127.0.0.0%3A3473%26appId%3Dtest%3Fsession%3Dmy_session_id");
+        assert_eq!(modified_url, "http://example.com/?param1=value1&__firebolt_endpoint=ws%3A%2F%2F127.0.0.1%3A3473%3FappId%3Dtest%26session%3Dmy_session_id");
     }
 
     #[test]
@@ -931,16 +931,16 @@ mod tests {
         app_lib.start_page = String::from("http://example.com/?param1=value1#menu");
         let session_id = "my_session_id";
         let modified_url = AppLauncher::get_modified_url(app_lib, session_id);
-        assert_eq!(modified_url, "http://example.com/?param1=value1&__firebolt_endpoint=ws%3A%2F%2F127.0.0.0%3A3473%26appId%3Dtest%3Fsession%3Dmy_session_id#menu");
+        assert_eq!(modified_url, "http://example.com/?param1=value1&__firebolt_endpoint=ws%3A%2F%2F127.0.0.1%3A3473%3FappId%3Dtest%26session%3Dmy_session_id#menu");
     }
 
     #[test]
     fn test_get_modified_url_with_firebolt_endpoint() {
         let mut app_lib = AppManifest::default();
-        app_lib.start_page = String::from("http://example.com/?param1=value1&__firebolt_endpoint=ws%253A%252F%252F127.0.0.0%253A3473%253FappId%253Dmy_app_id");
+        app_lib.start_page = String::from("http://example.com/?param1=value1&__firebolt_endpoint=ws%3A%2F%2F192.168.1.9%3A3474%3FappId%3Drefui");
         let session_id = "my_session_id";
-        let modified_url = AppLauncher::get_modified_url(app_lib, session_id);
-        assert_eq!(modified_url, modified_url);
+        let modified_url = AppLauncher::get_modified_url(app_lib, session_id.clone());
+        assert_eq!(modified_url, "http://example.com/?param1=value1&__firebolt_endpoint=ws%3A%2F%2F192.168.1.9%3A3474%3FappId%3Drefui");
     }
 
     #[test]

--- a/core/launcher/src/manager/app_launcher.rs
+++ b/core/launcher/src/manager/app_launcher.rs
@@ -903,8 +903,10 @@ mod tests {
 
     #[test]
     fn test_get_modified_url_without_firebolt_endpoint_and_query() {
-        let mut app_lib = AppManifest::default();
-        app_lib.start_page = String::from("http://example.com");
+        let app_lib = AppManifest {
+            start_page: String::from("http://example.com"),
+            ..Default::default()
+        };
         let session_id = "my_session_id";
         let modified_url = AppLauncher::get_modified_url(app_lib, session_id);
         assert_eq!(modified_url, "http://example.com/?__firebolt_endpoint=ws%3A%2F%2F127.0.0.1%3A3473%3FappId%3Dtest%26session%3Dmy_session_id");
@@ -912,8 +914,10 @@ mod tests {
 
     #[test]
     fn test_get_modified_url_without_firebolt_endpoint() {
-        let mut app_lib = AppManifest::default();
-        app_lib.start_page = String::from("http://example.com/?param1=value1");
+        let app_lib = AppManifest {
+            start_page: String::from("http://example.com/?param1=value1"),
+            ..Default::default()
+        };
         let session_id = "my_session_id";
         let modified_url = AppLauncher::get_modified_url(app_lib, session_id);
         assert_eq!(modified_url, "http://example.com/?param1=value1&__firebolt_endpoint=ws%3A%2F%2F127.0.0.1%3A3473%3FappId%3Dtest%26session%3Dmy_session_id");
@@ -921,8 +925,10 @@ mod tests {
 
     #[test]
     fn test_get_modified_url_without_firebolt_endpoint_with_fragment() {
-        let mut app_lib = AppManifest::default();
-        app_lib.start_page = String::from("http://example.com/?param1=value1#menu");
+        let app_lib = AppManifest {
+            start_page: String::from("http://example.com/?param1=value1#menu"),
+            ..Default::default()
+        };
         let session_id = "my_session_id";
         let modified_url = AppLauncher::get_modified_url(app_lib, session_id);
         assert_eq!(modified_url, "http://example.com/?param1=value1&__firebolt_endpoint=ws%3A%2F%2F127.0.0.1%3A3473%3FappId%3Dtest%26session%3Dmy_session_id#menu");
@@ -930,8 +936,7 @@ mod tests {
 
     #[test]
     fn test_get_modified_url_with_firebolt_endpoint() {
-        let mut app_lib = AppManifest::default();
-        app_lib.start_page = String::from("http://example.com/?param1=value1&__firebolt_endpoint=ws%3A%2F%2F192.168.1.9%3A3474%3FappId%3Drefui");
+        let app_lib = AppManifest { start_page: String::from("http://example.com/?param1=value1&__firebolt_endpoint=ws%3A%2F%2F192.168.1.9%3A3474%3FappId%3Drefui"), ..Default::default() };
         let session_id = "my_session_id";
         let modified_url = AppLauncher::get_modified_url(app_lib, session_id);
         assert_eq!(modified_url, "http://example.com/?param1=value1&__firebolt_endpoint=ws%3A%2F%2F192.168.1.9%3A3474%3FappId%3Drefui");
@@ -939,8 +944,10 @@ mod tests {
 
     #[test]
     fn test_get_modified_url_invalid_url() {
-        let mut app_lib = AppManifest::default();
-        app_lib.start_page = String::from("test_url_example.com");
+        let app_lib = AppManifest {
+            start_page: String::from("test_url_example.com"),
+            ..Default::default()
+        };
         let session_id = "my_session_id";
         let modified_url = AppLauncher::get_modified_url(app_lib, session_id);
         assert_eq!(modified_url, "Invalid URL");

--- a/core/sdk/src/api/manifest/apps.rs
+++ b/core/sdk/src/api/manifest/apps.rs
@@ -84,6 +84,32 @@ impl AppManifest {
     }
 }
 
+impl Default for AppManifest {
+    fn default() -> Self {
+        let capability = Capability {
+            required: [].to_vec(),
+            optional: [].to_vec(),
+        };
+        AppManifest {
+            app_key: String::from("xrn:firebolt:application:test"),
+            name: String::from("test"),
+            start_page: String::from("https://firecertapp.firecert.comcast.com/prod/index.html"),
+            content_catalog: None,
+            runtime: String::from("Web"),
+            x: x_default(),
+            y: y_default(),
+            w: w_default(),
+            h: h_default(),
+            capabilities: AppCapabilities {
+                used: capability.clone(),
+                managed: capability.clone(),
+                provided: capability.clone(),
+            },
+            properties: None,
+        }
+    }
+}
+
 fn x_default() -> u32 {
     X_DEFAULT
 }

--- a/core/sdk/src/api/manifest/apps.rs
+++ b/core/sdk/src/api/manifest/apps.rs
@@ -86,10 +86,6 @@ impl AppManifest {
 
 impl Default for AppManifest {
     fn default() -> Self {
-        let capability = Capability {
-            required: [].to_vec(),
-            optional: [].to_vec(),
-        };
         AppManifest {
             app_key: String::from("xrn:firebolt:application:test"),
             name: String::from("test"),
@@ -101,9 +97,18 @@ impl Default for AppManifest {
             w: w_default(),
             h: h_default(),
             capabilities: AppCapabilities {
-                used: capability.clone(),
-                managed: capability.clone(),
-                provided: capability.clone(),
+                used: Capability {
+                    required: [].to_vec(),
+                    optional: [].to_vec(),
+                },
+                managed: Capability {
+                    required: [].to_vec(),
+                    optional: [].to_vec(),
+                },
+                provided: Capability {
+                    required: [].to_vec(),
+                    optional: [].to_vec(),
+                },
             },
             properties: None,
         }


### PR DESCRIPTION
What
Currently, Launcher Extension doesn't use the sessionId received back from Main and pass on to the app being launched.

Why
These changes were not implemented in lieu with just being used as a Certification platform. With Accelerator UI effort Ripple will be using Launcher for more than just certification so we need to launch apps with session id to the secure port.