### PR TITLE
fix: Thunder client (un)subscribe issue

### DIFF
--- a/device/thunder_ripple_sdk/src/client/thunder_client.rs
+++ b/device/thunder_ripple_sdk/src/client/thunder_client.rs
@@ -168,7 +168,6 @@ impl ThunderClient {
     /// Sends a message to thunder. If this client is pooled
     /// then it will wrap the message in a pool command before sending
     pub async fn send_message(&self, message: ThunderMessage) {
-        info!("Client {} sending thunder message {:?}", self.id, message);
         if let Some(s) = &self.pooled_sender {
             mpsc_send_and_log(
                 s,
@@ -450,6 +449,7 @@ impl ThunderClientBuilder {
                         return;
                     }
                 }
+                info!("Client {} sending thunder message {:?}", id, message);
                 match message {
                     ThunderMessage::ThunderCallMessage(thunder_message) => {
                         ThunderClient::call(&client, thunder_message, plugin_manager_tx.clone())


### PR DESCRIPTION
## What

The current implementation of the ThunderPool doesn't actually unsubscribe on the correct client where it had subscribed. 

## Why

The current implementation uses an `in_use` Ordering::relaxed algorithm to find the unused client to shared the load

## How

In a given pool 0th index(first) client would be preferred for all subscribe and unsubscribe operations

## Test

Launch Certification App with system ui
From FCA trigger `Lifecycle:Close` with a close reason for "Error". This will force remove the app
Trigger FCA again from System UI

Without the fix the relaunch wouldnt show System UI


## Checklist

- [x] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
