### PR TITLE
feat: implement Advertising.skipRestriction & Advertising.onSkipRestrictionChanged manage APIs

### DIFF
--- a/core/sdk/src/api/storage_property.rs
+++ b/core/sdk/src/api/storage_property.rs
@@ -118,6 +118,7 @@ pub const EVENT_DEVICE_NAME_CHANGED: &str = "device.onNameChanged";
 pub const EVENT_DEVICE_DEVICE_NAME_CHANGED: &str = "device.onDeviceNameChanged";
 pub const EVENT_SECOND_SCREEN_FRIENDLY_NAME_CHANGED: &str = "secondscreen.onFriendlyNameChanged";
 pub const EVENT_ADVERTISING_POLICY_CHANGED: &str = "advertising.onPolicyChanged";
+pub const EVENT_ADVERTISING_SKIP_RESTRICTION_CHANGED: &str = "advertising.onSkipRestrictionChanged";
 pub const EVENT_ADVERTISING_SKIP_RESTRICTION: &str = "advertising.setSkipRestriction";
 
 pub const EVENT_TIMEZONE_CHANGED: &str = "localization.onTimeZoneChanged";
@@ -383,7 +384,10 @@ const PROPERTY_DATA_PARTNER_EXCLUSIONS: PropertyData = PropertyData {
 const PROPERTY_DATA_SKIP_RESTRICTION: PropertyData = PropertyData {
     key: KEY_SKIP_RESTRICTION,
     namespace: NAMESPACE_ADVERTISING,
-    event_names: Some(&[EVENT_ADVERTISING_SKIP_RESTRICTION]),
+    event_names: Some(&[
+        EVENT_ADVERTISING_SKIP_RESTRICTION,
+        EVENT_ADVERTISING_SKIP_RESTRICTION_CHANGED,
+    ]),
 };
 
 #[derive(Debug)]


### PR DESCRIPTION
## What

Implement Advertising.skipRestriction & Advertising.onSkipRestrictionChanged manage APIs

## Why

Advertising.skipRestriction - To get the value of skipRestriction
Advertising.onSkipRestrictionChanged - To subscribe to notifications when the value of skipRestriction changes

## How

Implement these APIs in advertising rpc

## Test

Make a request for `Advertising.skipRestriction` to get skip restriction value.
Subscribe to skip restriction changed event, then set skip restriction to a different value. Verify subscriber get notified for new skip restriction value.

## Checklist

- [x] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
