### PR TITLE
fix: handling for power active cleanup and caps

### DIFF
--- a/core/main/src/bootstrap/extn/load_session_step.rs
+++ b/core/main/src/bootstrap/extn/load_session_step.rs
@@ -16,6 +16,7 @@
 //
 
 use ripple_sdk::framework::bootstrap::Bootstep;
+use ripple_sdk::log::debug;
 use ripple_sdk::{async_trait::async_trait, framework::RippleResponse};
 
 use crate::processor::main_context_processor::MainContextProcessor;
@@ -33,6 +34,9 @@ impl Bootstep<BootstrapState> for LoadDistributorValuesStep {
 
     async fn setup(&self, s: BootstrapState) -> RippleResponse {
         MetricsState::initialize(&s.platform_state).await;
+        if MainContextProcessor::handle_power_active_cleanup(&s.platform_state) {
+            debug!("Power Active grants were cleaned up");
+        }
         ContextManager::setup(&s.platform_state).await;
         if !s.platform_state.supports_session() {
             return Ok(());

--- a/core/main/src/processor/main_context_processor.rs
+++ b/core/main/src/processor/main_context_processor.rs
@@ -136,15 +136,17 @@ impl MainContextProcessor {
         }
     }
 
-    async fn handle_power_state(state: &PlatformState, power_state: &SystemPowerState) {
-        if power_state.power_state != PowerState::On
-            && state
-                .cap_state
-                .grant_state
-                .delete_all_entries_for_lifespan(&GrantLifespan::PowerActive)
-        {
+    fn handle_power_state(state: &PlatformState, power_state: &SystemPowerState) {
+        if power_state.power_state != PowerState::On && Self::handle_power_active_cleanup(state) {
             info!("Usergrants updated for Powerstate");
         }
+    }
+
+    pub fn handle_power_active_cleanup(state: &PlatformState) -> bool {
+        state
+            .cap_state
+            .grant_state
+            .delete_all_entries_for_lifespan(&GrantLifespan::PowerActive)
     }
 }
 
@@ -182,7 +184,6 @@ impl ExtnEventProcessor for MainContextProcessor {
                 }
                 RippleContextUpdateType::PowerStateChanged => {
                     Self::handle_power_state(&state.state, &extracted_message.system_power_state)
-                        .await
                 }
                 _ => {}
             }

--- a/core/main/src/state/cap/permitted_state.rs
+++ b/core/main/src/state/cap/permitted_state.rs
@@ -140,14 +140,6 @@ impl PermissionHandler {
 
     pub async fn fetch_and_store(state: &PlatformState, app_id: &str) -> RippleResponse {
         let app_id_alias = Self::get_distributor_alias_for_app_id(state, app_id);
-        if state
-            .cap_state
-            .permitted_state
-            .get_app_permissions(app_id)
-            .is_some()
-        {
-            return Ok(());
-        }
         if let Some(session) = state.session_state.get_account_session() {
             if let Ok(extn_response) = state
                 .get_client()
@@ -166,6 +158,15 @@ impl PermissionHandler {
                     return Ok(());
                 }
             }
+        }
+
+        if state
+            .cap_state
+            .permitted_state
+            .get_app_permissions(app_id)
+            .is_some()
+        {
+            return Ok(());
         }
 
         Err(ripple_sdk::utils::error::RippleError::InvalidOutput)


### PR DESCRIPTION
## What
On Boot clear PowerActive States. Every RIpple restart will be treated as a power recycle event
Use cached permissions only when there is no data

## Why
To ensure that the capability information has integrity alignment with the scope and TTL.

## How
1. Use existing power active cleanup operation on boot
2. Swap the logic for checking local to only when there is an error

## Test
1. Set power Active usergrants and reboot verify if the grants are still available post reboot
2. Validate the permission cache locally after every launch 

## Checklist

- [ ] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
