### PR TITLE
RPPL-975: Add custom fmt::Debug() and fmt::Display() functions for DistributorSession and mask token field

### DIFF
--- a/core/sdk/src/api/session.rs
+++ b/core/sdk/src/api/session.rs
@@ -79,14 +79,33 @@ impl ExtnPayloadProvider for AccountSessionRequest {
 }
 
 #[repr(C)]
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct AccountSession {
     pub id: String,
     pub token: String,
     pub account_id: String,
     pub device_id: String,
 }
-
+impl std::fmt::Debug for AccountSession {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // mask token field
+        f.debug_struct("AccountSession")
+            .field("id", &self.id)
+            .field("account_id", &self.account_id)
+            .field("device_id", &self.device_id)
+            .finish()
+    }
+}
+impl std::fmt::Display for AccountSession {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // mask token field
+        write!(
+            f,
+            "AccountSession {{ id: {:?}, account_id: {:?}, device_id: {:?} }}",
+            self.id, self.account_id, self.device_id
+        )
+    }
+}
 impl ExtnPayloadProvider for AccountSession {
     fn get_from_payload(payload: ExtnPayload) -> Option<Self> {
         if let ExtnPayload::Response(ExtnResponse::AccountSession(v)) = payload {


### PR DESCRIPTION
## What

Add custom fmt::Debug() and fmt::Display() functions for DistributorSession and mask token field

## Why

We don't want to have token in log messages.

## How

Custom Debug and Display functions of DistributorSession / ActiveSession did not use token field

## Test

How has this been tested? How can a reviewer test it?

## Checklist

- [ ] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
