### PR TITLE
fix: fix for ifa when advertising:identifier is not permitted

### DIFF
--- a/core/main/src/firebolt/handlers/capabilities_rpc.rs
+++ b/core/main/src/firebolt/handlers/capabilities_rpc.rs
@@ -147,7 +147,7 @@ impl CapabilityServer for CapabilityImpl {
             .state
             .cap_state
             .permitted_state
-            .check_cap_role(&ctx.app_id, cap.clone().into())
+            .check_cap_role(&ctx.app_id, &cap.clone().into())
         {
             return Ok(v);
         } else if PermissionHandler::fetch_and_store(&self.state, &ctx.app_id)
@@ -159,7 +159,7 @@ impl CapabilityServer for CapabilityImpl {
                 .state
                 .cap_state
                 .permitted_state
-                .check_cap_role(&ctx.app_id, cap.into())
+                .check_cap_role(&ctx.app_id, &cap.into())
             {
                 return Ok(v);
             }
@@ -291,9 +291,9 @@ impl RippleRPCProvider<CapabilityImpl> for CapRPCProvider {
 }
 
 pub async fn is_permitted(
-    state: PlatformState,
-    ctx: CallContext,
-    cap: RoleInfo,
+    state: &PlatformState,
+    ctx: &CallContext,
+    cap: &RoleInfo,
 ) -> RpcResult<bool> {
     if state.open_rpc_state.is_app_excluded(&ctx.app_id) {
         return Ok(true);
@@ -301,7 +301,7 @@ pub async fn is_permitted(
     if let Ok(v) = state
         .cap_state
         .permitted_state
-        .check_cap_role(&ctx.app_id, cap.clone())
+        .check_cap_role(&ctx.app_id, &cap)
     {
         return Ok(v);
     } else if PermissionHandler::fetch_and_store(&state, &ctx.app_id)

--- a/core/main/src/processor/settings_processor.rs
+++ b/core/main/src/processor/settings_processor.rs
@@ -155,7 +155,7 @@ impl SettingsProcessor {
                         role: Some(CapabilityRole::Use),
                         capability: FireboltCap::Short(sk.use_capability().into()),
                     };
-                    if let Ok(result) = is_permitted(state.clone(), ctx.clone(), role_info).await {
+                    if let Ok(result) = is_permitted(&state, &ctx, &role_info).await {
                         if result {
                             settings.insert(sk.to_string(), v);
                         }

--- a/core/main/src/state/cap/permitted_state.rs
+++ b/core/main/src/state/cap/permitted_state.rs
@@ -78,7 +78,7 @@ impl PermittedState {
         self.permitted.read().unwrap().clone().value
     }
 
-    pub fn check_cap_role(&self, app_id: &str, role_info: RoleInfo) -> Result<bool, RippleError> {
+    pub fn check_cap_role(&self, app_id: &str, role_info: &RoleInfo) -> Result<bool, RippleError> {
         let role = role_info
             .role
             .unwrap_or(ripple_sdk::api::firebolt::fb_capabilities::CapabilityRole::Use);
@@ -100,7 +100,7 @@ impl PermittedState {
         for role_info in request {
             map.insert(
                 role_info.clone().capability.as_str(),
-                if let Ok(v) = self.check_cap_role(app_id, role_info) {
+                if let Ok(v) = self.check_cap_role(app_id, &role_info) {
                     v
                 } else {
                     false

--- a/distributor/general/src/general_permissions_map.json
+++ b/distributor/general/src/general_permissions_map.json
@@ -80,6 +80,8 @@
         "xrn:firebolt:capability:device:make",
         "xrn:firebolt:capability:device:model",
         "xrn:firebolt:capability:protocol:wifi",
+        "xrn:firebolt:capability:advertising:configuration",
+        "xrn:firebolt:capability:advertising:identifier",
         "xrn:firebolt:capability:privacy:settings"
     ],
     "test" : [
@@ -186,7 +188,6 @@
         "xrn:firebolt:capability:lifecycle:launch",
         "xrn:firebolt:capability:discovery:sign-in-status",
         "xrn:firebolt:capability:profile:flags",
-        "xrn:firebolt:capability:advertising:identifier",
         "xrn:firebolt:capability:discovery:entity-info",
         "xrn:firebolt:capability:discovery:purchased-content",
         "xrn:firebolt:capability:discovery:sign-in-status[provide]",


### PR DESCRIPTION
## What

ensure that ifa values are base 64 encoded when advertising:identifier permission is not present

## Why

To be inline with the spec

## How

instead of providing simple all 0s we are base encoding the path

## Test

Tested with the app both having/not having  permission for advertising:identifier and for both ifa values are base encoded. 

## Checklist

- [ ] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
