### PR TITLE
Fix session id metrics is empty

### DIFF
--- a/core/main/src/firebolt/handlers/metrics_management_rpc.rs
+++ b/core/main/src/firebolt/handlers/metrics_management_rpc.rs
@@ -15,7 +15,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 use jsonrpsee::{core::RpcResult, proc_macros::rpc, RpcModule};
-use ripple_sdk::{api::gateway::rpc_gateway_api::CallContext, async_trait::async_trait};
+use ripple_sdk::{
+    api::gateway::rpc_gateway_api::CallContext, async_trait::async_trait, uuid::Uuid,
+};
 use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::{firebolt::rpc::RippleRPCProvider, state::platform_state::PlatformState};
@@ -105,7 +107,9 @@ impl MetricsManagementServer for MetricsManagementImpl {
         for key in request.keys {
             // currently handling only one key which is deviceSessionId
             if key.as_str() == "deviceSessionId" {
-                self.state.metrics.update_session_id(None);
+                self.state
+                    .metrics
+                    .update_session_id(Some(Uuid::new_v4().to_string()));
             }
         }
         Ok(())

--- a/core/main/src/state/metrics_state.rs
+++ b/core/main/src/state/metrics_state.rs
@@ -29,6 +29,7 @@ use ripple_sdk::{
     },
     chrono::{DateTime, Utc},
     extn::extn_client_message::ExtnResponse,
+    uuid::Uuid,
 };
 
 use crate::processor::storage::storage_manager::StorageManager;
@@ -122,6 +123,7 @@ impl MetricsState {
             context.device_language = language;
             context.os_ver = os_ver;
             context.device_name = device_name;
+            context.device_session_id = Uuid::new_v4().to_string();
 
             if let Some(t) = timezone {
                 context.device_timezone = t;


### PR DESCRIPTION
## What

Assign default string to device_session_id in context

## Why

session id in metric payload is empty

## How

How do these changes achieve the goal?

## Test

How has this been tested? How can a reviewer test it?

## Checklist

- [ ] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
