### PR TITLE
fix: Grant check fails to do case-insensitive comparison of privacy settings method

### DIFF
--- a/core/main/src/service/user_grants.rs
+++ b/core/main/src/service/user_grants.rs
@@ -1446,6 +1446,10 @@ impl GrantPolicyEnforcer {
         );
         let method_name = Self::get_setter_method_name(platform_state, &privacy_setting.property);
         if method_name.is_none() {
+            error!(
+                "Unable to find setter method for property: {}",
+                privacy_setting.property.as_str()
+            );
             return;
         }
         let method_name = method_name.unwrap();
@@ -1880,7 +1884,7 @@ impl GrantStepExecutor {
         if let Err(reason) = result {
             Err(DenyReasonWithCap {
                 reason,
-                caps: vec![cap.clone()],
+                caps: vec![permission.cap.clone()],
             })
         } else {
             Ok(())
@@ -2175,7 +2179,9 @@ mod tests {
                 result.err().unwrap(),
                 DenyReasonWithCap {
                     reason: DenyReason::GrantDenied,
-                    caps: vec![FireboltCap::Full(PIN_CHALLENGE_CAPABILITY.to_owned())]
+                    caps: vec![FireboltCap::Full(
+                        "xrn:firebolt:capability:localization:postal-code".to_owned()
+                    )]
                 }
             );
         }
@@ -2223,7 +2229,9 @@ mod tests {
                 result.err().unwrap(),
                 DenyReasonWithCap {
                     reason: DenyReason::GrantDenied,
-                    caps: vec![FireboltCap::Full(ACK_CHALLENGE_CAPABILITY.to_owned())]
+                    caps: vec![FireboltCap::Full(
+                        "xrn:firebolt:capability:localization:postal-code".to_owned()
+                    )]
                 }
             );
         }

--- a/core/main/src/state/openrpc_state.rs
+++ b/core/main/src/state/openrpc_state.rs
@@ -139,7 +139,7 @@ impl OpenRpcState {
     }
 
     pub fn check_privacy_property(&self, property: &str) -> bool {
-        if let Some(method) = self.open_rpc.methods.iter().find(|x| x.name == property) {
+        if let Some(method) = self.open_rpc.methods.iter().find(|x| x.is_named(property)) {
             // Checking if the property tag is havin x-allow-value extension.
             if let Some(tags) = &method.tags {
                 if tags
@@ -154,7 +154,7 @@ impl OpenRpcState {
         {
             let ext_rpcs = self.extended_rpc.read().unwrap();
             for ext_rpc in ext_rpcs.iter() {
-                if let Some(method) = ext_rpc.methods.iter().find(|x| x.name == property) {
+                if let Some(method) = ext_rpc.methods.iter().find(|x| x.is_named(property)) {
                     // Checking if the property tag is havin x-allow-value extension.
                     if let Some(tags) = &method.tags {
                         if tags
@@ -180,7 +180,7 @@ impl OpenRpcState {
             .methods
             .iter()
             .find(|x| {
-                x.name == method_name
+                x.is_named(&method_name)
                     && x.tags.is_some()
                     && x.tags
                         .as_ref()
@@ -199,7 +199,7 @@ impl OpenRpcState {
                     .methods
                     .iter()
                     .find(|x| {
-                        x.name == method_name
+                        x.is_named(&method_name)
                             && x.tags.is_some()
                             && x.tags
                                 .as_ref()

--- a/core/sdk/src/api/firebolt/fb_openrpc.rs
+++ b/core/sdk/src/api/firebolt/fb_openrpc.rs
@@ -236,34 +236,32 @@ impl FireboltOpenRpc {
         &self,
         getter_method: &str,
     ) -> Option<FireboltOpenRpcMethod> {
-        let mut result = None;
         let tokens: Vec<&str> = getter_method.split_terminator('.').collect();
-        if tokens.len() == 2 {
-            let setter = self.get_setter_method_for_property(tokens[1]);
-            if let Some(method) = setter {
-                let setter_tokens: Vec<&str> = method.name.split_terminator('.').collect();
-                if !setter_tokens[0].eq(tokens[0]) {
-                    result = None;
-                } else {
-                    result = Some(method);
-                }
-            }
-        } else {
-            result = None;
+
+        if tokens.len() != 2 {
+            return None;
         }
-        result
+
+        let setter = self.get_setter_method_for_property(tokens[1]);
+        setter.filter(|method| {
+            if let Some(suffix) = method.name.to_lowercase().strip_prefix(tokens[0]) {
+                !suffix.is_empty() && suffix.starts_with('.')
+            } else {
+                false
+            }
+        })
     }
 
     pub fn get_setter_method_for_property(&self, property: &str) -> Option<FireboltOpenRpcMethod> {
         self.methods
             .iter()
             .find(|method| {
-                method.tags.is_some()
-                    && method.tags.as_ref().unwrap().iter().any(|tag| {
+                method.tags.as_ref().map_or(false, |tags| {
+                    tags.iter().any(|tag| {
                         (tag.name == "rpc-only" || tag.name == "setter")
-                            && tag.setter_for.is_some()
-                            && tag.setter_for.as_ref().unwrap().as_str() == property
+                            && tag.setter_for.as_deref() == Some(property)
                     })
+                })
             })
             .cloned()
     }


### PR DESCRIPTION
## What

When the user grants policy has an entry for a privacy setting, the property (privacy method) will be checked to validate certain conditions.

To ensure backward compatibility of Firebolt API, the module part of the method needs to be compared in a case-insensitive manner. This was missing in the current implementation

## Why

Why are these changes needed?

## How

How do these changes achieve the goal?

## Test

How has this been tested? How can a reviewer test it?

## Checklist

- [ ] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
