### PR TITLE
feat: Handle undefined intents in LifecycleManagement.session

### DIFF
--- a/core/main/src/service/apps/delegated_launcher_handler.rs
+++ b/core/main/src/service/apps/delegated_launcher_handler.rs
@@ -575,13 +575,16 @@ impl DelegatedLauncherHandler {
                 ))
             }
             _ => {
+                // New loaded Session, Caller must provide Intent.
+                if session.launch.intent.is_none() {
+                    return Err(AppError::NoIntentError);
+                }
+                // app is unloading
                 if self.platform_state.app_manager_state.get(&app_id).is_some() {
                     // app exist so we are creating a new session
                     // because the other one is unloading, remove the old session now
                     self.end_session(&app_id).await.ok();
                 }
-                // New loaded Session, Caller must provide Intent.
-                // app is unloading
                 Ok(AppManagerResponse::Session(
                     self.precheck_then_load_or_activate(session, true).await,
                 ))
@@ -729,6 +732,7 @@ impl DelegatedLauncherHandler {
         if app_opt.is_none() {
             return;
         }
+        // safe to unwrap here as app_opt is not None
         let app = app_opt.unwrap();
         if app.active_session_id.is_none() {
             self.platform_state
@@ -741,21 +745,22 @@ impl DelegatedLauncherHandler {
         if emit_event {
             self.emit_completed(app_id.clone()).await;
         }
-
-        AppEvents::emit_to_app(
-            &self.platform_state,
-            app_id.clone(),
-            DISCOVERY_EVENT_ON_NAVIGATE_TO,
-            &serde_json::to_value(session.launch.intent).unwrap(),
-        )
-        .await;
+        if let Some(intent) = session.launch.intent {
+            AppEvents::emit_to_app(
+                &self.platform_state,
+                app_id.clone(),
+                DISCOVERY_EVENT_ON_NAVIGATE_TO,
+                &serde_json::to_value(intent).unwrap_or_default(),
+            )
+            .await;
+        }
 
         if let Some(ss) = session.launch.second_screen {
             AppEvents::emit_to_app(
                 &self.platform_state,
                 app_id.clone(),
                 SECOND_SCREEN_EVENT_ON_LAUNCH_REQUEST,
-                &serde_json::to_value(ss).unwrap(),
+                &serde_json::to_value(ss).unwrap_or_default(),
             )
             .await;
         }

--- a/core/main/src/utils/rpc_utils.rs
+++ b/core/main/src/utils/rpc_utils.rs
@@ -34,6 +34,7 @@ use crate::{
 
 pub const FIRE_BOLT_DEEPLINK_ERROR_CODE: i32 = -40400;
 pub const DOWNSTREAM_SERVICE_UNAVAILABLE_ERROR_CODE: i32 = -50200;
+pub const SESSION_NO_INTENT_ERROR_CODE: i32 = -40000;
 
 pub fn rpc_err(msg: impl Into<String>) -> Error {
     Error::Custom(msg.into())
@@ -91,7 +92,13 @@ pub fn rpc_downstream_service_err(msg: &str) -> jsonrpsee::core::error::Error {
         data: None,
     })
 }
-
+pub fn rpc_session_no_intent_err(msg: &str) -> jsonrpsee::core::error::Error {
+    Error::Call(CallError::Custom {
+        code: SESSION_NO_INTENT_ERROR_CODE,
+        message: msg.to_owned(),
+        data: None,
+    })
+}
 pub fn rpc_navigate_reserved_app_err(msg: &str) -> jsonrpsee::core::error::Error {
     Error::Call(CallError::Custom {
         code: FIRE_BOLT_DEEPLINK_ERROR_CODE,

--- a/core/sdk/src/api/apps.rs
+++ b/core/sdk/src/api/apps.rs
@@ -40,7 +40,9 @@ use super::{
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct AppSession {
     pub app: AppBasicInfo,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub runtime: Option<AppRuntime>,
+    #[serde(default)]
     pub launch: AppLaunchInfo,
 }
 
@@ -92,7 +94,7 @@ pub struct AppRuntime {
     pub transport: AppRuntimeTransport,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct AppLaunchInfo {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub intent: Option<NavigationIntent>,
@@ -190,7 +192,7 @@ pub enum AppManagerResponse {
     Session(SessionResponse),
 }
 
-#[derive(Debug, Serialize, Deserialize, Copy, Clone)]
+#[derive(Debug, Serialize, Deserialize, Copy, Clone, PartialEq)]
 pub enum AppError {
     General,
     NotFound,
@@ -201,6 +203,7 @@ pub enum AppError {
     Timeout,
     Pending,
     AppNotReady,
+    NoIntentError,
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## What

In order to support the launcher "resuming" apps where they were left off, Ripple should support a new app session with no intent. The app is just brought to the foreground and should not react to any user intent.

Ripple MUST return an error if no intent is given and this is creating a new running session. An app MUST be able to get their cold launch intent through Parameters.initialization. Return an error back to the caller of LifecycleManagement.session for this case. The error code can be -40000 and the message like "An intent must be provided for new app running sessions".
For cases where this is a new active session but not a new running session, if no intent is given, then the navigateTo call for the app is simply not called.

## Why

## How

How do these changes achieve the goal?

## Test

How has this been tested? How can a reviewer test it?

## Checklist

- [ ] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
