### PR TITLE
Migrate to parking_lot

### DIFF
--- a/core/launcher/src/manager/container_manager.rs
+++ b/core/launcher/src/manager/container_manager.rs
@@ -15,10 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use std::{
-    collections::HashMap,
-    sync::{Arc, RwLock},
-};
+use std::{collections::HashMap, sync::Arc};
 
 use ripple_sdk::{
     api::{
@@ -26,6 +23,7 @@ use ripple_sdk::{
         firebolt::fb_lifecycle::LifecycleState,
     },
     log::{debug, error},
+    parking_lot::RwLock,
 };
 use serde::{Deserialize, Serialize};
 
@@ -63,7 +61,7 @@ pub struct ContainerState {
 impl ContainerState {
     fn get_prev_stack(&self) -> Option<String> {
         let prev_container = {
-            let stack = self.stack.read().unwrap();
+            let stack = self.stack.read();
             stack.peek().cloned()
         };
         prev_container
@@ -71,48 +69,48 @@ impl ContainerState {
 
     fn get_container_by_name(&self, id: &String) -> Option<ContainerProperties> {
         {
-            let container = self.containers.read().unwrap();
+            let container = self.containers.read();
             container.get(id).cloned()
         }
     }
 
     fn add_container(&self, k: String, v: ContainerProperties) {
-        let mut containers = self.containers.write().unwrap();
+        let mut containers = self.containers.write();
         containers.insert(k, v);
     }
 
     fn remove_container(&self, k: String) {
-        let mut containers = self.containers.write().unwrap();
+        let mut containers = self.containers.write();
         containers.remove(&k);
     }
 
     fn contains_stack_by_name(&self, id: &String) -> bool {
-        let mut stack = self.stack.write().unwrap();
+        let mut stack = self.stack.write();
         stack.contains(id)
     }
 
     fn stack_len(&self) -> usize {
-        let stack = self.stack.write().unwrap();
+        let stack = self.stack.write();
         stack.len()
     }
 
     fn add_stack(&self, id: String) {
-        let mut stack = self.stack.write().unwrap();
+        let mut stack = self.stack.write();
         stack.push(id);
     }
 
     fn pop_stack_by_name(&self, name: &str) {
-        let mut stack = self.stack.write().unwrap();
+        let mut stack = self.stack.write();
         stack.pop_item(name);
     }
 
     fn bring_stack_to_front(&self, name: &str) {
-        let mut stack = self.stack.write().unwrap();
+        let mut stack = self.stack.write();
         stack.bring_to_front(name);
     }
 
     fn send_stack_to_back(&self, name: &str) {
-        let mut stack = self.stack.write().unwrap();
+        let mut stack = self.stack.write();
         stack.send_to_back(name);
     }
 }

--- a/core/launcher/src/manager/container_message.rs
+++ b/core/launcher/src/manager/container_message.rs
@@ -15,9 +15,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use ripple_sdk::{
+    parking_lot::RwLock,
     tokio::sync::{mpsc, oneshot},
     uuid::Uuid,
 };

--- a/core/main/src/bootstrap/extn/load_extn_metadata_step.rs
+++ b/core/main/src/bootstrap/extn/load_extn_metadata_step.rs
@@ -73,7 +73,7 @@ impl Bootstep<BootstrapState> for LoadExtensionMetadataStep {
             })
             .collect();
         unsafe {
-            let mut loaded_extns = state.extn_state.loaded_libraries.write().unwrap();
+            let mut loaded_extns = state.extn_state.loaded_libraries.write();
             for (extn_path, entry) in extn_paths {
                 debug!("");
                 debug!("");

--- a/core/main/src/bootstrap/extn/load_extn_step.rs
+++ b/core/main/src/bootstrap/extn/load_extn_step.rs
@@ -46,7 +46,7 @@ impl Bootstep<BootstrapState> for LoadExtensionsStep {
         "LoadExtensionsStep".into()
     }
     async fn setup(&self, state: BootstrapState) -> Result<(), RippleError> {
-        let loaded_extensions = state.extn_state.loaded_libraries.read().unwrap();
+        let loaded_extensions = state.extn_state.loaded_libraries.read();
         let mut deferred_channels: Vec<PreLoadedExtnChannel> = Vec::new();
         let mut device_channels: Vec<PreLoadedExtnChannel> = Vec::new();
         let mut jsonrpsee_extns: Methods = Methods::new();
@@ -122,13 +122,13 @@ impl Bootstep<BootstrapState> for LoadExtensionsStep {
         }
 
         {
-            let mut device_channel_state = state.extn_state.device_channels.write().unwrap();
+            let mut device_channel_state = state.extn_state.device_channels.write();
             info!("{} Device channels extension loaded", device_channels.len());
             let _ = device_channel_state.extend(device_channels);
         }
 
         {
-            let mut deferred_channel_state = state.extn_state.deferred_channels.write().unwrap();
+            let mut deferred_channel_state = state.extn_state.deferred_channels.write();
             info!(
                 "{} Deferred channels extension loaded",
                 deferred_channels.len()

--- a/core/main/src/bootstrap/extn/start_extn_channel_step.rs
+++ b/core/main/src/bootstrap/extn/start_extn_channel_step.rs
@@ -55,7 +55,7 @@ impl Bootstep<BootstrapState> for StartExtnChannelsStep {
     async fn setup(&self, state: BootstrapState) -> Result<(), RippleError> {
         let mut extn_ids = Vec::new();
         {
-            let mut device_channels = state.extn_state.device_channels.write().unwrap();
+            let mut device_channels = state.extn_state.device_channels.write();
             while let Some(device_channel) = device_channels.pop() {
                 let id = device_channel.extn_id.clone();
                 extn_ids.push(id.clone());
@@ -67,7 +67,7 @@ impl Bootstep<BootstrapState> for StartExtnChannelsStep {
         }
 
         {
-            let mut deferred_channels = state.extn_state.deferred_channels.write().unwrap();
+            let mut deferred_channels = state.extn_state.deferred_channels.write();
             while let Some(deferred_channel) = deferred_channels.pop() {
                 let id = deferred_channel.extn_id.clone();
                 extn_ids.push(id.clone());

--- a/core/main/src/firebolt/rpc_router.rs
+++ b/core/main/src/firebolt/rpc_router.rs
@@ -27,6 +27,7 @@ use jsonrpsee::{
     },
     types::{error::ErrorCode, Id, Params},
 };
+
 use ripple_sdk::{
     api::{
         apps::EffectiveTransport,
@@ -35,11 +36,12 @@ use ripple_sdk::{
     chrono::Utc,
     extn::extn_client_message::{ExtnMessage, ExtnResponse},
     log::{error, info},
+    parking_lot::RwLock,
     serde_json::{self, Result as SResult},
     tokio::{self},
     utils::error::RippleError,
 };
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use crate::{
     service::telemetry_builder::TelemetryBuilder,
@@ -63,12 +65,12 @@ impl RouterState {
     }
 
     pub fn update_methods(&self, methods: Methods) {
-        let mut methods_state = self.methods.write().unwrap();
+        let mut methods_state = self.methods.write();
         let _ = methods_state.merge(methods.initialize_resources(&self.resources).unwrap());
     }
 
     fn get_methods(&self) -> Methods {
-        self.methods.read().unwrap().clone()
+        self.methods.read().clone()
     }
 }
 

--- a/core/main/src/processor/main_context_processor.rs
+++ b/core/main/src/processor/main_context_processor.rs
@@ -16,7 +16,7 @@
 //
 
 use std::{
-    sync::{Arc, Once, RwLock},
+    sync::{Arc, Once},
     time::Duration,
 };
 
@@ -40,6 +40,7 @@ use ripple_sdk::{
         extn_client_message::ExtnMessage,
     },
     log::{debug, error, info},
+    parking_lot::RwLock,
     tokio::{
         self,
         sync::{mpsc::Receiver as MReceiver, mpsc::Sender as MSender},
@@ -221,7 +222,7 @@ impl ExtnEventProcessor for MainContextProcessor {
                 _ => {}
             }
             {
-                let mut context = state.current_context.write().unwrap();
+                let mut context = state.current_context.write();
                 context.deep_copy(extracted_message);
             }
         }

--- a/core/main/src/service/apps/delegated_launcher_handler.rs
+++ b/core/main/src/service/apps/delegated_launcher_handler.rs
@@ -15,11 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use std::{
-    collections::HashMap,
-    env, fs,
-    sync::{Arc, RwLock},
-};
+use std::{collections::HashMap, env, fs, sync::Arc};
 
 use ripple_sdk::{
     api::{
@@ -45,6 +41,7 @@ use ripple_sdk::{
         gateway::rpc_gateway_api::{AppIdentification, CallerSession},
     },
     log::{debug, error, trace, warn},
+    parking_lot::RwLock,
     serde_json::{self},
     tokio::sync::oneshot,
     utils::time_utils::Timer,
@@ -171,17 +168,16 @@ impl AppManagerState {
         path.display().to_string()
     }
     pub fn get_persisted_app_title_for_app_id(&self, app_id: &str) -> Option<String> {
-        self.app_title.read().unwrap().get(app_id).cloned()
+        self.app_title.read().get(app_id).cloned()
     }
     pub fn persist_app_title(&self, app_id: &str, title: &str) -> bool {
         {
             let _ = self
                 .app_title
                 .write()
-                .unwrap()
                 .insert(app_id.to_owned(), title.to_owned());
         }
-        let map = { self.app_title.read().unwrap().clone() };
+        let map = { self.app_title.read().clone() };
         let path = std::path::Path::new(&self.app_title_persist_path).join(APP_ID_TITLE_FILE_NAME);
         if let Ok(file) = fs::OpenOptions::new()
             .create(true)
@@ -197,17 +193,16 @@ impl AppManagerState {
         false
     }
     pub fn exists(&self, app_id: &str) -> bool {
-        self.apps.read().unwrap().contains_key(app_id)
+        self.apps.read().contains_key(app_id)
     }
 
     pub fn get_app_id_from_session_id(&self, session_id: &str) -> Option<String> {
         {
-            debug!("apps and sessions {:?}", self.apps.read().unwrap());
+            debug!("apps and sessions {:?}", self.apps.read());
         }
         if let Some((_, app)) = self
             .apps
             .read()
-            .unwrap()
             .iter()
             .find(|(_, app)| app.session_id.eq(session_id))
         {
@@ -218,14 +213,14 @@ impl AppManagerState {
     }
 
     fn set_session(&self, app_id: &str, session: AppSession) {
-        let mut apps = self.apps.write().unwrap();
+        let mut apps = self.apps.write();
         if let Some(app) = apps.get_mut(app_id) {
             app.current_session = session
         }
     }
 
     fn update_active_session(&self, app_id: &str, session: Option<String>) {
-        let mut apps = self.apps.write().unwrap();
+        let mut apps = self.apps.write();
         if let Some(app) = apps.get_mut(app_id) {
             debug!(
                 "Setting session : {{ appId:{} , session:{:?} }}",
@@ -236,33 +231,33 @@ impl AppManagerState {
     }
 
     fn set_state(&self, app_id: &str, state: LifecycleState) {
-        let mut apps = self.apps.write().unwrap();
+        let mut apps = self.apps.write();
         if let Some(app) = apps.get_mut(app_id) {
             app.state = state;
         }
     }
 
     fn insert(&self, app_id: String, app: App) {
-        let mut apps = self.apps.write().unwrap();
+        let mut apps = self.apps.write();
         let _ = apps.insert(app_id, app);
     }
 
     pub fn get(&self, app_id: &str) -> Option<App> {
-        self.apps.read().unwrap().get(app_id).cloned()
+        self.apps.read().get(app_id).cloned()
     }
 
     fn remove(&self, app_id: &str) -> Option<App> {
-        let mut apps = self.apps.write().unwrap();
+        let mut apps = self.apps.write();
         apps.remove(app_id)
     }
     fn set_internal_state(&mut self, app_id: &str, method: AppMethod) {
-        let mut apps = self.apps.write().unwrap();
+        let mut apps = self.apps.write();
         if let Some(app) = apps.get_mut(app_id) {
             app.internal_state = Some(method);
         }
     }
     fn get_internal_state(&mut self, app_id: &str) -> Option<AppMethod> {
-        let apps = self.apps.read().unwrap();
+        let apps = self.apps.read();
         if let Some(app) = apps.get(app_id) {
             app.internal_state.clone()
         } else {
@@ -270,12 +265,12 @@ impl AppManagerState {
         }
     }
     fn store_intent(&self, app_id: &str, intent: NavigationIntent) {
-        let mut intents = self.intents.write().unwrap();
+        let mut intents = self.intents.write();
         let _ = intents.insert(app_id.to_owned(), intent);
     }
 
     fn take_intent(&self, app_id: &str) -> Option<NavigationIntent> {
-        let mut intents = self.intents.write().unwrap();
+        let mut intents = self.intents.write();
         intents.remove(app_id)
     }
 }

--- a/core/main/src/service/apps/provider_broker.rs
+++ b/core/main/src/service/apps/provider_broker.rs
@@ -32,6 +32,7 @@ use ripple_sdk::{
         gateway::rpc_gateway_api::{CallContext, CallerSession},
     },
     log::{debug, error, info, warn},
+    parking_lot::RwLock,
     serde_json,
     tokio::sync::oneshot,
     utils::channel_utils::oneshot_send_and_log,
@@ -39,10 +40,7 @@ use ripple_sdk::{
 };
 use serde::{Deserialize, Serialize};
 
-use std::{
-    collections::HashMap,
-    sync::{Arc, RwLock},
-};
+use std::{collections::HashMap, sync::Arc};
 
 use crate::{
     service::apps::app_events::AppEvents,
@@ -194,7 +192,7 @@ impl ProviderBrokerState {
         debug!("sending challenge provider response = {:#?}", result);
 
         let c_id = {
-            let sessions = self.active_sessions.read().unwrap();
+            let sessions = self.active_sessions.read();
             sessions
                 .iter()
                 .find(|(_, session)| session._capability == capability)
@@ -294,7 +292,7 @@ impl ProviderBroker {
         method: String,
         provider: CallContext,
     ) {
-        let mut provider_methods = pst.provider_broker_state.provider_methods.write().unwrap();
+        let mut provider_methods = pst.provider_broker_state.provider_methods.write();
         let cap_method = format!("{}:{}", capability, method);
         if let Some(method) = provider_methods.get(&cap_method) {
             // unregister the capability if it is provided by the session
@@ -328,7 +326,7 @@ impl ProviderBroker {
             listen_request,
         );
         {
-            let mut provider_methods = pst.provider_broker_state.provider_methods.write().unwrap();
+            let mut provider_methods = pst.provider_broker_state.provider_methods.write();
             provider_methods.insert(
                 cap_method,
                 ProviderMethod {
@@ -353,7 +351,7 @@ impl ProviderBroker {
     }
 
     pub fn get_provider_methods(pst: &PlatformState) -> ProviderResult {
-        let provider_methods = pst.provider_broker_state.provider_methods.read().unwrap();
+        let provider_methods = pst.provider_broker_state.provider_methods.read();
         let mut result: HashMap<String, Vec<String>> = HashMap::new();
         let caps_keys = provider_methods.keys();
         let all_caps = caps_keys.cloned().collect::<Vec<String>>();
@@ -377,7 +375,7 @@ impl ProviderBroker {
         debug!("invoking provider for {}", cap_method);
 
         let provider_opt = {
-            let provider_methods = pst.provider_broker_state.provider_methods.read().unwrap();
+            let provider_methods = pst.provider_broker_state.provider_methods.read();
             provider_methods.get(&cap_method).cloned()
         };
         if let Some(provider) = provider_opt {
@@ -423,7 +421,7 @@ impl ProviderBroker {
         provider: ProviderMethod,
     ) -> String {
         let c_id = Uuid::new_v4().to_string();
-        let mut active_sessions = pst.provider_broker_state.active_sessions.write().unwrap();
+        let mut active_sessions = pst.provider_broker_state.active_sessions.write();
         debug!("started provider session {} {}", c_id, request.capability);
         active_sessions.insert(
             c_id.clone(),
@@ -444,7 +442,7 @@ impl ProviderBroker {
         // Remove any duplicate requests.
         ProviderBroker::remove_request(pst, &request.capability);
 
-        let mut request_queue = pst.provider_broker_state.request_queue.write().unwrap();
+        let mut request_queue = pst.provider_broker_state.request_queue.write();
         if request_queue.is_full() {
             warn!("invoke_method: Request queue full, removing oldest request");
             request_queue.remove(0);
@@ -457,7 +455,7 @@ impl ProviderBroker {
             "provider_response, {}, {:?}",
             resp.correlation_id, resp.result
         );
-        let mut active_sessions = pst.provider_broker_state.active_sessions.write().unwrap();
+        let mut active_sessions = pst.provider_broker_state.active_sessions.write();
         match active_sessions.remove(&resp.correlation_id) {
             Some(session) => {
                 oneshot_send_and_log(session.caller.tx, resp.result, "ProviderResponse");
@@ -479,7 +477,7 @@ impl ProviderBroker {
     }
 
     fn cleanup_caps_for_unregister(pst: &PlatformState, session_id: String) -> Vec<String> {
-        let mut active_sessions = pst.provider_broker_state.active_sessions.write().unwrap();
+        let mut active_sessions = pst.provider_broker_state.active_sessions.write();
         let cid_keys = active_sessions.keys();
         let all_cids = cid_keys.cloned().collect::<Vec<String>>();
         let mut clear_cids = Vec::<String>::new();
@@ -501,7 +499,7 @@ impl ProviderBroker {
         for cid in clear_cids {
             active_sessions.remove(&cid);
         }
-        let mut provider_methods = pst.provider_broker_state.provider_methods.write().unwrap();
+        let mut provider_methods = pst.provider_broker_state.provider_methods.write();
         // find all providers for the session being unregistered
         // remove the provided capability
         let mut clear_caps = Vec::new();
@@ -532,7 +530,7 @@ impl ProviderBroker {
     }
 
     fn remove_request(pst: &PlatformState, capability: &String) -> Option<ProviderBrokerRequest> {
-        let mut request_queue = pst.provider_broker_state.request_queue.write().unwrap();
+        let mut request_queue = pst.provider_broker_state.request_queue.write();
         let mut iter = request_queue.iter();
         let cap = iter.position(|request| request.capability.eq(capability));
         if let Some(index) = cap {
@@ -548,7 +546,7 @@ impl ProviderBroker {
         _capability: String,
         request: FocusRequest,
     ) {
-        let mut active_sessions = pst.provider_broker_state.active_sessions.write().unwrap();
+        let mut active_sessions = pst.provider_broker_state.active_sessions.write();
         if let Some(session) = active_sessions.get_mut(&request.correlation_id) {
             session.focused = true;
             if pst.has_internal_launcher() {

--- a/core/main/src/service/data_governance.rs
+++ b/core/main/src/service/data_governance.rs
@@ -25,10 +25,11 @@ use ripple_sdk::{
         storage_property::StorageProperty,
     },
     log::{debug, info},
+    parking_lot::RwLock,
     utils::error::RippleError,
 };
 use std::collections::HashSet;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use crate::{
     processor::storage::storage_manager::StorageManager, state::platform_state::PlatformState,
@@ -65,12 +66,12 @@ impl std::fmt::Debug for DataGovernanceState {
 
 impl DataGovernance {
     fn update_local_exclusion_policy(state: &DataGovernanceState, excl: ExclusionPolicy) {
-        let mut dg = state.exclusions.write().unwrap();
+        let mut dg = state.exclusions.write();
         *dg = Some(excl)
     }
 
     fn get_local_exclusion_policy(state: &DataGovernanceState) -> Option<ExclusionPolicy> {
-        let dg = state.exclusions.read().unwrap();
+        let dg = state.exclusions.read();
         (*dg).clone()
     }
 

--- a/core/main/src/service/extn/ripple_client.rs
+++ b/core/main/src/service/extn/ripple_client.rs
@@ -15,7 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use ripple_sdk::{
     api::{
@@ -35,6 +35,7 @@ use ripple_sdk::{
     },
     framework::RippleResponse,
     log::error,
+    parking_lot::RwLock,
     tokio::{
         self,
         sync::{mpsc::Sender, oneshot},
@@ -119,7 +120,7 @@ impl RippleClient {
     }
 
     pub fn get_extn_client(&self) -> ExtnClient {
-        self.client.read().unwrap().clone()
+        self.client.read().clone()
     }
 
     pub async fn init(&self) {

--- a/core/main/src/service/user_grants.rs
+++ b/core/main/src/service/user_grants.rs
@@ -18,7 +18,7 @@
 use std::{
     collections::{HashMap, HashSet},
     path::Path,
-    sync::{Arc, RwLock},
+    sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -54,6 +54,7 @@ use ripple_sdk::{
     },
     framework::file_store::FileStore,
     log::{debug, error, warn},
+    parking_lot::RwLock,
     serde_json::Value,
     tokio::sync::oneshot,
     utils::error::RippleError,
@@ -104,7 +105,7 @@ impl GrantState {
     }
 
     fn check_device_grants(&self, grant_entry: &GrantEntry) -> Option<GrantStatus> {
-        let device_grants = self.device_grants.read().unwrap();
+        let device_grants = self.device_grants.read();
         if let Some(v) = device_grants.value.get(grant_entry) {
             return v.status.clone();
         }
@@ -112,7 +113,7 @@ impl GrantState {
     }
 
     fn check_app_grants(&self, grant_entry: &GrantEntry, app_id: &str) -> Option<GrantStatus> {
-        let grant_app_map = self.grant_app_map.read().unwrap();
+        let grant_app_map = self.grant_app_map.read();
         if let Some(app_map) = grant_app_map.value.get(app_id) {
             if let Some(v) = app_map.get(grant_entry) {
                 return v.status.clone();
@@ -153,12 +154,7 @@ impl GrantState {
         } else {
             HashMap::default()
         };
-        let grant_entries = platform_state
-            .cap_state
-            .grant_state
-            .grant_app_map
-            .read()
-            .unwrap();
+        let grant_entries = platform_state.cap_state.grant_state.grant_app_map.read();
         for (app_id, app_entries) in grant_entries.value.iter() {
             let mut grant_entry_set_to_remove: HashSet<GrantEntry> = HashSet::new();
             for grant_entry in app_entries.iter() {
@@ -185,12 +181,7 @@ impl GrantState {
         } else {
             HashMap::default()
         };
-        let grant_entries = platform_state
-            .cap_state
-            .grant_state
-            .device_grants
-            .read()
-            .unwrap();
+        let grant_entries = platform_state.cap_state.grant_state.device_grants.read();
         let mut grant_entry_set_to_remove: HashSet<GrantEntry> = HashSet::new();
         for grant_entry in grant_entries.value.iter() {
             if !grant_policies_map.contains_key(&grant_entry.capability) {
@@ -223,12 +214,8 @@ impl GrantState {
             app_id_opt = Some(id.to_string());
         } else {
             // Delete device grant in local storage and grant state
-            let mut device_grant_map_write = platform_state
-                .cap_state
-                .grant_state
-                .device_grants
-                .write()
-                .unwrap();
+            let mut device_grant_map_write =
+                platform_state.cap_state.grant_state.device_grants.write();
 
             device_grant_map_write
                 .value
@@ -254,12 +241,8 @@ impl GrantState {
     ) -> Option<GrantEntry> {
         let mut gc_opt: Option<GrantEntry> = None;
         {
-            let mut grant_app_map_write = platform_state
-                .cap_state
-                .grant_state
-                .grant_app_map
-                .write()
-                .unwrap();
+            let mut grant_app_map_write =
+                platform_state.cap_state.grant_state.grant_app_map.write();
             let entries = grant_app_map_write.value.entry(app_id).or_default();
             if entries.contains(entry) {
                 gc_opt = Some(entry.clone());
@@ -276,7 +259,7 @@ impl GrantState {
         new_entry: GrantEntry,
     ) {
         if let Some(app_id) = app_id {
-            let mut grant_state = self.grant_app_map.write().unwrap();
+            let mut grant_state = self.grant_app_map.write();
             //Get a mutable reference to the value associated with a key, create it if it doesn't exist,
             let entries = grant_state.value.entry(app_id).or_default();
             if entries.contains(&new_entry) {
@@ -292,7 +275,7 @@ impl GrantState {
     }
 
     pub fn clear_local_entries(&self, ps: &PlatformState, persistence_type: PolicyPersistenceType) {
-        let mut app_grant_state = self.grant_app_map.write().unwrap();
+        let mut app_grant_state = self.grant_app_map.write();
         for (_, entries) in app_grant_state.value.iter_mut() {
             entries.retain(|entry| {
                 !self.check_grant_policy_persistence(
@@ -305,7 +288,7 @@ impl GrantState {
         }
         app_grant_state.sync();
 
-        let mut device_grant_state = self.device_grants.write().unwrap();
+        let mut device_grant_state = self.device_grants.write();
         device_grant_state.value.retain(|entry: &GrantEntry| {
             !self.check_grant_policy_persistence(
                 ps,
@@ -347,7 +330,7 @@ impl GrantState {
         F: FnMut(&GrantEntry) -> bool,
     {
         let mut deleted = false;
-        let mut grant_state = self.grant_app_map.write().unwrap();
+        let mut grant_state = self.grant_app_map.write();
         let entries = match grant_state.value.get_mut(&app_id) {
             Some(entries) => entries,
             None => return false,
@@ -367,7 +350,7 @@ impl GrantState {
     pub fn delete_all_entries_for_lifespan(&self, lifespan: &GrantLifespan) -> bool {
         let mut deleted = false;
         {
-            let mut grant_state = self.grant_app_map.write().unwrap();
+            let mut grant_state = self.grant_app_map.write();
 
             for set in grant_state.value.values_mut() {
                 let prev_len = set.len();
@@ -381,7 +364,7 @@ impl GrantState {
             }
         }
         {
-            let mut grant_state = self.device_grants.write().unwrap();
+            let mut grant_state = self.device_grants.write();
             let prev_len = grant_state.value.len();
             grant_state
                 .value
@@ -403,7 +386,7 @@ impl GrantState {
         app_id: String, // None is for device
     ) -> bool {
         let mut deleted = false;
-        let mut grant_state = self.grant_app_map.write().unwrap();
+        let mut grant_state = self.grant_app_map.write();
         let entries = match grant_state.value.get_mut(&app_id) {
             Some(entries) => entries,
             None => return false,
@@ -419,7 +402,7 @@ impl GrantState {
 
     pub fn delete_all_expired_entries(&self) -> bool {
         let mut deleted = false;
-        let mut grant_state = self.grant_app_map.write().unwrap();
+        let mut grant_state = self.grant_app_map.write();
         for (_, entries) in grant_state.value.iter_mut() {
             let prev_len = entries.len();
             entries.retain(|entry| !entry.has_expired());
@@ -432,7 +415,7 @@ impl GrantState {
     }
 
     fn add_device_entry(&self, entry: GrantEntry) {
-        let mut device_grants = self.device_grants.write().unwrap();
+        let mut device_grants = self.device_grants.write();
         if entry.status.is_none() {
             device_grants.value.remove(&entry);
         } else {
@@ -453,7 +436,7 @@ impl GrantState {
             return result;
         }
 
-        let grant_state = self.grant_app_map.read().unwrap();
+        let grant_state = self.grant_app_map.read();
         debug!("grant state: {:?}", grant_state);
         let entries = grant_state.value.get(app_id)?;
 
@@ -476,7 +459,7 @@ impl GrantState {
         role: CapabilityRole,
         capability: &str,
     ) -> Option<GrantStatus> {
-        let grant_state = self.device_grants.read().unwrap();
+        let grant_state = self.device_grants.read();
 
         for entry in grant_state.value.iter() {
             if !entry.has_expired() && (entry.role == role) && (entry.capability == capability) {
@@ -668,7 +651,7 @@ impl GrantState {
     // Pass None for device scope
     pub fn get_grant_entries_for_app_id(&self, app_id: String) -> HashSet<GrantEntry> {
         self.delete_expired_entries_for_app(app_id.clone());
-        match self.grant_app_map.read().unwrap().value.get(&app_id) {
+        match self.grant_app_map.read().value.get(&app_id) {
             Some(x) => x.iter().cloned().collect(),
             None => HashSet::new(),
         }
@@ -677,7 +660,7 @@ impl GrantState {
     // Returns all active and denied user grant entries for the given `app_id`.
     // Pass None for device scope
     pub fn get_device_entries(&self) -> HashSet<GrantEntry> {
-        self.device_grants.read().unwrap().value.clone()
+        self.device_grants.read().value.clone()
     }
 
     // Returns all active and denied user grant entries for the given `capability`
@@ -686,7 +669,7 @@ impl GrantState {
         capability: &str,
     ) -> HashMap<String, HashSet<GrantEntry>> {
         self.delete_all_expired_entries();
-        let grant_state = self.grant_app_map.read().unwrap();
+        let grant_state = self.grant_app_map.read();
         let mut grant_entry_map: HashMap<String, HashSet<GrantEntry>> = HashMap::new();
         for (app_id, app_entries) in grant_state.value.iter() {
             for item in app_entries {
@@ -698,7 +681,7 @@ impl GrantState {
                 }
             }
         }
-        let device_grants = self.device_grants.read().unwrap();
+        let device_grants = self.device_grants.read();
         let grant_sets = device_grants
             .value
             .iter()

--- a/core/main/src/state/cap/cap_state.rs
+++ b/core/main/src/state/cap/cap_state.rs
@@ -18,14 +18,14 @@
 use std::{
     collections::HashSet,
     hash::{Hash, Hasher},
-    sync::{Arc, RwLock},
+    sync::Arc,
 };
 
 use crate::{
     service::{apps::app_events::AppEvents, user_grants::GrantState},
     state::platform_state::PlatformState,
 };
-use ripple_sdk::{api::firebolt::fb_capabilities::RolePermission, serde_json};
+use ripple_sdk::{api::firebolt::fb_capabilities::RolePermission, parking_lot::RwLock, serde_json};
 use ripple_sdk::{
     api::{
         firebolt::{
@@ -72,7 +72,7 @@ impl CapState {
         event: CapEvent,
         request: CapListenRPCRequest,
     ) {
-        let mut r = ps.cap_state.primed_listeners.write().unwrap();
+        let mut r = ps.cap_state.primed_listeners.write();
         if let Some(cap) = FireboltCap::parse(request.clone().capability) {
             let check = CapEventEntry {
                 app_id: call_context.clone().app_id,
@@ -114,7 +114,7 @@ impl CapState {
         cap: FireboltCap,
         app_id: Option<String>,
     ) -> bool {
-        let r = ps.cap_state.primed_listeners.read().unwrap();
+        let r = ps.cap_state.primed_listeners.read();
         debug!("primed entries {:?}", r);
         if r.iter().any(|x| {
             if x.event == event && x.cap == cap {

--- a/core/main/src/state/cap/generic_cap_state.rs
+++ b/core/main/src/state/cap/generic_cap_state.rs
@@ -17,7 +17,7 @@
 
 use std::{
     collections::{HashMap, HashSet},
-    sync::{Arc, RwLock},
+    sync::Arc,
 };
 
 use ripple_sdk::{
@@ -28,6 +28,7 @@ use ripple_sdk::{
         manifest::device_manifest::DeviceManifest,
     },
     log::debug,
+    parking_lot::RwLock,
 };
 
 use crate::state::platform_state::PlatformState;
@@ -54,7 +55,7 @@ impl GenericCapState {
     }
 
     pub fn ingest_supported(&self, request: Vec<FireboltCap>) {
-        let mut supported = self.supported.write().unwrap();
+        let mut supported = self.supported.write();
         supported.extend(
             request
                 .iter()
@@ -64,7 +65,7 @@ impl GenericCapState {
     }
 
     pub fn ingest_availability(&self, request: Vec<FireboltCap>, is_available: bool) {
-        let mut not_available = self.not_available.write().unwrap();
+        let mut not_available = self.not_available.write();
         for cap in request {
             if is_available {
                 not_available.remove(&cap.as_str());
@@ -75,7 +76,7 @@ impl GenericCapState {
     }
 
     pub fn check_for_processor(&self, request: Vec<String>) -> HashMap<String, bool> {
-        let supported = self.supported.read().unwrap();
+        let supported = self.supported.read();
         let mut result = HashMap::new();
         for cap in request {
             result.insert(cap.clone(), supported.contains(&cap));
@@ -84,7 +85,7 @@ impl GenericCapState {
     }
 
     pub fn check_supported(&self, request: &[FireboltPermission]) -> Result<(), DenyReasonWithCap> {
-        let supported = self.supported.read().unwrap();
+        let supported = self.supported.read();
         let not_supported: Vec<FireboltCap> = request
             .iter()
             .filter(|fb_perm| !supported.contains(&fb_perm.cap.as_str()))
@@ -109,7 +110,7 @@ impl GenericCapState {
         &self,
         request: &Vec<FireboltPermission>,
     ) -> Result<(), DenyReasonWithCap> {
-        let not_available = self.not_available.read().unwrap();
+        let not_available = self.not_available.read();
         let mut result: Vec<FireboltCap> = Vec::new();
         for fb_perm in request {
             if not_available.contains(&fb_perm.cap.as_str()) {

--- a/core/main/src/state/cap/permitted_state.rs
+++ b/core/main/src/state/cap/permitted_state.rs
@@ -18,7 +18,7 @@
 use std::{
     collections::{HashMap, HashSet},
     path::Path,
-    sync::{Arc, RwLock},
+    sync::Arc,
 };
 
 use ripple_sdk::{
@@ -35,6 +35,7 @@ use ripple_sdk::{
     },
     framework::{file_store::FileStore, RippleResponse},
     log::{debug, error, info},
+    parking_lot::RwLock,
     tokio,
     utils::error::RippleError,
 };
@@ -63,24 +64,24 @@ impl PermittedState {
     }
 
     fn ingest(&mut self, extend_perms: HashMap<String, Vec<FireboltPermission>>) {
-        let mut perms = self.permitted.write().unwrap();
+        let mut perms = self.permitted.write();
         perms.value.extend(extend_perms);
         perms.sync();
     }
 
     #[cfg(test)]
     pub fn set_permissions(&mut self, permissions: HashMap<String, Vec<FireboltPermission>>) {
-        let mut perms = self.permitted.write().unwrap();
+        let mut perms = self.permitted.write();
         perms.value = permissions;
         perms.sync();
     }
 
     fn get_all_permissions(&self) -> HashMap<String, Vec<FireboltPermission>> {
-        self.permitted.read().unwrap().clone().value
+        self.permitted.read().clone().value
     }
     fn has_cached_permissions(&self, app_id: &String) -> bool {
         // check if the app has permissions cached
-        self.permitted.read().unwrap().value.contains_key(app_id)
+        self.permitted.read().value.contains_key(app_id)
     }
     pub fn check_cap_role(&self, app_id: &str, role_info: &RoleInfo) -> Result<bool, RippleError> {
         let role = role_info

--- a/core/main/src/state/metrics_state.rs
+++ b/core/main/src/state/metrics_state.rs
@@ -15,10 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use std::{
-    collections::HashSet,
-    sync::{Arc, RwLock},
-};
+use std::{collections::HashSet, sync::Arc};
 
 use jsonrpsee::tracing::debug;
 use ripple_sdk::{
@@ -29,6 +26,7 @@ use ripple_sdk::{
     },
     chrono::{DateTime, Utc},
     extn::extn_client_message::ExtnResponse,
+    parking_lot::RwLock,
 };
 
 use crate::processor::storage::storage_manager::StorageManager;
@@ -44,7 +42,7 @@ pub struct MetricsState {
 
 impl MetricsState {
     pub fn get_context(&self) -> MetricsContext {
-        self.context.read().unwrap().clone()
+        self.context.read().clone()
     }
 
     pub async fn initialize(state: &PlatformState) {
@@ -106,7 +104,7 @@ impl MetricsState {
         }
         {
             // Time to set them
-            let mut context = state.metrics.context.write().unwrap();
+            let mut context = state.metrics.context.write();
             if let Some(mac) = mac_address {
                 context.mac_address = mac;
             }
@@ -152,7 +150,7 @@ impl MetricsState {
     }
 
     pub async fn update_account_session(state: &PlatformState) {
-        let mut context = state.metrics.context.write().unwrap();
+        let mut context = state.metrics.context.write();
         let account_session = state.session_state.get_account_session();
         if let Some(session) = account_session {
             context.account_id = session.account_id;
@@ -166,7 +164,7 @@ impl MetricsState {
     }
 
     pub fn operational_telemetry_listener(&self, target: &str, listen: bool) {
-        let mut listeners = self.operational_telemetry_listeners.write().unwrap();
+        let mut listeners = self.operational_telemetry_listeners.write();
         if listen {
             listeners.insert(target.to_string());
         } else {
@@ -177,7 +175,6 @@ impl MetricsState {
     pub fn get_listeners(&self) -> Vec<String> {
         self.operational_telemetry_listeners
             .read()
-            .unwrap()
             .clone()
             .iter()
             .map(|x| x.to_owned())
@@ -186,7 +183,7 @@ impl MetricsState {
 
     pub fn update_session_id(&self, value: Option<String>) {
         let value = value.unwrap_or_default();
-        let mut context = self.context.write().unwrap();
+        let mut context = self.context.write();
         context.device_session_id = value;
     }
 }

--- a/core/main/src/state/session_state.rs
+++ b/core/main/src/state/session_state.rs
@@ -15,10 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use std::{
-    collections::HashMap,
-    sync::{Arc, RwLock},
-};
+use std::{collections::HashMap, sync::Arc};
 
 use ripple_sdk::{
     api::{
@@ -26,6 +23,7 @@ use ripple_sdk::{
         gateway::rpc_gateway_api::{ApiMessage, CallContext},
         session::{AccountSession, ProvisionRequest},
     },
+    parking_lot::RwLock,
     tokio::sync::mpsc::Sender,
     utils::error::RippleError,
 };
@@ -95,7 +93,7 @@ pub struct SessionState {
 
 impl SessionState {
     pub fn insert_session_token(&self, token: String) {
-        let mut session_state = self.account_session.write().unwrap();
+        let mut session_state = self.account_session.write();
         let account_session = session_state.take();
         if let Some(mut session) = account_session {
             session.token = token;
@@ -104,12 +102,12 @@ impl SessionState {
     }
 
     pub fn insert_account_session(&self, account_session: AccountSession) {
-        let mut session_state = self.account_session.write().unwrap();
+        let mut session_state = self.account_session.write();
         let _ = session_state.insert(account_session);
     }
 
     pub fn get_account_session(&self) -> Option<AccountSession> {
-        let session_state = self.account_session.read().unwrap();
+        let session_state = self.account_session.read();
         if let Some(session) = session_state.clone() {
             return Some(session);
         }
@@ -118,7 +116,7 @@ impl SessionState {
     }
 
     pub fn get_app_id(&self, session_id: String) -> Option<String> {
-        let session_map = self.session_map.read().unwrap();
+        let session_map = self.session_map.read();
         if let Some(session) = session_map.get(&session_id) {
             return Some(session.get_app_id());
         }
@@ -126,21 +124,21 @@ impl SessionState {
     }
 
     pub fn has_session(&self, ctx: &CallContext) -> bool {
-        self.session_map.read().unwrap().contains_key(&ctx.get_id())
+        self.session_map.read().contains_key(&ctx.get_id())
     }
 
     pub fn add_session(&self, id: String, session: Session) {
-        let mut session_state = self.session_map.write().unwrap();
+        let mut session_state = self.session_map.write();
         session_state.insert(id, session);
     }
 
     pub fn clear_session(&self, id: &str) {
-        let mut session_state = self.session_map.write().unwrap();
+        let mut session_state = self.session_map.write();
         session_state.remove(id);
     }
 
     pub fn update_account_session(&self, provision: ProvisionRequest) {
-        let mut session_state = self.account_session.write().unwrap();
+        let mut session_state = self.account_session.write();
         let account_session = session_state.take();
         if let Some(mut session) = account_session {
             session.device_id = provision.device_id;
@@ -153,7 +151,7 @@ impl SessionState {
     }
 
     pub fn get_session(&self, ctx: &CallContext) -> Option<Session> {
-        let session_state = self.session_map.read().unwrap();
+        let session_state = self.session_map.read();
         if let Some(cid) = &ctx.cid {
             session_state.get(cid).cloned()
         } else {
@@ -162,7 +160,7 @@ impl SessionState {
     }
 
     pub fn get_session_for_connection_id(&self, cid: &str) -> Option<Session> {
-        let session_state = self.session_map.read().unwrap();
+        let session_state = self.session_map.read();
         session_state.get(cid).cloned()
     }
 }

--- a/core/sdk/Cargo.toml
+++ b/core/sdk/Cargo.toml
@@ -52,4 +52,5 @@ futures = "0.3.21"
 jsonrpsee-core = { version = "0.9.0", features = ["server"], optional = true }
 regex = "=1.7.3"
 async-channel = "2.1.0"
+parking_lot = "0.12.1"
 

--- a/core/sdk/src/api/apps.rs
+++ b/core/sdk/src/api/apps.rs
@@ -15,8 +15,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
+use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::sync::oneshot;
@@ -167,12 +168,13 @@ impl AppRequest {
     }
 
     pub fn send_response(&self, response: AppResponse) -> Result<(), RippleError> {
-        let mut sender = self.resp_tx.write().unwrap();
-        if sender.is_some() {
-            oneshot_send_and_log(sender.take().unwrap(), response, "AppManager response");
-            Ok(())
-        } else {
-            Err(RippleError::SenderMissing)
+        let mut sender = self.resp_tx.write();
+        match sender.take() {
+            Some(tx) => {
+                oneshot_send_and_log(tx, response, "AppManager response");
+                Ok(())
+            }
+            None => Err(RippleError::SenderMissing),
         }
     }
 }

--- a/core/sdk/src/extn/client/extn_client.rs
+++ b/core/sdk/src/extn/client/extn_client.rs
@@ -15,15 +15,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use std::{
-    collections::HashMap,
-    sync::{Arc, RwLock},
-    time::Duration,
-};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use async_channel::{bounded, Receiver as CReceiver, Sender as CSender};
 use chrono::Utc;
 use log::{debug, error, info, trace};
+use parking_lot::RwLock;
 use tokio::sync::{
     mpsc::Sender as MSender,
     oneshot::{self, Sender as OSender},
@@ -75,12 +72,12 @@ pub struct ExtnClient {
 }
 
 fn add_stream_processor<P>(id: String, context: P, map: Arc<RwLock<HashMap<String, P>>>) {
-    let mut processor_state = map.write().unwrap();
+    let mut processor_state = map.write();
     processor_state.insert(id, context);
 }
 
 fn add_vec_stream_processor<P>(id: String, context: P, map: Arc<RwLock<HashMap<String, Vec<P>>>>) {
-    let mut processor_state = map.write().unwrap();
+    let mut processor_state = map.write();
     if let std::collections::hash_map::Entry::Vacant(e) = processor_state.entry(id.clone()) {
         e.insert(vec![context]);
     } else {
@@ -90,13 +87,13 @@ fn add_vec_stream_processor<P>(id: String, context: P, map: Arc<RwLock<HashMap<S
 
 fn add_single_processor<P>(id: String, processor: Option<P>, map: Arc<RwLock<HashMap<String, P>>>) {
     if let Some(processor) = processor {
-        let mut processor_state = map.write().unwrap();
+        let mut processor_state = map.write();
         processor_state.insert(id, processor);
     }
 }
 
 pub fn remove_processor<P>(id: String, map: Arc<RwLock<HashMap<String, P>>>) {
-    let mut processor_state = map.write().unwrap();
+    let mut processor_state = map.write();
     let sender = processor_state.remove(&id);
     drop(sender);
 }
@@ -186,7 +183,7 @@ impl ExtnClient {
     pub fn add_sender(&mut self, id: ExtnId, symbol: ExtnSymbol, sender: CSender<CExtnMessage>) {
         let id = id.to_string();
         {
-            let mut sender_map = self.extn_sender_map.write().unwrap();
+            let mut sender_map = self.extn_sender_map.write();
             sender_map.insert(id.clone(), sender);
         }
         {
@@ -201,7 +198,7 @@ impl ExtnClient {
                     None => error!("Unknown contract {}", contract),
                 }
             }
-            let mut contract_map = self.contract_map.write().unwrap();
+            let mut contract_map = self.contract_map.write();
             contract_map.extend(map);
         }
     }
@@ -209,7 +206,6 @@ impl ExtnClient {
     pub fn get_other_senders(&self) -> Vec<CSender<CExtnMessage>> {
         self.extn_sender_map
             .read()
-            .unwrap()
             .iter()
             .map(|(_, v)| v)
             .cloned()
@@ -244,7 +240,7 @@ impl ExtnClient {
                             message
                         );
                         {
-                            let mut ripple_context = self.ripple_context.write().unwrap();
+                            let mut ripple_context = self.ripple_context.write();
                             ripple_context.deep_copy(context);
                         }
                     }
@@ -301,10 +297,10 @@ impl ExtnClient {
         }
 
         {
-            let mut ripple_context = self.ripple_context.write().unwrap();
+            let mut ripple_context = self.ripple_context.write();
             ripple_context.update(request)
         }
-        let new_context = { self.ripple_context.read().unwrap().clone() };
+        let new_context = { self.ripple_context.read().clone() };
         let message = new_context.get_event_message();
         let c_message: CExtnMessage = message.clone().into();
         {
@@ -334,7 +330,7 @@ impl ExtnClient {
     ) {
         let id_c = msg.id.clone();
         let processor_result = {
-            let mut processors = processor.write().unwrap();
+            let mut processors = processor.write();
             processors.remove(&id_c)
         };
 
@@ -356,7 +352,7 @@ impl ExtnClient {
         let id_c: String = msg.target.as_clear_string();
 
         let v = {
-            let processors = processor.read().unwrap();
+            let processors = processor.read();
             processors.get(&id_c).cloned()
         };
         if let Some(sender) = v {
@@ -381,7 +377,7 @@ impl ExtnClient {
         let mut sender: Option<MSender<ExtnMessage>> = None;
         let read_processor = processor.clone();
         {
-            let processors = read_processor.read().unwrap();
+            let processors = read_processor.read();
             let v = processors.get(&id_c).cloned();
             if let Some(v) = v {
                 for (index, s) in v.iter().enumerate() {
@@ -415,7 +411,7 @@ impl ExtnClient {
     ) {
         let indices = match gc_sender_indexes {
             Some(i) => Some(i),
-            None => processor.read().unwrap().get(&id_c).map(|v| {
+            None => processor.read().get(&id_c).map(|v| {
                 v.iter()
                     .filter(|x| x.is_closed())
                     .enumerate()
@@ -425,7 +421,7 @@ impl ExtnClient {
         };
         if let Some(indices) = indices {
             if !indices.is_empty() {
-                let mut gc_cleanup = processor.write().unwrap();
+                let mut gc_cleanup = processor.write();
                 if let Some(sender_list) = gc_cleanup.get_mut(&id_c) {
                     for index in indices {
                         let r = sender_list.remove(index);
@@ -441,13 +437,7 @@ impl ExtnClient {
         contract: RippleContract,
     ) -> Option<CSender<CExtnMessage>> {
         let contract_str: String = contract.as_clear_string();
-        let id = {
-            self.contract_map
-                .read()
-                .unwrap()
-                .get(&contract_str)
-                .cloned()
-        };
+        let id = { self.contract_map.read().get(&contract_str).cloned() };
         if let Some(extn_id) = id {
             return self.get_extn_sender_with_extn_id(&extn_id);
         }
@@ -456,7 +446,7 @@ impl ExtnClient {
     }
 
     fn get_extn_sender_with_extn_id(&self, id: &str) -> Option<CSender<CExtnMessage>> {
-        return self.extn_sender_map.read().unwrap().get(id).cloned();
+        return self.extn_sender_map.read().get(id).cloned();
     }
 
     /// Critical method used by request processors to send response message back to the requestor
@@ -606,7 +596,7 @@ impl ExtnClient {
     }
 
     pub fn has_token(&self) -> bool {
-        let ripple_context = self.ripple_context.read().unwrap();
+        let ripple_context = self.ripple_context.read();
         matches!(
             ripple_context.activation_status.clone(),
             ActivationStatus::AccountToken(_)
@@ -614,12 +604,12 @@ impl ExtnClient {
     }
 
     pub fn get_activation_status(&self) -> ActivationStatus {
-        let ripple_context = self.ripple_context.read().unwrap();
+        let ripple_context = self.ripple_context.read();
         ripple_context.activation_status.clone()
     }
 
     pub fn has_internet(&self) -> bool {
-        let ripple_context = self.ripple_context.read().unwrap();
+        let ripple_context = self.ripple_context.read();
         matches!(
             ripple_context.internet_connectivity,
             InternetConnectionStatus::FullyConnected | InternetConnectionStatus::LimitedInternet
@@ -627,7 +617,7 @@ impl ExtnClient {
     }
 
     pub fn get_timezone(&self) -> Option<TimeZone> {
-        let ripple_context = self.ripple_context.read().unwrap();
+        let ripple_context = self.ripple_context.read();
         Some(ripple_context.time_zone.clone())
     }
 }

--- a/core/sdk/src/lib.rs
+++ b/core/sdk/src/lib.rs
@@ -29,6 +29,7 @@ pub extern crate chrono;
 pub extern crate futures;
 pub extern crate libloading;
 pub extern crate log;
+pub extern crate parking_lot;
 pub extern crate semver;
 pub extern crate serde;
 pub extern crate serde_json;

--- a/core/sdk/src/utils/time_utils.rs
+++ b/core/sdk/src/utils/time_utils.rs
@@ -16,10 +16,8 @@
 //
 
 use chrono::{LocalResult, TimeZone, Utc};
-use std::{
-    sync::{Arc, Mutex},
-    time::Duration,
-};
+use parking_lot::Mutex;
+use std::{sync::Arc, time::Duration};
 
 use futures::Future;
 use tokio::task::JoinHandle;
@@ -71,7 +69,7 @@ impl Timer {
         let cancelled = cancelled_flag_mutex.clone();
         let handle = tokio::spawn(async move {
             tokio::time::sleep(Duration::from_millis(delay_ms)).await;
-            let cancelled = { *cancelled_flag_mutex.lock().unwrap() };
+            let cancelled = { *cancelled_flag_mutex.lock() };
             if !cancelled {
                 callback.await;
             }
@@ -80,7 +78,7 @@ impl Timer {
     }
 
     pub fn cancel(self) {
-        let mut cancelled_flag = self.cancelled.lock().unwrap();
+        let mut cancelled_flag = self.cancelled.lock();
         *cancelled_flag = true;
         self.handle.abort();
     }

--- a/device/thunder_ripple_sdk/src/events/thunder_event_processor.rs
+++ b/device/thunder_ripple_sdk/src/events/thunder_event_processor.rs
@@ -15,11 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use std::{
-    collections::HashMap,
-    str::FromStr,
-    sync::{Arc, RwLock},
-};
+use std::{collections::HashMap, str::FromStr, sync::Arc};
 
 use ripple_sdk::{
     api::{
@@ -36,6 +32,7 @@ use ripple_sdk::{
     },
     extn::extn_client_message::ExtnEvent,
     log::{debug, error, trace},
+    parking_lot::RwLock,
     serde_json::{self, Value},
     utils::error::RippleError,
 };
@@ -278,7 +275,7 @@ impl ThunderEventProcessor {
     }
 
     pub fn get_handler(&self, event: &str) -> Option<ThunderEventHandler> {
-        let event_map = self.event_map.read().unwrap();
+        let event_map = self.event_map.read();
         event_map.get(event).cloned()
     }
 
@@ -297,7 +294,7 @@ impl ThunderEventProcessor {
 
     pub fn add_event_listener(&self, app_id: String, handler: ThunderEventHandler) -> bool {
         let event_name = handler.get_id();
-        let mut event_map = self.event_map.write().unwrap();
+        let mut event_map = self.event_map.write();
         if let Some(entry) = event_map.get_mut(&event_name) {
             entry.add_listener(app_id);
             return false;
@@ -308,7 +305,7 @@ impl ThunderEventProcessor {
     }
 
     pub fn remove_event_listener(&self, event_name: String, app_id: String) -> bool {
-        let mut event_map = self.event_map.write().unwrap();
+        let mut event_map = self.event_map.write();
         if let Some(entry) = event_map.get_mut(&event_name) {
             if !entry.remove_listener(app_id) {
                 return false;
@@ -319,7 +316,7 @@ impl ThunderEventProcessor {
     }
 
     pub fn add_last_event(&self, event_name: &str, value: &ExtnEvent) {
-        let mut last_event_map = self.last_event.write().unwrap();
+        let mut last_event_map = self.last_event.write();
         last_event_map.insert(
             event_name.to_string(),
             serde_json::to_value(value.clone()).unwrap(),
@@ -328,7 +325,7 @@ impl ThunderEventProcessor {
 
     pub fn check_last_event(&self, event_name: &str, value: &ExtnEvent) -> bool {
         let ref_value = serde_json::to_value(value.clone()).unwrap();
-        let last_event_map = self.last_event.read().unwrap();
+        let last_event_map = self.last_event.read();
         if let Some(last_event) = last_event_map.get(event_name) {
             return last_event.eq(&ref_value);
         }

--- a/device/thunder_ripple_sdk/src/processors/thunder_device_info.rs
+++ b/device/thunder_ripple_sdk/src/processors/thunder_device_info.rs
@@ -15,11 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use std::{
-    collections::HashMap,
-    sync::{Arc, RwLock},
-    time::Duration,
-};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use crate::{
     client::{thunder_client::ThunderClient, thunder_plugin::ThunderPlugin},
@@ -72,6 +68,7 @@ use ripple_sdk::{
         manifest::device_manifest::DefaultValues,
     },
     log::trace,
+    parking_lot::RwLock,
     serde_json::{Map, Value},
     tokio::join,
 };
@@ -170,74 +167,74 @@ impl CachedState {
     }
 
     fn get_hdcp_support(&self) -> Option<HashMap<HdcpProfile, bool>> {
-        self.cached.read().unwrap().hdcp_support.clone()
+        self.cached.read().hdcp_support.clone()
     }
 
     fn update_hdcp_support(&self, value: HashMap<HdcpProfile, bool>) {
-        let mut hdcp = self.cached.write().unwrap();
+        let mut hdcp = self.cached.write();
         let _ = hdcp.hdcp_support.insert(value);
     }
 
     fn get_hdcp_status(&self) -> Option<HDCPStatus> {
-        self.cached.read().unwrap().hdcp_status.clone()
+        self.cached.read().hdcp_status.clone()
     }
 
     fn update_hdcp_status(&self, value: HDCPStatus) {
-        let mut hdcp = self.cached.write().unwrap();
+        let mut hdcp = self.cached.write();
         let _ = hdcp.hdcp_status.insert(value);
     }
 
     fn get_hdr(&self) -> Option<HashMap<HdrProfile, bool>> {
-        self.cached.read().unwrap().hdr_profile.clone()
+        self.cached.read().hdr_profile.clone()
     }
 
     fn update_hdr_support(&self, value: HashMap<HdrProfile, bool>) {
-        let mut hdr = self.cached.write().unwrap();
+        let mut hdr = self.cached.write();
         let _ = hdr.hdr_profile.insert(value);
     }
 
     fn get_mac_address(&self) -> Option<String> {
-        self.cached.read().unwrap().mac_address.clone()
+        self.cached.read().mac_address.clone()
     }
 
     fn get_serial_number(&self) -> Option<String> {
-        self.cached.read().unwrap().serial_number.clone()
+        self.cached.read().serial_number.clone()
     }
 
     fn update_serial_number(&self, serial_number: String) {
-        let mut cached = self.cached.write().unwrap();
+        let mut cached = self.cached.write();
         let _ = cached.serial_number.insert(serial_number);
     }
 
     fn update_mac_address(&self, mac: String) {
-        let mut cached = self.cached.write().unwrap();
+        let mut cached = self.cached.write();
         let _ = cached.mac_address.insert(mac);
     }
 
     fn get_model(&self) -> Option<String> {
-        self.cached.read().unwrap().model.clone()
+        self.cached.read().model.clone()
     }
 
     fn update_model(&self, model: String) {
-        let mut cached = self.cached.write().unwrap();
+        let mut cached = self.cached.write();
         let _ = cached.model.insert(model);
     }
 
     fn get_make(&self) -> Option<String> {
-        self.cached.read().unwrap().make.clone()
+        self.cached.read().make.clone()
     }
 
     fn update_make(&self, make: String) {
-        let mut cached = self.cached.write().unwrap();
+        let mut cached = self.cached.write();
         let _ = cached.make.insert(make);
     }
 
     fn get_version(&self) -> Option<FireboltSemanticVersion> {
-        self.cached.read().unwrap().version.clone()
+        self.cached.read().version.clone()
     }
 
     fn update_version(&self, version: FireboltSemanticVersion) {
-        let mut cached = self.cached.write().unwrap();
+        let mut cached = self.cached.write();
         let _ = cached.version.insert(version);
     }
 }

--- a/device/thunder_ripple_sdk/src/thunder_state.rs
+++ b/device/thunder_ripple_sdk/src/thunder_state.rs
@@ -15,7 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use ripple_sdk::{
     api::device::device_operator::{
@@ -25,6 +25,7 @@ use ripple_sdk::{
         client::extn_client::ExtnClient,
         extn_client_message::{ExtnMessage, ExtnPayloadProvider},
     },
+    parking_lot::RwLock,
     tokio,
     tokio::sync::mpsc,
     utils::error::RippleError,
@@ -120,7 +121,7 @@ impl ThunderState {
     }
 
     pub fn start_event_thread(&self) {
-        let mut rx = self.receiver.write().unwrap();
+        let mut rx = self.receiver.write();
         let rx = rx.take();
         if let Some(mut r) = rx {
             let state_c = self.clone();

--- a/distributor/general/src/general_privacy_processor.rs
+++ b/distributor/general/src/general_privacy_processor.rs
@@ -15,10 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use std::{
-    collections::HashMap,
-    sync::{Arc, RwLock},
-};
+use std::{collections::HashMap, sync::Arc};
 
 use ripple_sdk::{
     api::distributor::distributor_privacy::{
@@ -36,6 +33,7 @@ use ripple_sdk::{
         extn_client_message::{ExtnPayloadProvider, ExtnResponse},
     },
     framework::file_store::FileStore,
+    parking_lot::RwLock,
 };
 use serde::{Deserialize, Serialize};
 
@@ -73,7 +71,7 @@ impl PrivacyState {
     }
 
     fn get_property(&self, params: GetPropertyParams) -> bool {
-        let data = self.privacy_data.read().unwrap();
+        let data = self.privacy_data.read();
         match params.setting {
             PrivacySetting::AppDataCollection(a) => data.value.get_data_collections(a),
             PrivacySetting::AppEntitlementCollection(e) => data.value.get_ent_collections(e),
@@ -104,7 +102,7 @@ impl PrivacyState {
     }
 
     fn set_property(&self, params: SetPropertyParams) -> bool {
-        let mut data = self.privacy_data.write().unwrap();
+        let mut data = self.privacy_data.write();
         match params.setting.clone() {
             PrivacySetting::AppDataCollection(a) => {
                 data.value.set_data_collections(a, params.value)
@@ -118,7 +116,7 @@ impl PrivacyState {
     }
 
     fn get_settings(&self) -> PrivacySettings {
-        let data = self.privacy_data.read().unwrap();
+        let data = self.privacy_data.read();
         data.value.settings.clone()
     }
 }

--- a/distributor/general/src/general_session_processor.rs
+++ b/distributor/general/src/general_session_processor.rs
@@ -34,9 +34,10 @@ use ripple_sdk::{
     },
     framework::file_store::FileStore,
     log::error,
+    parking_lot::RwLock,
     utils::error::RippleError,
 };
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub struct DistSessionState {
@@ -86,7 +87,7 @@ impl DistributorSessionProcessor {
     }
 
     async fn get_token(mut state: DistSessionState, msg: ExtnMessage) -> bool {
-        let session = state.session.read().unwrap().value.clone();
+        let session = state.session.read().value.clone();
         if let Err(e) = state
             .client
             .respond(
@@ -110,7 +111,7 @@ impl DistributorSessionProcessor {
         token: AccountSessionTokenRequest,
     ) -> bool {
         {
-            let mut session = state.session.write().unwrap();
+            let mut session = state.session.write();
             session.value.token = token.token;
             session.sync();
         }
@@ -123,7 +124,7 @@ impl DistributorSessionProcessor {
         provision: ProvisionRequest,
     ) -> bool {
         {
-            let mut session = state.session.write().unwrap();
+            let mut session = state.session.write();
             session.value.account_id = provision.account_id;
             session.value.device_id = provision.device_id;
             if let Some(distributor) = provision.distributor_id {


### PR DESCRIPTION
## What

Migrate from std implementations of Mutex and RwLock to the parking_lot implementations. They are faster and more flexible than the those found in the Rust standard library. The `parking_lot` implementation also can not be poisoned, meaning that any `Mutex` / `RwLock` operations do not return a `Result<>` making the call to `unwrap()` no longer needed.

**This change does make `parking_lot` crate a part of the `ripple_sdk`. It is up to the Ripple team to determine if that is an acceptable change.**

## Why

* Faster processing of `Mutex` and `RwLock` operations  
* 186 `unwrap()`s removed.
* Smaller code size. Each time `unwrap()` is called a conditional must be inserted with a `panic` for the `Err` variant.

## How

By swapping `std::sync::Mutex` with `parking_lot::Mutex` and `std::sync::RwLock` with `parking_lot::RwLock`.

## Test

TBD

## Checklist

- [x] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
