### PR TITLE
feat: Add default features for device manifest

### DIFF
--- a/core/sdk/src/api/manifest/device_manifest.rs
+++ b/core/sdk/src/api/manifest/device_manifest.rs
@@ -421,15 +421,10 @@ pub enum PrivacySettingsStorageType {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RippleFeatures {
+    #[serde(default = "default_privacy_settings_storage_type")]
     pub privacy_settings_storage_type: PrivacySettingsStorageType,
+    #[serde(default = "default_intent_validation")]
     pub intent_validation: IntentValidation,
-}
-
-fn default_ripple_features() -> RippleFeatures {
-    RippleFeatures {
-        privacy_settings_storage_type: PrivacySettingsStorageType::Local,
-        intent_validation: IntentValidation::FailOpen,
-    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -455,6 +450,21 @@ impl DataGovernanceConfig {
             .find(|p| p.data_type == data_type)
             .cloned()
     }
+}
+
+fn default_ripple_features() -> RippleFeatures {
+    RippleFeatures {
+        privacy_settings_storage_type: default_privacy_settings_storage_type(),
+        intent_validation: default_intent_validation(),
+    }
+}
+
+fn default_intent_validation() -> IntentValidation {
+    IntentValidation::FailOpen
+}
+
+fn default_privacy_settings_storage_type() -> PrivacySettingsStorageType {
+    PrivacySettingsStorageType::Local
 }
 
 pub fn default_enforcement_value() -> bool {
@@ -592,5 +602,38 @@ impl DeviceManifest {
 
     pub fn get_lifecycle_configuration(&self) -> LifecycleConfiguration {
         self.lifecycle.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn check_default_features() {
+        if let Ok(v) = serde_json::from_str::<RippleFeatures>("{}") {
+            assert!(matches!(v.intent_validation, IntentValidation::FailOpen));
+            assert!(matches!(
+                v.privacy_settings_storage_type,
+                PrivacySettingsStorageType::Local
+            ));
+        }
+
+        if let Ok(v) =
+            serde_json::from_str::<RippleFeatures>("{\"privacy_settings_storage_type\": \"sync\"}")
+        {
+            assert!(matches!(v.intent_validation, IntentValidation::FailOpen));
+            assert!(matches!(
+                v.privacy_settings_storage_type,
+                PrivacySettingsStorageType::Sync
+            ));
+        }
+
+        if let Ok(v) = serde_json::from_str::<RippleFeatures>("{\"intent_validation\": \"fail\"}") {
+            assert!(matches!(v.intent_validation, IntentValidation::Fail));
+            assert!(matches!(
+                v.privacy_settings_storage_type,
+                PrivacySettingsStorageType::Local
+            ));
+        }
     }
 }


### PR DESCRIPTION
## What

Adds default features for manifest

## Why

Ripple features are entries in the manifest that determine reconfigurability for a given feature. Mandating them in manifest would make it cumbersome for operators while generating artifacts.

## How
Uses serde default macros to create the default RippleFeature struct

## Test
Added unit test to validate and also tested it locally with a manifest without RippleFeatures

## Checklist

- [ ] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
