### PR TITLE
fix: ripple sends wrong eventName

### DIFF
--- a/core/sdk/src/api/firebolt/fb_capabilities.rs
+++ b/core/sdk/src/api/firebolt/fb_capabilities.rs
@@ -402,6 +402,12 @@ pub enum CapEvent {
 
 impl CapEvent {
     pub fn as_str(self) -> String {
-        serde_json::to_string(&self).unwrap()
+        let variant_name = match self {
+            CapEvent::OnAvailable => "onAvailable",
+            CapEvent::OnUnavailable => "onUnavailable",
+            CapEvent::OnGranted => "onGranted",
+            CapEvent::OnRevoked => "onRevoked",
+        };
+        variant_name.to_owned()
     }
 }


### PR DESCRIPTION
## What

Update as_str() to convert cap event to string

## Why

Converts cap event to string instead of json string

## How

Converts cap event to string instead of using serde json which serialize data structure as json string

## Test

How has this been tested? How can a reviewer test it?

## Checklist

- [x] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
