### PR TITLE
fix: Authentication always return Platform

### DIFF
--- a/core/main/src/state/platform_state.rs
+++ b/core/main/src/state/platform_state.rs
@@ -24,6 +24,7 @@ use ripple_sdk::{
             extn_manifest::ExtnManifest,
         },
         protocol::BridgeProtocolRequest,
+        session::SessionAdjective,
     },
     extn::{extn_client_message::ExtnMessage, extn_id::ExtnId},
     framework::{ripple_contract::RippleContract, RippleResponse},
@@ -172,6 +173,11 @@ impl PlatformState {
 
     pub fn supports_encoding(&self) -> bool {
         let contract = RippleContract::Encoder.as_clear_string();
+        self.extn_manifest.required_contracts.contains(&contract)
+    }
+
+    pub fn supports_distributor_session(&self) -> bool {
+        let contract = RippleContract::Session(SessionAdjective::Distributor).as_clear_string();
         self.extn_manifest.required_contracts.contains(&contract)
     }
 

--- a/device/thunder_ripple_sdk/src/tests/contracts/contract_utils.rs
+++ b/device/thunder_ripple_sdk/src/tests/contracts/contract_utils.rs
@@ -134,7 +134,7 @@ pub fn get_extn_client(s: Sender<CExtnMessage>, r: Receiver<CExtnMessage>) -> Ex
     let option_map: Option<HashMap<String, String>> = Some(HashMap::new());
 
     ExtnClient::new(
-        r.clone(),
+        r,
         ExtnSender::new(
             s,
             ExtnId::new_channel(ExtnClassId::Device, "pact".into()),


### PR DESCRIPTION
## What

What does this PR add or remove?
This PR fixes the problem caused by https://github.com/rdkcentral/Ripple/pull/231 where all auth calls return platform token type

## Why

Why are these changes needed?
To fix authentication firebolt APIs to return correct token types

## How

How do these changes achieve the goal?
By accommodating the token type in the request

## Test

How has this been tested? How can a reviewer test it?
Tested using device.
Reviewer can test it by cloning the change locally and executing Authentication.* [firebolt API ](https://developer.comcast.com/firebolt-apis/core-sdk/v0.14.0/authentication)calls

## Checklist

- [x] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
