### PR TITLE
feat: Add support for additional reserved appId.

### DIFF
--- a/core/sdk/src/api/manifest/device_manifest.rs
+++ b/core/sdk/src/api/manifest/device_manifest.rs
@@ -117,11 +117,15 @@ pub struct ApplicationDefaultsConfiguration {
 }
 
 impl ApplicationDefaultsConfiguration {
-    pub fn get_reserved_application_id(&self, field_name: &str) -> Option<&str> {
-        match field_name {
-            "xrn:firebolt:application-type:main" => Some(&self.main),
-            "xrn:firebolt:application-type:settings" => Some(&self.settings),
-            "xrn:firebolt:application-type:player" => self.player.as_deref().or(Some("")),
+    pub fn get_reserved_application_id(&self, reserved_app_type: &str) -> Option<&str> {
+        match reserved_app_type {
+            "xrn:firebolt:application-type:main" | "urn:firebolt:apps:main" => Some(&self.main),
+            "xrn:firebolt:application-type:settings" | "urn:firebolt:apps:settings" => {
+                Some(&self.settings)
+            }
+            "xrn:firebolt:application-type:player" | "urn:firebolt:apps:player" => {
+                self.player.as_deref().or(Some(""))
+            }
             _ => None,
         }
     }


### PR DESCRIPTION
## What

Supporting `urn:firebolt:apps:<string>` format for reserved app-type.

## Why

Firebolt example documentation shows old URN formats which are currently implemented by some firebolt users. We need to be back compatible to the old URN values to support those users.

## How

Added mapping in Ripple to support the legacy urn format.
eg: Both the legacy format `urn:firebolt:apps:main` and the new XRN format `xrn:firebolt:application-type:main` are now supported. 

## Test

Testing was done using the following Request.

```
{
    "jsonrpc": "2.0",
    "id": 10,
    "method": "discovery.launch",
    "params": {
        "appId": "urn:firebolt:apps:main",
        "intent": {
            "action": "section",
            "data": {
                "sectionName": "subscribe"
            },
            "context": {
                "source": "voice"
            }
        }
    }
}
```
The mapped app must register for discovery.onNavigateTo event

The following event will be emitted to the mapped app. 

```
{
    "id": 1,
    "jsonrpc": "2.0",
    "result": {
        "action": "section",
        "context": {
            "source": "xrn:firebolt:application:foo.test.cert"
        },
        "data": {
            "sectionName": "subscribe"
        }
    }
}
```
## Checklist

- [x ] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
