### PR TITLE
fix: capabilities info for app ignore

### DIFF
--- a/core/main/src/firebolt/handlers/advertising_rpc.rs
+++ b/core/main/src/firebolt/handlers/advertising_rpc.rs
@@ -28,7 +28,7 @@ use ripple_sdk::{
                 AdIdRequestParams, AdInitObjectRequestParams, AdvertisingFrameworkConfig,
                 AdvertisingRequest, AdvertisingResponse, GetAdConfig,
             },
-            fb_capabilities::{CapabilityRole, RoleInfo},
+            fb_capabilities::{CapabilityRole, FireboltCap, RoleInfo},
             fb_general::{ListenRequest, ListenerResponse},
         },
         gateway::rpc_gateway_api::CallContext,
@@ -272,7 +272,7 @@ impl AdvertisingServer for AdvertisingImpl {
             .get_device_manifest()
             .get_distributor_experience_id();
         let params = RoleInfo {
-            capability: "advertising:identifier".to_string(),
+            capability: FireboltCap::short("advertising:identifier".to_string()),
             role: Some(CapabilityRole::Use),
         };
         let ad_id_authorised = is_permitted(self.state.clone(), ctx, params).await;

--- a/core/main/src/firebolt/handlers/capabilities_rpc.rs
+++ b/core/main/src/firebolt/handlers/capabilities_rpc.rs
@@ -28,7 +28,7 @@ use ripple_sdk::api::{
     firebolt::{
         fb_capabilities::{
             CapEvent, CapInfoRpcRequest, CapListenRPCRequest, CapRPCRequest, CapRequestRpcRequest,
-            CapabilityInfo, FireboltCap, FireboltPermission, RoleInfo,
+            CapabilityInfo, FireboltPermission, RoleInfo,
         },
         fb_general::ListenerResponse,
     },
@@ -171,11 +171,12 @@ impl CapabilityServer for CapabilityImpl {
         ctx: CallContext,
         request: CapInfoRpcRequest,
     ) -> RpcResult<Vec<CapabilityInfo>> {
-        let cap_set = request
-            .capabilities
-            .iter()
-            .map(|cap| FireboltCap::Full(cap.to_owned()))
-            .collect();
+        if request.capabilities.is_empty() {
+            return Err(jsonrpsee::core::Error::Custom(String::from(
+                "Error invalid input capabilities are empty",
+            )));
+        }
+        let cap_set = request.capabilities;
         if let Ok(a) = CapState::get_cap_info(&self.state, ctx, &cap_set).await {
             Ok(a)
         } else {
@@ -242,7 +243,7 @@ impl CapabilityServer for CapabilityImpl {
         let request = grants
             .grants
             .iter()
-            .map(|role_info| FireboltCap::Full(role_info.capability.to_owned()))
+            .map(|role_info| role_info.capability.clone())
             .collect();
 
         if let Ok(a) = CapState::get_cap_info(&self.state, ctx, &request).await {

--- a/core/main/src/firebolt/handlers/privacy_rpc.rs
+++ b/core/main/src/firebolt/handlers/privacy_rpc.rs
@@ -27,6 +27,7 @@ use jsonrpsee::{
     RpcModule,
 };
 use ripple_sdk::api::distributor::distributor_privacy::PrivacySettingsStoreRequest;
+use ripple_sdk::api::firebolt::fb_capabilities::FireboltCap;
 use ripple_sdk::extn::extn_client_message::ExtnPayload;
 use ripple_sdk::{
     api::{
@@ -344,7 +345,7 @@ impl PrivacyImpl {
         _app_id: &str,
     ) -> bool {
         let cap = RoleInfo {
-            capability: "xrn:firebolt:capability:discovery:watched".to_string(),
+            capability: FireboltCap::Short("discovery:watched".to_string()),
             role: Some(CapabilityRole::Use),
         };
         if let Ok(watch_granted) = is_granted(state.clone(), ctx.clone(), cap).await {

--- a/core/main/src/processor/settings_processor.rs
+++ b/core/main/src/processor/settings_processor.rs
@@ -153,7 +153,7 @@ impl SettingsProcessor {
                 if let Some(v) = val {
                     let role_info = RoleInfo {
                         role: Some(CapabilityRole::Use),
-                        capability: FireboltCap::Short(sk.use_capability().into()).as_str(),
+                        capability: FireboltCap::Short(sk.use_capability().into()),
                     };
                     if let Ok(result) = is_permitted(state.clone(), ctx.clone(), role_info).await {
                         if result {

--- a/core/main/src/state/cap/cap_state.rs
+++ b/core/main/src/state/cap/cap_state.rs
@@ -215,26 +215,20 @@ impl CapState {
                 supported: ignored_app,
                 available: ignored_app,
                 _use: RolePermission {
-                    permitted: ignored_app,
+                    permitted: false,
                     granted: None,
                 },
                 manage: RolePermission {
-                    permitted: ignored_app,
+                    permitted: false,
                     granted: None,
                 },
                 provide: RolePermission {
-                    permitted: ignored_app,
+                    permitted: false,
                     granted: None,
                 },
                 details: None,
             };
-            if ignored_app {
-                capability_info._use.granted = Some(true);
-                capability_info.manage.granted = Some(true);
-                capability_info.provide.granted = Some(true);
-                capability_infos.push(capability_info);
-                continue;
-            }
+
             capability_info.supported = state
                 .cap_state
                 .generic
@@ -248,6 +242,17 @@ impl CapState {
                         .generic
                         .check_available(&vec![cap.clone().into()])
                         .is_ok();
+
+                if ignored_app {
+                    capability_info._use.permitted = true;
+                    capability_info.manage.permitted = true;
+                    capability_info.provide.permitted = true;
+                    capability_info._use.granted = Some(true);
+                    capability_info.manage.granted = Some(true);
+                    capability_info.provide.granted = Some(true);
+                    capability_infos.push(capability_info);
+                    continue;
+                }
             }
             (
                 capability_info._use.permitted,

--- a/core/main/src/state/cap/cap_state.rs
+++ b/core/main/src/state/cap/cap_state.rs
@@ -355,7 +355,7 @@ mod tests {
         if let Ok(v) = CapState::get_cap_info(
             &runtime.platform_state,
             MockCallContext::get_from_app_id("some_app"),
-            &vec![FireboltCap::Short("some:many".to_owned())],
+            &vec![FireboltCap::Short("device:info".to_owned())],
         )
         .await
         {

--- a/core/main/src/state/cap/permitted_state.rs
+++ b/core/main/src/state/cap/permitted_state.rs
@@ -81,7 +81,7 @@ impl PermittedState {
             .unwrap_or(ripple_sdk::api::firebolt::fb_capabilities::CapabilityRole::Use);
         if let Some(perms) = self.get_all_permissions().get(app_id) {
             for perm in perms {
-                if perm.cap.as_str() == role_info.capability && perm.role == role {
+                if perm.cap.as_str() == role_info.capability.as_str() && perm.role == role {
                     return Ok(true);
                 }
             }
@@ -96,7 +96,7 @@ impl PermittedState {
         let mut map = HashMap::new();
         for role_info in request {
             map.insert(
-                role_info.clone().capability,
+                role_info.clone().capability.as_str(),
                 if let Ok(v) = self.check_cap_role(app_id, role_info) {
                     v
                 } else {

--- a/core/main/src/state/cap/permitted_state.rs
+++ b/core/main/src/state/cap/permitted_state.rs
@@ -76,20 +76,20 @@ impl PermittedState {
     }
 
     pub fn check_cap_role(&self, app_id: &str, role_info: RoleInfo) -> Result<bool, RippleError> {
-        if let Some(role) = role_info.role {
-            if let Some(perms) = self.get_all_permissions().get(app_id) {
-                for perm in perms {
-                    if perm.cap.as_str() == role_info.capability && perm.role == role {
-                        return Ok(true);
-                    }
+        let role = role_info
+            .role
+            .unwrap_or(ripple_sdk::api::firebolt::fb_capabilities::CapabilityRole::Use);
+        if let Some(perms) = self.get_all_permissions().get(app_id) {
+            for perm in perms {
+                if perm.cap.as_str() == role_info.capability && perm.role == role {
+                    return Ok(true);
                 }
-                return Ok(false);
-            } else {
-                // Not cached prior
-                return Err(RippleError::InvalidAccess);
             }
+            Ok(false)
+        } else {
+            // Not cached prior
+            Err(RippleError::InvalidAccess)
         }
-        Ok(false)
     }
 
     pub fn check_multiple(&self, app_id: &str, request: Vec<RoleInfo>) -> HashMap<String, bool> {

--- a/core/main/src/utils/test_utils.rs
+++ b/core/main/src/utils/test_utils.rs
@@ -85,3 +85,20 @@ pub async fn cap_state_listener(
 
     resp_rx
 }
+
+pub struct MockCallContext;
+
+impl MockCallContext {
+    pub fn get_from_app_id(app_id: &str) -> CallContext {
+        CallContext {
+            session_id: "session_id".to_owned(),
+            request_id: "request_id".to_owned(),
+            app_id: app_id.to_owned(),
+            call_id: 0,
+            protocol: ripple_sdk::api::gateway::rpc_gateway_api::ApiProtocol::JsonRpc,
+            method: "some_method".to_owned(),
+            cid: Some("cid".to_owned()),
+            gateway_secure: false,
+        }
+    }
+}

--- a/core/sdk/src/api/firebolt/fb_capabilities.rs
+++ b/core/sdk/src/api/firebolt/fb_capabilities.rs
@@ -154,7 +154,7 @@ pub struct FireboltPermission {
 impl From<RoleInfo> for FireboltPermission {
     fn from(role_info: RoleInfo) -> Self {
         FireboltPermission {
-            cap: FireboltCap::Full(role_info.capability.to_owned()),
+            cap: role_info.capability.to_owned(),
             role: role_info.role.unwrap_or(CapabilityRole::Use),
         }
     }
@@ -175,7 +175,7 @@ impl From<CapRequestRpcRequest> for Vec<FireboltPermission> {
             .grants
             .iter()
             .map(|role_info| FireboltPermission {
-                cap: FireboltCap::Full(role_info.capability.to_owned()),
+                cap: role_info.capability.to_owned(),
                 role: role_info.role.unwrap_or(CapabilityRole::Use),
             })
             .collect()
@@ -400,12 +400,12 @@ pub struct CapRequestRpcRequest {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct RoleInfo {
     pub role: Option<CapabilityRole>,
-    pub capability: String,
+    pub capability: FireboltCap,
 }
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct CapInfoRpcRequest {
-    pub capabilities: Vec<String>,
+    pub capabilities: Vec<FireboltCap>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -431,7 +431,7 @@ impl From<CapRPCRequest> for RoleInfo {
     fn from(value: CapRPCRequest) -> Self {
         RoleInfo {
             role: Some(value.options.unwrap_or_default().role),
-            capability: value.capability.as_str(),
+            capability: value.capability,
         }
     }
 }

--- a/core/sdk/src/api/firebolt/fb_capabilities.rs
+++ b/core/sdk/src/api/firebolt/fb_capabilities.rs
@@ -19,9 +19,9 @@ use std::hash::{Hash, Hasher};
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::api::gateway::rpc_error::RpcError;
-
 use super::fb_openrpc::CapabilitySet;
+use crate::api::gateway::rpc_error::RpcError;
+use regex::Regex;
 
 /// There are many types of Firebolt Cap enums
 /// 1. Short: `device:model` becomes = `xrn:firebolt:capability:account:session` its just a handy cap which helps us write less code
@@ -38,6 +38,32 @@ impl FireboltCap {
         S: Into<String>,
     {
         FireboltCap::Short(s.into())
+    }
+}
+
+impl Serialize for FireboltCap {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for FireboltCap {
+    fn deserialize<D>(deserializer: D) -> Result<FireboltCap, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let cap = String::deserialize(deserializer)?;
+        if let Some(fc) = FireboltCap::parse(cap.clone()) {
+            Ok(fc)
+        } else {
+            Err(serde::de::Error::custom(format!(
+                "Invalid capability: {}",
+                cap
+            )))
+        }
     }
 }
 
@@ -66,22 +92,20 @@ impl FireboltCap {
     }
 
     pub fn parse(cap: String) -> Option<FireboltCap> {
-        let prefix = ["xrn", "firebolt", "capability"];
-        let c_a = cap.split(':');
-        if c_a.count() > 1 {
-            let c_a = cap.split(':');
-            let mut cap_vec = Vec::<String>::new();
-            for c in c_a {
-                if !prefix.contains(&c) {
-                    cap_vec.push(String::from(c));
-                    if cap_vec.len() == 2 {
-                        return Some(FireboltCap::Short(cap_vec.join(":")));
-                    }
-                }
-            }
+        let pattern = r"^xrn:firebolt:capability:([a-z0-9\\-]+)((:[a-z0-9\\-]+)?)$";
+        if !Regex::new(pattern).unwrap().is_match(cap.as_str()) {
+            return None;
         }
 
-        None
+        let prefix = vec!["xrn", "firebolt", "capability"];
+        let c_a = cap.split(':');
+        let mut cap_vec = Vec::<String>::new();
+        for c in c_a.into_iter() {
+            if !prefix.contains(&c) {
+                cap_vec.push(String::from(c));
+            }
+        }
+        Some(FireboltCap::Short(cap_vec.join(":")))
     }
 
     pub fn from_vec_string(cap_strings: Vec<String>) -> Vec<FireboltCap> {
@@ -382,6 +406,34 @@ pub struct RoleInfo {
 #[derive(Debug, Deserialize, Clone)]
 pub struct CapInfoRpcRequest {
     pub capabilities: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct CapRPCRequest {
+    pub capability: FireboltCap,
+    pub options: Option<CapabilityOption>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct CapabilityOption {
+    pub role: CapabilityRole,
+}
+
+impl Default for CapabilityOption {
+    fn default() -> Self {
+        Self {
+            role: CapabilityRole::Use,
+        }
+    }
+}
+
+impl From<CapRPCRequest> for RoleInfo {
+    fn from(value: CapRPCRequest) -> Self {
+        RoleInfo {
+            role: Some(value.options.unwrap_or_default().role),
+            capability: value.capability.as_str(),
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/core/sdk/src/api/firebolt/fb_openrpc.rs
+++ b/core/sdk/src/api/firebolt/fb_openrpc.rs
@@ -384,15 +384,14 @@ impl From<CapRequestRpcRequest> for CapabilitySet {
         let mut manage_caps_vec = Vec::new();
 
         for cap in c.grants {
-            if let Some(capability) = FireboltCap::parse(cap.clone().capability) {
-                if let Some(role) = cap.clone().role {
-                    match role {
-                        CapabilityRole::Use => use_caps_vec.push(capability),
-                        CapabilityRole::Provide => {
-                            let _ = provide_cap.insert(capability);
-                        }
-                        CapabilityRole::Manage => manage_caps_vec.push(capability),
+            let capability = cap.clone().capability;
+            if let Some(role) = cap.clone().role {
+                match role {
+                    CapabilityRole::Use => use_caps_vec.push(capability),
+                    CapabilityRole::Provide => {
+                        let _ = provide_cap.insert(capability);
                     }
+                    CapabilityRole::Manage => manage_caps_vec.push(capability),
                 }
             }
         }


### PR DESCRIPTION
## What

Add support for ignore rules for capabilities.info

## Why

Ignore rules defined in the manifest should be accounted for capabilities.info.

## How

Adding the support to ignore the checks for app ids mentioned in the manifest

## Test

1. Setup the device manifest with the app_ignore_rules for the Exclusory field
2. Call capabilities.info from the ignored app
3. Validate the results

## Checklist

- [x] I have self-reviewed this PR
- [x] I have added tests that prove the feature works or the fix is effective
