### PR TITLE
build: fix rust version in CI

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt
-          toolchain: 1.69.0
       - name: Rust Format Checker
         uses: actions-rust-lang/rustfmt@v1
 
@@ -31,7 +30,6 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
-          toolchain: 1.69.0
       - run: cargo clippy --tests --examples --all-targets --all-features -- -D warnings
 
   test:
@@ -40,6 +38,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: 1.69.0
       - run: cargo test

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt
+          toolchain: 1.69.0
       - name: Rust Format Checker
         uses: actions-rust-lang/rustfmt@v1
 
@@ -30,6 +31,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
+          toolchain: 1.69.0
       - run: cargo clippy --tests --examples --all-targets --all-features -- -D warnings
 
   test:
@@ -38,4 +40,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: 1.69.0
       - run: cargo test

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.69.0"


### PR DESCRIPTION
## What

Sets the rust version in GitHub actions to 1.69.0

## Why

Currently the CI chain uses the latest rust version. This is causing confusion and problems when clippy warnings are different in CI to what they are on developer laptops. It also ensures that developers can set a version locally and not use APIs (e.g. `.is_some_and()`) which are not available in build chains using older rust versions.

## How

Add a rust-toolchain.toml file in the root of the project. This enforces the correct versions are used in CI and local development.

## Test

Tested by checking the CI passes and the logs show a specific version of rust was installed.

https://github.com/rdkcentral/Ripple/actions/runs/6454392693/job/17519832131?pr=269#step:3:164
https://github.com/rdkcentral/Ripple/actions/runs/6454392693/job/17519831892?pr=269#step:3:164
https://github.com/rdkcentral/Ripple/actions/runs/6454392693/job/17519831657?pr=269#step:3:161


## Checklist

- [X] I have self-reviewed this PR
- [ ] ~~I have added tests that prove the feature works or the fix is effective~~
