### PR TITLE
fix: fixing compilation error on rust 1.69.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ Cargo.lock
 /.vscode/
 
 /device/thunder_ripple_sdk/target/
+.DS_Store

--- a/core/main/src/service/apps/delegated_launcher_handler.rs
+++ b/core/main/src/service/apps/delegated_launcher_handler.rs
@@ -592,9 +592,13 @@ impl DelegatedLauncherHandler {
                         }
                     };
                     debug!("exact policy {:?}", policy);
-                    policy.is_some_and(|policy| {
-                        policy.evaluate_at.contains(&EvaluateAt::ActiveSession)
-                    })
+                    if policy.is_none() {
+                        return false;
+                    }
+                    policy
+                        .unwrap()
+                        .evaluate_at
+                        .contains(&EvaluateAt::ActiveSession)
                 } else {
                     false
                 }

--- a/core/sdk/src/utils/time_utils.rs
+++ b/core/sdk/src/utils/time_utils.rs
@@ -15,7 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
+use chrono::{DateTime, LocalResult, NaiveDateTime, TimeZone, Utc};
 use std::{
     sync::{Arc, Mutex},
     thread,
@@ -32,8 +32,8 @@ for ISO8601 format, e.g: 2022-06-23T16:16:10Z
 */
 
 pub fn timestamp_2_iso8601(timestamp: i64) -> String {
-    if let Some(t) = NaiveDateTime::from_timestamp_opt(timestamp, 0) {
-        DateTime::<Utc>::from_utc(t, Utc).to_rfc3339()
+    if let LocalResult::Single(t) = chrono::Local.timestamp_opt(timestamp, 0) {
+        t.to_rfc3339()
     } else {
         timestamp.to_string()
     }

--- a/core/sdk/src/utils/time_utils.rs
+++ b/core/sdk/src/utils/time_utils.rs
@@ -15,7 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use chrono::{DateTime, LocalResult, NaiveDateTime, TimeZone, Utc};
+use chrono::{LocalResult, TimeZone, Utc};
 use std::{
     sync::{Arc, Mutex},
     thread,


### PR DESCRIPTION
## What

This PR fixes an error when compiled on Rust 1.69.0
## Why

It is not compatible with Rustc 1.69.0
## How

By replacing is_some_and function with is_none and unwrap separately.
## Test

The build should be completed without any error.
## Checklist

- [x] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
