### PR TITLE
Updated pact_consumer version to 1.0.0

### DIFF
--- a/device/thunder_ripple_sdk/Cargo.toml
+++ b/device/thunder_ripple_sdk/Cargo.toml
@@ -29,8 +29,6 @@ contract_tests = [
     "pact_consumer",
     "reqwest",
     "expectest",
-    "pact-plugin-driver",
-    "pact_models",
     "maplit",
     "test-log",
 ]
@@ -42,11 +40,9 @@ serde = { version = "1.0", features = ["derive"] }
 url = "2.2.2"
 strum = "0.24"
 strum_macros = "0.24"
-pact_consumer = { version = "=0.10.4", optional = true }
+pact_consumer = { version = "1.0.0", optional = true }
 reqwest = { version = "0.11", optional = true }
 expectest = { version = "0.12.0", optional = true }
-pact-plugin-driver = { version = "0.4.1", optional = true }
-pact_models = { version = "1.0.9", optional = true }
 maplit = { version = "1.0.2", optional = true }
 test-log = { version = "0.2.11", optional = true }
 csv = "=1.1.5"


### PR DESCRIPTION
## What
Multiple redundant dependencies affecting the build

## Why
Pact consumer and other dependencies were creating transitive dependencies with multiple Pact crates 

## How
Removing dependencies which are not used 
