### PR TITLE
fix: Privacy Sync returning not implemented

### DIFF
--- a/core/main/src/firebolt/handlers/privacy_rpc.rs
+++ b/core/main/src/firebolt/handlers/privacy_rpc.rs
@@ -971,7 +971,9 @@ impl PrivacyServer for PrivacyImpl {
             .privacy_settings_storage_type;
 
         match privacy_settings_storage_type {
-            PrivacySettingsStorageType::Local => self.get_settings_local().await,
+            PrivacySettingsStorageType::Local | PrivacySettingsStorageType::Sync => {
+                self.get_settings_local().await
+            }
             PrivacySettingsStorageType::Cloud => {
                 let dist_session = self.state.session_state.get_account_session().unwrap();
                 let request = PrivacyCloudRequest::GetProperties(dist_session);
@@ -984,9 +986,6 @@ impl PrivacyServer for PrivacyImpl {
                     "PrivacySettingsStorageType::Cloud: Not Available",
                 )))
             }
-            PrivacySettingsStorageType::Sync => Err(jsonrpsee::core::Error::Custom(String::from(
-                "PrivacySettingsStorageType::Sync: Unimplemented",
-            ))),
         }
     }
 }


### PR DESCRIPTION
## What

What does this PR add or remove?
Adds support for PrivacySettingsStorageType:Sync to have same support as PrivacySettingsStorageType:Local 

## Why

Why are these changes needed?
We need these changes to make sure Ripple is implementing the privacy expectations for storage type of sync

## How

How do these changes achieve the goal?
Adds `Sync` arm to the existing `Local` arm

## Test

How has this been tested? How can a reviewer test it?
Use Privacy.settings Firebolt APi Call to get the settings

## Checklist

- [x] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
