### PR TITLE
fix: Discovery.contentAccess API date-time format is forced to one particular format

### DIFF
--- a/core/sdk/src/utils/serde_utils.rs
+++ b/core/sdk/src/utils/serde_utils.rs
@@ -158,13 +158,13 @@ pub mod date_time_str_serde {
     use chrono::DateTime;
     use serde::{self, Deserialize, Deserializer, Serializer};
 
-    pub fn serialize<S>(data: &String, serializer: S) -> Result<S::Ok, S::Error>
+    pub fn serialize<S>(data: &str, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        let formed_date_res = DateTime::parse_from_rfc3339(&data);
+        let formed_date_res = DateTime::parse_from_rfc3339(data);
         if formed_date_res.is_ok() {
-            serializer.serialize_str(&data)
+            serializer.serialize_str(data)
         } else {
             Err(serde::ser::Error::custom(
                 "String not convertible to date-time",

--- a/core/sdk/src/utils/serde_utils.rs
+++ b/core/sdk/src/utils/serde_utils.rs
@@ -158,15 +158,13 @@ pub mod date_time_str_serde {
     use chrono::DateTime;
     use serde::{self, Deserialize, Deserializer, Serializer};
 
-    const FORMAT: &str = "%Y-%m-%dT%H:%M:%S.%3fZ";
-
-    pub fn serialize<S>(data: &str, serializer: S) -> Result<S::Ok, S::Error>
+    pub fn serialize<S>(data: &String, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        let formed_date_res = DateTime::parse_from_str(data, FORMAT);
+        let formed_date_res = DateTime::parse_from_rfc3339(&data);
         if formed_date_res.is_ok() {
-            serializer.serialize_str(data)
+            serializer.serialize_str(&data)
         } else {
             Err(serde::ser::Error::custom(
                 "String not convertible to date-time",
@@ -179,12 +177,12 @@ pub mod date_time_str_serde {
         D: Deserializer<'de>,
     {
         let str = String::deserialize(deserializer)?;
-        let formed_date_res = DateTime::parse_from_str(&str, FORMAT);
+        let formed_date_res = DateTime::parse_from_rfc3339(&str);
         if formed_date_res.is_ok() {
             Ok(str)
         } else {
             Err(serde::de::Error::custom(
-                "Field not in expected Date-Time (YYYY-MM-DDTHH:mm:SS.xxxZ) format",
+                "Field is not a valid OpenRPC date-time format string",
             ))
         }
     }


### PR DESCRIPTION
## What

Discovery.contentAccess API date-time format is forced to one particular format. 
Firebolt need to support all pattern of OpenRPC date-time format.

## Why

We need to support all pattern of OpenRPC date-time format.

## How

Used DateTime::parse_from_rfc3339() function for validating the time passed by the caller.

## Test

Use Discovery.watched() or Discovery.contentAccess() API to validate the time used in the API

## Checklist

- [x ] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
