### PR TITLE
fix: Add Missing partner id in context

### DIFF
--- a/core/main/src/processor/metrics_processor.rs
+++ b/core/main/src/processor/metrics_processor.rs
@@ -89,6 +89,10 @@ pub async fn update_app_context(
         context.app_user_session_id = app.active_session_id;
         context.app_version = SEMVER_LIGHTWEIGHT.to_string();
     }
+    if let Some(session) = ps.session_state.get_account_session() {
+        context.partner_id = session.id;
+    }
+
     let (tags, drop_data) =
         DataGovernance::resolve_tags(ps, ctx.app_id.clone(), DataEventType::BusinessIntelligence)
             .await;
@@ -128,16 +132,18 @@ pub async fn send_metric_for_app_state_change(
             }
 
             let mut context: BehavioralMetricContext = payload.get_context();
-            if let Some(app) = ps.app_manager_state.get(app_id) {
-                context.app_session_id = app.loaded_session_id.to_owned();
-                context.app_user_session_id = app.active_session_id;
-                context.app_version = SEMVER_LIGHTWEIGHT.to_string();
-            }
-            context.governance_state = Some(AppDataGovernanceState::new(tag_name_set));
-            payload.update_context(context);
 
             let session = ps.session_state.get_account_session();
             if let Some(session) = session {
+                if let Some(app) = ps.app_manager_state.get(app_id) {
+                    context.app_session_id = app.loaded_session_id.to_owned();
+                    context.app_user_session_id = app.active_session_id;
+                    context.app_version = SEMVER_LIGHTWEIGHT.to_string();
+                }
+                context.governance_state = Some(AppDataGovernanceState::new(tag_name_set));
+                context.partner_id = session.clone().id;
+                payload.update_context(context);
+
                 let request = BehavioralMetricRequest {
                     context: Some(ps.metrics.get_context()),
                     payload,


### PR DESCRIPTION
## What

PR adds the partner id in the context

## Why
PartnerId used within AppContext needs to be added by the context processor it was missing this entry

## How
By using the partner identification information available in platform state and updating context

## Test
After the changes were made logs for BehaviorMetricsContext would not contain partner.id.not.set in the request

## Checklist

- [x] I have self-reviewed this PR
- [x] I have added tests that prove the feature works or the fix is effective
