### PR TITLE
fix: wifi.scan not honoring the type of timeout in parameter

### DIFF
--- a/core/sdk/src/api/device/device_wifi.rs
+++ b/core/sdk/src/api/device/device_wifi.rs
@@ -20,6 +20,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     extn::extn_client_message::{ExtnPayload, ExtnPayloadProvider, ExtnRequest},
     framework::ripple_contract::RippleContract,
+    utils::serde_utils::timeout_value_deserialize,
 };
 
 use super::device_request::DeviceRequest;
@@ -50,6 +51,12 @@ pub struct AccessPointRequest {
     pub ssid: String,
     pub passphrase: String,
     pub security: WifiSecurityMode,
+}
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WifiScanRequest {
+    #[serde(default, deserialize_with = "timeout_value_deserialize")]
+    pub timeout: u64,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/core/sdk/src/api/wifi.rs
+++ b/core/sdk/src/api/wifi.rs
@@ -30,13 +30,25 @@ pub struct WifiScanRequestTimeout {
     pub timeout: u64,
 }
 
+const DEFAULT_WIFI_SCAN_TIMEOUT: u64 = 60;
+
 impl WifiScanRequestTimeout {
     pub fn new() -> Self {
-        WifiScanRequestTimeout { timeout: 60 }
+        WifiScanRequestTimeout {
+            timeout: DEFAULT_WIFI_SCAN_TIMEOUT,
+        }
     }
 
     pub fn timeout(&self) -> u64 {
         self.timeout
+    }
+    pub fn set_timeout(&mut self, timeout: u64) {
+        // use default if timeout is 0
+        if timeout == 0 {
+            self.timeout = DEFAULT_WIFI_SCAN_TIMEOUT;
+        } else {
+            self.timeout = timeout;
+        }
     }
 }
 

--- a/core/sdk/src/utils/serde_utils.rs
+++ b/core/sdk/src/utils/serde_utils.rs
@@ -257,6 +257,19 @@ where
     }
 }
 
+pub fn timeout_value_deserialize<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let timeout: u64 = Deserialize::deserialize(deserializer)?;
+    if timeout <= 9999 {
+        Ok(timeout)
+    } else {
+        Err(serde::de::Error::custom(
+            "Value of timeout is out of the valid range (0 - 9999)",
+        ))
+    }
+}
 pub struct SerdeClearString;
 
 impl SerdeClearString {


### PR DESCRIPTION
## What

wifi.scan function was not accepting timeout value as an input param.

## Why

This fix is needed for making the implementation spec compliant.  

## How

Added the optional timeout param as an input to wifi.scan API

## Test

How has this been tested? How can a reviewer test it?

## Checklist

- [x] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
