### PR TITLE
fix: Session with grant resolution

### DIFF
--- a/core/main/src/service/apps/delegated_launcher_handler.rs
+++ b/core/main/src/service/apps/delegated_launcher_handler.rs
@@ -79,7 +79,7 @@ use crate::{
         apps::app_events::AppEvents,
         extn::ripple_client::RippleClient,
         telemetry_builder::TelemetryBuilder,
-        user_grants::{GrantPolicyEnforcer, GrantState},
+        user_grants::{GrantHandler, GrantPolicyEnforcer, GrantState},
     },
     state::{
         bootstrap_state::ChannelsState, cap::permitted_state::PermissionHandler,
@@ -910,10 +910,13 @@ impl DelegatedLauncherHandler {
             final_perms
         );
         if !final_perms.is_empty() {
-            Some(final_perms)
-        } else {
-            None
+            // check if grants are resolved after checking for partner exclusion
+            let final_perms = GrantHandler::are_all_user_grants_resolved(ps, &app_id, final_perms);
+            if !final_perms.is_empty() {
+                return Some(final_perms);
+            }
         }
+        None
     }
 
     fn to_completed_session(app: &App) -> CompletedSessionResponse {

--- a/core/main/src/service/user_grants.rs
+++ b/core/main/src/service/user_grants.rs
@@ -992,6 +992,22 @@ impl GrantHandler {
 
         Ok(())
     }
+
+    pub fn are_all_user_grants_resolved(
+        state: &PlatformState,
+        app_id: &str,
+        permissions: Vec<FireboltPermission>,
+    ) -> Vec<FireboltPermission> {
+        let user_grant = state.clone().cap_state.grant_state;
+        let mut final_perms = Vec::new();
+        for permission in permissions {
+            let result = user_grant.get_grant_state(app_id, &permission, Some(state));
+            if let GrantActiveState::PendingGrant = result {
+                final_perms.push(permission.clone());
+            }
+        }
+        final_perms
+    }
 }
 
 pub struct GrantPolicyEnforcer;


### PR DESCRIPTION
## What

Adds support for resolving user grants before generating session

## Why
Resolved usergrants would never prompt provider UI for challenge. This was missing in the original delegated launcher implementation

## How

Checks for resolved user grants and then proceeds with session generation

## Test

Setup grant policy with an acknowledge challenge and launch an app requesting a capability mapped to it 
```
"grantPolicies": {
      "xrn:firebolt:capability:data:app-usage": {
        "use": {
          "options": [
            {
              "steps": [
                {
                  "capability": "xrn:firebolt:capability:usergrant:acknowledgechallenge"
                }
              ]
            }
          ],
          "scope": "app",
          "lifespan": "seconds",
          "overridable": false,
          "lifespanTtl": 200000,
          "persistence": "account",
          "evaluateAt": [
            "activeSession"
          ]
        }
      }
    }
```

## Checklist

- [ ] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
