### PR TITLE
fix: Handling watched and watchNext scenarios

### DIFF
--- a/core/main/src/processor/account_link_processor.rs
+++ b/core/main/src/processor/account_link_processor.rs
@@ -17,7 +17,7 @@
 
 use ripple_sdk::{
     api::{
-        account_link::AccountLinkRequest,
+        account_link::{AccountLinkRequest, WatchedRequest},
         apps::{AppManagerResponse, AppMethod, AppRequest, AppResponse},
         distributor::{
             distributor_discovery::{DiscoveryRequest, MediaEventRequest},
@@ -27,7 +27,6 @@ use ripple_sdk::{
             ClearContentSetParams, ContentAccessAvailability, ContentAccessEntitlement,
             ContentAccessInfo, ContentAccessListSetParams, ContentAccessRequest, MediaEvent,
             MediaEventsAccountLinkRequestParams, ProgressUnit, SessionParams, SignInRequestParams,
-            WatchNextInfo, WatchedInfo,
         },
         gateway::rpc_gateway_api::CallContext,
     },
@@ -234,27 +233,9 @@ impl AccountLinkProcessor {
         Ok(content_partner_id)
     }
 
-    async fn watch_next(
-        state: &PlatformState,
-        msg: ExtnMessage,
-        ctx: CallContext,
-        watch_next: WatchNextInfo,
-    ) -> bool {
-        let watched_info = WatchedInfo {
-            entity_id: watch_next.identifiers.entity_id.unwrap(),
-            progress: 1.0,
-            completed: Some(false),
-            watched_on: None,
-        };
-        Self::watched(state, msg, ctx, watched_info).await
-    }
-
-    async fn watched(
-        state: &PlatformState,
-        msg: ExtnMessage,
-        ctx: CallContext,
-        watched_info: WatchedInfo,
-    ) -> bool {
+    async fn watched(state: &PlatformState, msg: ExtnMessage, request: WatchedRequest) -> bool {
+        let watched_info = request.info;
+        let ctx = request.context;
         let (data_tags, drop_data) =
             DataGovernance::resolve_tags(state, ctx.app_id.clone(), DataEventType::Watched).await;
         debug!("drop_all={:?} data_tags={:?}", drop_data, data_tags);
@@ -267,23 +248,21 @@ impl AccountLinkProcessor {
             .await
             .is_ok();
         }
-        let progress = watched_info.progress;
+        let progress =
+            if matches!(request.unit, ProgressUnit::WatchNext) || watched_info.progress > 1.0 {
+                watched_info.progress
+            } else {
+                watched_info.progress * 100.0
+            };
+
         if let Some(dist_session) = state.session_state.get_account_session() {
             let request =
                 MediaEventRequest::MediaEventAccountLink(MediaEventsAccountLinkRequestParams {
                     media_event: MediaEvent {
                         content_id: watched_info.entity_id.to_owned(),
                         completed: watched_info.completed.unwrap_or(true),
-                        progress: if progress > 1.0 {
-                            progress
-                        } else {
-                            progress * 100.0
-                        },
-                        progress_unit: if progress > 1.0 {
-                            ProgressUnit::Seconds
-                        } else {
-                            ProgressUnit::Percent
-                        },
+                        progress,
+                        progress_unit: request.unit.clone(),
                         watched_on: watched_info.watched_on.clone(),
                         app_id: ctx.app_id.to_owned(),
                     },
@@ -354,12 +333,7 @@ impl ExtnRequestProcessor for AccountLinkProcessor {
             AccountLinkRequest::ClearContentAccess(ctx) => {
                 Self::clear_content_access(&state, msg, ctx).await
             }
-            AccountLinkRequest::Watched(ctx, request) => {
-                Self::watched(&state, msg, ctx, request).await
-            }
-            AccountLinkRequest::WatchedNext(ctx, watch_next) => {
-                Self::watch_next(&state, msg, ctx, *watch_next).await
-            }
+            AccountLinkRequest::Watched(request) => Self::watched(&state, msg, request).await,
         }
     }
 }

--- a/core/sdk/src/api/account_link.rs
+++ b/core/sdk/src/api/account_link.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 
 use super::{
-    firebolt::fb_discovery::{ContentAccessRequest, WatchNextInfo, WatchedInfo},
+    firebolt::fb_discovery::{ContentAccessRequest, ProgressUnit, WatchedInfo},
     gateway::rpc_gateway_api::CallContext,
 };
 
@@ -33,9 +33,15 @@ pub enum AccountLinkRequest {
     SignOut(CallContext),
     ContentAccess(CallContext, ContentAccessRequest),
     ClearContentAccess(CallContext),
-    Watched(CallContext, WatchedInfo),
-    // TODO: assess if boxing this is a productive move: https://rust-lang.github.io/rust-clippy/master/index.html#/large_enum_variant
-    WatchedNext(CallContext, Box<WatchNextInfo>),
+    Watched(WatchedRequest),
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct WatchedRequest {
+    pub context: CallContext,
+    pub info: WatchedInfo,
+    pub unit: ProgressUnit,
 }
 
 impl ExtnPayloadProvider for AccountLinkRequest {

--- a/core/sdk/src/api/firebolt/fb_discovery.rs
+++ b/core/sdk/src/api/firebolt/fb_discovery.rs
@@ -118,6 +118,17 @@ pub struct WatchedInfo {
     )]
     pub watched_on: Option<String>,
 }
+
+impl WatchedInfo {
+    pub fn get_progress(&self) -> ProgressUnit {
+        if self.progress.ge(&1.0) {
+            ProgressUnit::Percent
+        } else {
+            ProgressUnit::Seconds
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct WatchNextInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -315,6 +326,7 @@ pub struct DiscoveryEntitlement {
 pub enum ProgressUnit {
     Seconds,
     Percent,
+    WatchNext,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
## What

Cleanup Account Processor for Watched and WatchNext Api(s)


## Why

ProgressUnit for WatchNext needs to be different from the progress value of `watched_info` to allow the distributor to define the progress value.

## How

Providing a new ProgressUnit gives the distributor the ability to configure. 
## Test

How has this been tested? How can a reviewer test it?

## Checklist

- [x] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
