### PR TITLE
fix: Patch Schema and other 1.0.0 issues

### DIFF
--- a/core/main/src/firebolt/handlers/metrics_rpc.rs
+++ b/core/main/src/firebolt/handlers/metrics_rpc.rs
@@ -417,13 +417,13 @@ impl MetricsServer for MetricsImpl {
     ) -> RpcResult<InternalInitializeResponse> {
         TelemetryBuilder::internal_initialize(&self.state, &ctx, &internal_initialize_params);
         let readable_result = internal_initialize_params
-            .value
+            .version
             .readable
             .replace("SDK", "FEE");
         let internal_initialize_resp = Version {
-            major: internal_initialize_params.value.major,
-            minor: internal_initialize_params.value.minor,
-            patch: internal_initialize_params.value.patch,
+            major: internal_initialize_params.version.major,
+            minor: internal_initialize_params.version.minor,
+            patch: internal_initialize_params.version.patch,
             readable: readable_result,
         };
         Ok(InternalInitializeResponse {

--- a/core/main/src/service/telemetry_builder.rs
+++ b/core/main/src/service/telemetry_builder.rs
@@ -163,7 +163,7 @@ impl TelemetryBuilder {
                 app_id: ctx.app_id.to_owned(),
                 ripple_session_id: ps.metrics.get_context().device_session_id,
                 app_session_id: Some(ctx.session_id.to_owned()),
-                semantic_version: params.value.to_string(),
+                semantic_version: params.version.to_string(),
             }),
         ) {
             error!("send_telemetry={:?}", e)

--- a/core/sdk/src/api/device/device_accessibility_data.rs
+++ b/core/sdk/src/api/device/device_accessibility_data.rs
@@ -18,6 +18,7 @@
 use serde::{Deserialize, Serialize, Serializer};
 
 #[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ClosedCaptionsSettings {
     pub enabled: bool,
     pub styles: ClosedCaptionStyle,

--- a/core/sdk/src/api/device/entertainment_data.rs
+++ b/core/sdk/src/api/device/entertainment_data.rs
@@ -965,7 +965,7 @@ mod tests {
             },
         });
         let value = serde_json::to_string(&intent).unwrap();
-        assert!(value.eq("{\"action\":\"entity\",\"data\":{\"programType\":\"movie\",\"entityType\":\"program\",\"entityId\":\"example-movie-id\",\"assetId\":null,\"appContentData\":null},\"context\":{\"source\":\"xrn:firebolt:application:refui\"}}"));
+        assert!(value.eq("{\"action\":\"entity\",\"data\":{\"programType\":\"movie\",\"entityType\":\"program\",\"entityId\":\"example-movie-id\"},\"context\":{\"source\":\"xrn:firebolt:application:refui\"}}"));
     }
 
     #[test]

--- a/core/sdk/src/api/device/entertainment_data.rs
+++ b/core/sdk/src/api/device/entertainment_data.rs
@@ -648,7 +648,9 @@ pub struct BaseEntity {
     #[serde(default = "default_program_type")]
     pub entity_type: ProgramEntityType,
     pub entity_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub asset_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub app_content_data: Option<AppContentDataString>,
 }
 

--- a/core/sdk/src/utils/error.rs
+++ b/core/sdk/src/utils/error.rs
@@ -19,8 +19,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::api::firebolt::fb_capabilities::DenyReason;
 
-use jsonrpsee_core::Error as JsonRpcError;
-
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub enum RippleError {
     MissingInput,
@@ -58,16 +56,18 @@ impl std::fmt::Display for RippleError {
         }
     }
 }
-impl From<RippleError> for JsonRpcError {
+
+#[cfg(feature = "rpc")]
+impl From<RippleError> for jsonrpsee_core::Error {
     fn from(value: RippleError) -> Self {
-        JsonRpcError::Custom(format!("{}", value))
+        jsonrpsee_core::Error::Custom(format!("{}", value))
     }
 }
-#[cfg(test)]
+#[cfg(all(test, feature = "rpc"))]
 mod tests {
     use super::*;
-    fn custom_error_match(expected: &str, error: JsonRpcError) {
-        if let JsonRpcError::Custom(e) = error {
+    fn custom_error_match(expected: &str, error: jsonrpsee_core::Error) {
+        if let jsonrpsee_core::Error::Custom(e) = error {
             assert_eq!(expected, e);
         } else {
             unreachable!("{}", " non error passed");


### PR DESCRIPTION
## What

1. Add deserialization validations for calls namely Internal.initialize, ccSettings for preferredLanguages, remove none values in entity info and  version deserialization
2. Applauncher issue with bad app library with mismatching name and app_id
3. Feature cleanup in SDK to run unit tests locally 

## Why

These changes were having a lower priority and was not blocking 1.0.0. Changes are added to have these fixed by 1.1.0

## How

Serialization were mainly updated with annotations 

## Test

Tested this locally by triggering Internal.initialize, ccSettings  and also setting up listeners for entity info

## Checklist

- [ ] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
