### PR TITLE
fix: should not store grant when app state is unavailable

### DIFF
--- a/core/main/src/service/user_grants.rs
+++ b/core/main/src/service/user_grants.rs
@@ -1371,7 +1371,7 @@ impl GrantStepExecutor {
                 Err(_) => {
                     error!("Unable to get app state");
                     return Err(DenyReasonWithCap {
-                        reason: DenyReason::Unavailable,
+                        reason: DenyReason::AppNotInActiveState,
                         caps: vec![permission.cap.clone()],
                     });
                 }


### PR DESCRIPTION
## What

Update request deny reason for when app state is unavailable to be `Capability cannot be used when app is not in foreground state due to requiring a user grant`

## Why

Error message for when app state is unavailable is returned as `{capability} is not available` 


## How

Update deny reason

## Test

How has this been tested? How can a reviewer test it?

## Checklist

- [x] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
