### PR TITLE
Added aarch64 workflow

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -85,3 +85,35 @@ jobs:
           append: true
           path: current_coverage.md
         continue-on-error: true
+
+  build_and_test_aarch64:
+    name: Build and Test on aarch64
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Build and Test
+        uses: uraimo/run-on-arch-action@v2.5.1
+        id: build_and_test
+        with:
+          arch: aarch64
+          distro: ubuntu22.04
+          githubToken: ${{ github.token }}
+          install: |
+            apt-get update -q -y
+            apt-get install -q -y --no-install-recommends \
+              ca-certificates \
+              curl \
+              pkg-config \
+              build-essential \
+              libssl-dev
+            curl --proto '=https' -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.69.0 --component "rustfmt, clippy"
+          run: |
+            source "$HOME/.cargo/env"
+            export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+            cargo --version --verbose
+            rustc --version
+            cargo clippy --version
+            cargo fmt -- --check
+            cargo clippy --tests --examples --all-targets --all-features -- -D warnings -A clippy::large_enum_variant
+            cargo test


### PR DESCRIPTION
## What
Given that the vast majority of our target devices use the aarch64 ISA, it would be beneficial to run a build and test using that architecture. Since Github runners use x64, we have to use qemu to emulate both the build and test environment. There is a signifact performance penalty when using qemu. It might be possible to do the build using the aarch64-unknown-linux-gnu toolchain on x64 and just run the unit tests in the qemu environment, but it would require the sysroot and rootfs to be binary compatible.

## Why

Difference in types (especially when using FFI functions) can cause compilation errors. This ensure that future changes must pass both x64 and aarch64 workflows inorder to be considered for a merge into master.

## How

By using qemu, we are able to confirm that Ripple can compile on aarch64, the target architecture.

## Test

Verify that the new Github action passes.

## Checklist

- [x] I have self-reviewed this PR
- [x] I have added tests that prove the feature works or the fix is effective
