### PR TITLE
Fix securestorage get return as blank

### DIFF
--- a/core/main/src/firebolt/handlers/secure_storage_rpc.rs
+++ b/core/main/src/firebolt/handlers/secure_storage_rpc.rs
@@ -120,9 +120,7 @@ impl SecureStorageServer for SecureStorageImpl {
             .await
         {
             Ok(response) => match response.payload.extract().unwrap() {
-                SecureStorageResponse::Get(value) => {
-                    Ok(value.value)
-                }
+                SecureStorageResponse::Get(value) => Ok(value.value),
                 _ => Err(jsonrpsee::core::Error::Custom(String::from(
                     "Secure Storage Response error response TBD",
                 ))),

--- a/core/main/src/firebolt/handlers/secure_storage_rpc.rs
+++ b/core/main/src/firebolt/handlers/secure_storage_rpc.rs
@@ -35,7 +35,7 @@ use crate::{firebolt::rpc::RippleRPCProvider, state::platform_state::PlatformSta
 #[rpc(server)]
 pub trait SecureStorage {
     #[method(name = "securestorage.get")]
-    async fn get_rpc(&self, ctx: CallContext, request: GetRequest) -> RpcResult<String>;
+    async fn get_rpc(&self, ctx: CallContext, request: GetRequest) -> RpcResult<Option<String>>;
     #[method(name = "securestorage.set")]
     async fn set_rpc(&self, ctx: CallContext, request: SetRequest) -> RpcResult<()>;
     #[method(name = "securestorage.remove")]
@@ -107,7 +107,7 @@ impl SecureStorageImpl {
 
 #[async_trait]
 impl SecureStorageServer for SecureStorageImpl {
-    async fn get_rpc(&self, ctx: CallContext, request: GetRequest) -> RpcResult<String> {
+    async fn get_rpc(&self, ctx: CallContext, request: GetRequest) -> RpcResult<Option<String>> {
         match self
             .state
             .get_client()
@@ -121,7 +121,7 @@ impl SecureStorageServer for SecureStorageImpl {
         {
             Ok(response) => match response.payload.extract().unwrap() {
                 SecureStorageResponse::Get(value) => {
-                    Ok(value.value.unwrap_or_else(|| String::from("")))
+                    Ok(value.value)
                 }
                 _ => Err(jsonrpsee::core::Error::Custom(String::from(
                     "Secure Storage Response error response TBD",


### PR DESCRIPTION
## What

SecureStorage.get is returning a result = " " if no value is present for a key.

## Why

Expected -
There result in the response should be "null"

## How

Update securestorage.get() return param to be an optional string which is same as the upstream function return param so that we just return whatever is returned from upstream function.

## Test

Steps to reproduce :
1. Set a value for key foo as "test" using the SecureStorage.setForApp api
2. Do a get and check the result is the value we set(test)
3. Clear the value for key foo using SecureStorage.removeForApp api
4. Do a get with key=foo 

## Checklist

- [X ] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
