### PR TITLE
fix: adding  missing device_timezone_offset field

### DIFF
--- a/core/sdk/src/api/firebolt/fb_metrics.rs
+++ b/core/sdk/src/api/firebolt/fb_metrics.rs
@@ -332,6 +332,7 @@ pub struct MetricsContext {
     pub device_id: String,
     pub account_id: String,
     pub device_timezone: String,
+    pub device_timezone_offset: String,
     pub device_name: String,
     pub platform: String,
     pub os_ver: String,
@@ -348,6 +349,7 @@ pub enum MetricsContextField {
     device_id,
     account_id,
     device_timezone,
+    device_timezone_offset,
     device_name,
     platform,
     os_ver,
@@ -363,6 +365,7 @@ impl MetricsContext {
             device_model: String::from(""),
             device_id: String::from(""),
             device_timezone: String::from(""),
+            device_timezone_offset: String::from(""),
             device_name: String::from(""),
             mac_address: String::from(""),
             serial_number: String::from(""),
@@ -380,6 +383,9 @@ impl MetricsContext {
             MetricsContextField::device_id => self.device_id = value,
             MetricsContextField::account_id => self.account_id = value,
             MetricsContextField::device_timezone => self.device_timezone = value.parse().unwrap(),
+            MetricsContextField::device_timezone_offset => {
+                self.device_timezone_offset = value.parse().unwrap()
+            }
             MetricsContextField::platform => self.platform = value,
             MetricsContextField::os_ver => self.os_ver = value,
             MetricsContextField::distributor_id => self.distribution_tenant_id = value,


### PR DESCRIPTION
## What
Addition of missing adding  missing device_timezone_offset field to model

## Why

Model was out of sync with downstream 

## How

Field is added where appropriate

## Test

Manual test. Can be tested per usual manual testing procedure used by QA to test BI metrics

## Checklist

- [ x] I have self-reviewed this PR
- [ - I have added tests that prove the feature works or the fix is effective
