### PR TITLE
Fix auth

### DIFF
--- a/core/main/src/firebolt/handlers/authentication_rpc.rs
+++ b/core/main/src/firebolt/handlers/authentication_rpc.rs
@@ -78,15 +78,7 @@ impl AuthenticationServer for AuthenticationImpl {
                 }
             }
             TokenType::Root => self.token(TokenType::Root, ctx).await,
-            TokenType::Device => {
-                let feats = self.platform_state.get_device_manifest().get_features();
-                // let feats = self.helper.get_config().get_features();
-                if feats.app_scoped_device_tokens {
-                    self.token(TokenType::Device, ctx).await
-                } else {
-                    self.token(TokenType::Root, ctx).await
-                }
-            }
+            TokenType::Device => self.token(TokenType::Device, ctx).await,
             TokenType::Distributor => {
                 let cap = FireboltCap::Short("token:session".into());
                 let supported_caps = self

--- a/core/main/src/state/platform_state.rs
+++ b/core/main/src/state/platform_state.rs
@@ -191,6 +191,11 @@ impl PlatformState {
         self.get_client().send_extn_request(request).await?;
         Ok(())
     }
+
+    pub fn supports_device_tokens(&self) -> bool {
+        let contract = RippleContract::Session(SessionAdjective::Device).as_clear_string();
+        self.extn_manifest.required_contracts.contains(&contract)
+    }
 }
 
 #[cfg(test)]

--- a/core/sdk/src/api/manifest/device_manifest.rs
+++ b/core/sdk/src/api/manifest/device_manifest.rs
@@ -421,14 +421,12 @@ pub enum PrivacySettingsStorageType {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RippleFeatures {
-    pub app_scoped_device_tokens: bool,
     pub privacy_settings_storage_type: PrivacySettingsStorageType,
     pub intent_validation: IntentValidation,
 }
 
 fn default_ripple_features() -> RippleFeatures {
     RippleFeatures {
-        app_scoped_device_tokens: false,
         privacy_settings_storage_type: PrivacySettingsStorageType::Local,
         intent_validation: IntentValidation::FailOpen,
     }


### PR DESCRIPTION
## What

Removes App Scoped Device Token Feature Flag
Removes backup for sending Root incase the flag is disabled

## Why

They were legacy implementations which needed cleanup

## How

Cleans up the device token implementation based on the feature flag

## Test

Remove device.session from the `required_contracts` list of the extension manifest.
Trigger authentication.token({type: Device}) Firebolt API call

## Checklist

- [x] I have self-reviewed this PR
- [x] I have added tests that prove the feature works or the fix is effective
