### PR TITLE
chore: enhance advertising.advertisingId API

### DIFF
--- a/core/main/src/firebolt/handlers/advertising_rpc.rs
+++ b/core/main/src/firebolt/handlers/advertising_rpc.rs
@@ -97,10 +97,47 @@ pub struct SetSkipRestrictionRequest {
     pub value: SkipRestriction,
 }
 
+#[derive(Debug, Deserialize, Clone)]
+pub struct AdvertisingIdRPCRequest {
+    pub options: Option<ScopeOption>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct ScopeOption {
+    pub scope: Scope,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Scope {
+    #[serde(rename = "type")]
+    pub _type: ScopeType,
+    pub id: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub enum ScopeType {
+    Browse,
+    Content,
+}
+
+impl ScopeType {
+    pub fn as_string(&self) -> &'static str {
+        match self {
+            ScopeType::Browse => "browse",
+            ScopeType::Content => "content",
+        }
+    }
+}
+
 #[rpc(server)]
 pub trait Advertising {
     #[method(name = "advertising.advertisingId")]
-    async fn advertising_id(&self, ctx: CallContext) -> RpcResult<AdvertisingId>;
+    async fn advertising_id(
+        &self,
+        ctx: CallContext,
+        request: AdvertisingIdRPCRequest,
+    ) -> RpcResult<AdvertisingId>;
     #[method(name = "advertising.appBundleId")]
     fn app_bundle_id(&self, ctx: CallContext) -> RpcResult<String>;
     #[method(name = "advertising.config")]
@@ -212,20 +249,37 @@ impl AdvertisingServer for AdvertisingImpl {
             .map_err(|err| err.into())
     }
 
-    async fn advertising_id(&self, ctx: CallContext) -> RpcResult<AdvertisingId> {
+    async fn advertising_id(
+        &self,
+        ctx: CallContext,
+        request: AdvertisingIdRPCRequest,
+    ) -> RpcResult<AdvertisingId> {
         if let Some(session) = self.state.session_state.get_account_session() {
-            let payload = AdvertisingRequest::GetAdIdObject(AdIdRequestParams {
-                privacy_data: privacy_rpc::get_allow_app_content_ad_targeting_settings(&self.state)
-                    .await,
-                app_id: ctx.app_id.to_owned(),
-                dist_session: session,
-            });
-            let resp = self.state.get_client().send_extn_request(payload).await;
+        let mut scope_option_map = HashMap::new();
+        if let Some(req_opt) = &request.options {
+            scope_option_map.insert(
+                "type".to_string(),
+                req_opt.scope._type.as_string().to_string(),
+            );
+            scope_option_map.insert("id".to_string(), req_opt.scope.id.to_string());
+        }
+        let payload = AdvertisingRequest::GetAdIdObject(AdIdRequestParams {
+            privacy_data: privacy_rpc::get_allow_app_content_ad_targeting_settings(
+                &self.state,
+                request.options.as_ref(),
+                &ctx.app_id,
+            )
+            .await,
+            app_id: ctx.app_id.to_owned(),
+            dist_session: session,
+            scope: scope_option_map,
+        });
+        let resp = self.state.get_client().send_extn_request(payload).await;
 
-            if resp.is_err() {
-                error!("Error getting ad init object: {:?}", resp);
-                return Err(rpc_err("Could not get ad init object from the device"));
-            }
+        if resp.is_err() {
+            error!("Error getting ad init object: {:?}", resp);
+            return Err(rpc_err("Could not get ad init object from the device"));
+        }
 
             if let Ok(payload) = resp {
                 if let Some(AdvertisingResponse::AdIdObject(obj)) =
@@ -277,8 +331,12 @@ impl AdvertisingServer for AdvertisingImpl {
             .unwrap_or(false);
 
         let payload = AdvertisingRequest::GetAdInitObject(AdInitObjectRequestParams {
-            privacy_data: privacy_rpc::get_allow_app_content_ad_targeting_settings(&self.state)
-                .await,
+            privacy_data: privacy_rpc::get_allow_app_content_ad_targeting_settings(
+                &self.state,
+                None,
+                &app_id,
+            )
+            .await,
             environment: config.options.environment.to_string(),
             durable_app_id: app_id,
             app_version: "".to_string(),
@@ -288,6 +346,7 @@ impl AdvertisingServer for AdvertisingImpl {
             authentication_entity: config.options.authentication_entity.unwrap_or_default(),
             dist_session: session
                 .ok_or_else(|| Error::Custom(String::from("no session available")))?,
+            scope: HashMap::new(),
         });
 
         match self.state.get_client().send_extn_request(payload).await {

--- a/core/main/src/firebolt/handlers/advertising_rpc.rs
+++ b/core/main/src/firebolt/handlers/advertising_rpc.rs
@@ -255,30 +255,31 @@ impl AdvertisingServer for AdvertisingImpl {
         request: AdvertisingIdRPCRequest,
     ) -> RpcResult<AdvertisingId> {
         if let Some(session) = self.state.session_state.get_account_session() {
-        let mut scope_option_map = HashMap::new();
-        if let Some(scope_opt) = &request.options {
-            if let Some(scope) = &scope_opt.scope {
-                scope_option_map.insert("type".to_string(), scope._type.as_string().to_string());
-                scope_option_map.insert("id".to_string(), scope.id.to_string());
+            let mut scope_option_map = HashMap::new();
+            if let Some(scope_opt) = &request.options {
+                if let Some(scope) = &scope_opt.scope {
+                    scope_option_map
+                        .insert("type".to_string(), scope._type.as_string().to_string());
+                    scope_option_map.insert("id".to_string(), scope.id.to_string());
+                }
             }
-        }
-        let payload = AdvertisingRequest::GetAdIdObject(AdIdRequestParams {
-            privacy_data: privacy_rpc::get_allow_app_content_ad_targeting_settings(
-                &self.state,
-                request.options.as_ref(),
-                &ctx.app_id,
-            )
-            .await,
-            app_id: ctx.app_id.to_owned(),
-            dist_session: session,
-            scope: scope_option_map,
-        });
-        let resp = self.state.get_client().send_extn_request(payload).await;
+            let payload = AdvertisingRequest::GetAdIdObject(AdIdRequestParams {
+                privacy_data: privacy_rpc::get_allow_app_content_ad_targeting_settings(
+                    &self.state,
+                    request.options.as_ref(),
+                    &ctx.app_id,
+                )
+                .await,
+                app_id: ctx.app_id.to_owned(),
+                dist_session: session,
+                scope: scope_option_map,
+            });
+            let resp = self.state.get_client().send_extn_request(payload).await;
 
-        if resp.is_err() {
-            error!("Error getting ad init object: {:?}", resp);
-            return Err(rpc_err("Could not get ad init object from the device"));
-        }
+            if resp.is_err() {
+                error!("Error getting ad init object: {:?}", resp);
+                return Err(rpc_err("Could not get ad init object from the device"));
+            }
 
             if let Ok(payload) = resp {
                 if let Some(AdvertisingResponse::AdIdObject(obj)) =

--- a/core/main/src/firebolt/handlers/advertising_rpc.rs
+++ b/core/main/src/firebolt/handlers/advertising_rpc.rs
@@ -104,7 +104,7 @@ pub struct AdvertisingIdRPCRequest {
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct ScopeOption {
-    pub scope: Scope,
+    pub scope: Option<Scope>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -256,12 +256,11 @@ impl AdvertisingServer for AdvertisingImpl {
     ) -> RpcResult<AdvertisingId> {
         if let Some(session) = self.state.session_state.get_account_session() {
         let mut scope_option_map = HashMap::new();
-        if let Some(req_opt) = &request.options {
-            scope_option_map.insert(
-                "type".to_string(),
-                req_opt.scope._type.as_string().to_string(),
-            );
-            scope_option_map.insert("id".to_string(), req_opt.scope.id.to_string());
+        if let Some(scope_opt) = &request.options {
+            if let Some(scope) = &scope_opt.scope {
+                scope_option_map.insert("type".to_string(), scope._type.as_string().to_string());
+                scope_option_map.insert("id".to_string(), scope.id.to_string());
+            }
         }
         let payload = AdvertisingRequest::GetAdIdObject(AdIdRequestParams {
             privacy_data: privacy_rpc::get_allow_app_content_ad_targeting_settings(

--- a/core/main/src/firebolt/handlers/parameters_rpc.rs
+++ b/core/main/src/firebolt/handlers/parameters_rpc.rs
@@ -76,9 +76,16 @@ pub struct ParametersImpl {
 impl ParametersServer for ParametersImpl {
     async fn initialization(&self, ctx: CallContext) -> RpcResult<AppInitParameters> {
         let (app_resp_tx, app_resp_rx) = oneshot::channel::<AppResponse>();
-        let app_request = AppRequest::new(AppMethod::GetLaunchRequest(ctx.app_id), app_resp_tx);
-        let privacy_data =
-            privacy_rpc::get_allow_app_content_ad_targeting_settings(&self.platform_state).await;
+        let app_request = AppRequest::new(
+            AppMethod::GetLaunchRequest(ctx.app_id.to_owned()),
+            app_resp_tx,
+        );
+        let privacy_data = privacy_rpc::get_allow_app_content_ad_targeting_settings(
+            &self.platform_state,
+            None,
+            &ctx.app_id.to_string(),
+        )
+        .await;
 
         let _ = self
             .platform_state

--- a/core/main/src/firebolt/handlers/privacy_rpc.rs
+++ b/core/main/src/firebolt/handlers/privacy_rpc.rs
@@ -280,16 +280,18 @@ pub async fn get_allow_app_content_ad_targeting_settings(
 ) -> HashMap<String, String> {
     let mut data = StorageProperty::AllowAppContentAdTargeting.as_data();
     if let Some(scope_opt) = scope_option {
-        let primary_app = platform_state
-            .get_device_manifest()
-            .applications
-            .defaults
-            .main;
-        if primary_app == *caller_app.to_string() {
-            if scope_opt.scope._type.as_string() == "browse" {
-                data = StorageProperty::AllowPrimaryBrowseAdTargeting.as_data();
-            } else if scope_opt.scope._type.as_string() == "content" {
-                data = StorageProperty::AllowPrimaryContentAdTargeting.as_data();
+        if let Some(scope) = &scope_opt.scope {
+            let primary_app = platform_state
+                .get_device_manifest()
+                .applications
+                .defaults
+                .main;
+            if primary_app == *caller_app.to_string() {
+                if scope._type.as_string() == "browse" {
+                    data = StorageProperty::AllowPrimaryBrowseAdTargeting.as_data();
+                } else if scope._type.as_string() == "content" {
+                    data = StorageProperty::AllowPrimaryContentAdTargeting.as_data();
+                }
             }
         }
     }

--- a/core/sdk/src/api/firebolt/fb_advertising.rs
+++ b/core/sdk/src/api/firebolt/fb_advertising.rs
@@ -42,6 +42,7 @@ pub struct AdInitObjectRequestParams {
     pub coppa: bool,
     pub authentication_entity: String,
     pub dist_session: AccountSession,
+    pub scope: HashMap<String, String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -69,6 +70,7 @@ pub struct AdIdRequestParams {
     pub privacy_data: HashMap<String, String>,
     pub app_id: String,
     pub dist_session: AccountSession,
+    pub scope: HashMap<String, String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
## What

Enhance Advertising.advertisingId so that an optional scope can be passed from an app

## Why

This changes is needed to meet implementation spec compliant

## How

How do these changes achieve the goal?

## Test

How has this been tested? How can a reviewer test it?

## Checklist

- [ ] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
