### PR TITLE
fix: Cache cases where folder is not created

### DIFF
--- a/core/main/src/state/cap/permitted_state.rs
+++ b/core/main/src/state/cap/permitted_state.rs
@@ -17,6 +17,7 @@
 
 use std::{
     collections::HashMap,
+    path::Path,
     sync::{Arc, RwLock},
 };
 
@@ -118,7 +119,8 @@ impl PermittedState {
 }
 
 fn get_permissions_path(saved_dir: String) -> String {
-    format!("{}/{}", saved_dir, "app_perms")
+    let dir_path = Path::new(&saved_dir).join("app_perms");
+    dir_path.into_os_string().into_string().unwrap()
 }
 
 pub struct PermissionHandler;

--- a/core/sdk/src/framework/file_store.rs
+++ b/core/sdk/src/framework/file_store.rs
@@ -43,6 +43,11 @@ where
     }
 
     fn write_to_disk(&self, value: String) {
+        // Create the folder if it doesnt exist
+        let p = Path::new(&self.path);
+        if let Some(parent) = p.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
         match OpenOptions::new()
             .create(true)
             .truncate(true)


### PR DESCRIPTION
## What

Adds support to create a folder if it doesnt exist before 

## Why

Cache folder might not exist in some of the device environments. 

## How

By creating a folder in the desired path or verify the folder exists before the cache data is stored.

## Test

Delete the folder for the saved_dir in the manifest and start ripple

## Checklist

- [x] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
