### PR TITLE
fix: Launcher not sending events

### DIFF
--- a/core/launcher/src/manager/app_launcher.rs
+++ b/core/launcher/src/manager/app_launcher.rs
@@ -608,7 +608,7 @@ impl AppLauncher {
             }
         }
 
-        if !sessionid.is_empty() {
+        if !bool_contract && !sessionid.is_empty() {
             let modified_url = Self::get_modified_url(&manifest, &sessionid);
             debug!("modified url with sessionid : {:?}", modified_url);
             Ok(modified_url)
@@ -875,6 +875,7 @@ impl AppLauncher {
                     if ContainerManager::bring_to_front(
                         state,
                         existing.container_props.name.as_str(),
+                        None,
                     )
                     .await
                     .is_ok()


### PR DESCRIPTION
## What

When UI Provide operations like Keyboard, Pin Challenge and User grants were processed lifecycle events were not sent.

## Why

Firebolt specification mandates apps to be provided with lifecycle events if they are registered

## How

When provide operations are executed Lifecycle events are sent based on the implementation in Container Manager.

## Test

1. Use Refui as the System App
2. Trigger keyboard

## Checklist

- [x] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
