### PR TITLE
chore: add pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## What
+
+What does this PR add or remove?
+
+## Why
+
+Why are these changes needed?
+
+## How
+
+How do these changes achieve the goal?
+
+## Test
+
+How has this been tested? How can a reviewer test it?
+
+## Checklist
+
+- [ ] I have self-reviewed this PR
+- [ ] I have added tests that prove the feature works or the fix is effective


### PR DESCRIPTION
## What

New open PRs all follow the same template.

## Why

So that all submitted PRs follow the same format and make it easier for reviewers to understand.

## How

By creating a PR template file in the .github folder