### PR TITLE
cherry-pick: Remove unnecessary clones (fixes #50) (#326)

### DIFF
--- a/core/launcher/src/launcher_state.rs
+++ b/core/launcher/src/launcher_state.rs
@@ -59,9 +59,9 @@ impl LauncherState {
         self.extn_client.clone().request(payload).await
     }
 
-    pub async fn new(extn_client: ExtnClient) -> Result<LauncherState, RippleError> {
+    pub async fn new(mut extn_client: ExtnClient) -> Result<LauncherState, RippleError> {
         let extn_message_response: Result<ExtnMessage, RippleError> =
-            extn_client.clone().request(Config::LauncherConfig).await;
+            extn_client.request(Config::LauncherConfig).await;
         if let Ok(message) = extn_message_response {
             if let Some(config) = message.payload.extract() {
                 return Ok(LauncherState {

--- a/core/launcher/src/manager/app_launcher.rs
+++ b/core/launcher/src/manager/app_launcher.rs
@@ -112,7 +112,7 @@ fn get_app_type(manifest: &AppManifest) -> Option<String> {
 }
 
 impl AppLauncherState {
-    fn get_active_instances(self, manifest: &AppManifest) -> usize {
+    fn get_active_instances(&self, manifest: &AppManifest) -> usize {
         match get_app_type(manifest) {
             Some(t) => self
                 .apps
@@ -202,10 +202,7 @@ impl AppLauncher {
         async move {
             debug!("set_state: container_id={}", container_id);
             let mut final_resp = Ok(AppManagerResponse::None);
-            let item = state
-                .clone()
-                .app_launcher_state
-                .get_app_by_id(&container_id);
+            let item = state.app_launcher_state.get_app_by_id(&container_id);
 
             if let Some(app) = item {
                 let previous_state = app.state;
@@ -217,7 +214,6 @@ impl AppLauncher {
                     final_resp = Err(AppError::UnexpectedState);
                 } else {
                     state
-                        .clone()
                         .app_launcher_state
                         .set_app_state(&container_id, lc_state);
 
@@ -258,11 +254,10 @@ impl AppLauncher {
             } else {
                 // Container ID for app not found, check registered providers to
                 // see if it's a provider container ID.
-                let app_library_state = state.clone().config.app_library_state;
-                let resp = AppLibrary::get_provider(&app_library_state, container_id.to_string());
+                let app_library_state = &state.config.app_library_state;
+                let resp = AppLibrary::get_provider(app_library_state, container_id.to_string());
                 if let Some(provider) = resp {
                     final_resp = state
-                        .clone()
                         .app_launcher_state
                         .get_app_by_id(&provider)
                         .map_or(Err(AppError::NotFound), |_| Ok(AppManagerResponse::None));
@@ -319,7 +314,7 @@ impl AppLauncher {
     }
 
     async fn check_retention_policy(state: &LauncherState) {
-        let policy = state.clone().config.retention_policy;
+        let policy = state.config.retention_policy.clone();
         let mut app_count_exceeded = false;
         let app_count = state.app_launcher_state.get_app_len() as u64;
         if app_count > policy.max_retained {
@@ -373,7 +368,7 @@ impl AppLauncher {
     }
 
     fn get_oldest_removeable_app(state: &LauncherState) -> Option<String> {
-        let policy = state.clone().config.retention_policy;
+        let policy = state.config.retention_policy.clone();
         let mut candidates = state.app_launcher_state.always_retained_apps(policy);
 
         let count = candidates.len();
@@ -439,11 +434,7 @@ impl AppLauncher {
         debug!("on_unloading: entry: app_id={}", app_id);
 
         let id = app_id.to_string();
-        let timeout = state
-            .clone()
-            .config
-            .lifecycle_policy
-            .app_finished_timeout_ms;
+        let timeout = state.config.lifecycle_policy.app_finished_timeout_ms;
         let state_c = state.clone();
         tokio::spawn(async move {
             sleep(Duration::from_millis(timeout)).await;
@@ -629,10 +620,7 @@ impl AppLauncher {
         if app_type.is_none() {
             return Err(AppError::NotSupported);
         }
-        let instances = state
-            .clone()
-            .app_launcher_state
-            .get_active_instances(&app_manifest);
+        let instances = state.app_launcher_state.get_active_instances(&app_manifest);
         let bnrp = BrowserNameRequestParams {
             name: app_manifest.name.clone(),
             runtime: app_manifest.runtime.clone(),
@@ -695,7 +683,7 @@ impl AppLauncher {
             h: launch_params.h,
         };
 
-        let policy = state.clone().config.retention_policy;
+        let policy = state.config.retention_policy.clone();
         let always_retained = policy
             .always_retained
             .iter()
@@ -740,7 +728,7 @@ impl AppLauncher {
                 Err(_) => return Err(AppError::IoError),
             }
         } else {
-            let timeout = state.clone().config.lifecycle_policy.app_ready_timeout_ms;
+            let timeout = state.config.lifecycle_policy.app_ready_timeout_ms;
             let state_c = state.clone();
             let app_id = request.app_id.clone();
             let launch_time = app.launch_time;

--- a/core/launcher/src/manager/container_manager.rs
+++ b/core/launcher/src/manager/container_manager.rs
@@ -212,8 +212,8 @@ impl ContainerManager {
 
         state.container_state.bring_stack_to_front(name);
 
-        let props = item.unwrap().clone();
-        let resp = ViewManager::set_position(state, props.clone().view_id, Position::Front).await;
+        let props = item.unwrap();
+        let resp = ViewManager::set_position(state, props.view_id, Position::Front).await;
         if let Err(e) = resp {
             debug!("bring_to_front: error: req_id={:?}", e);
             return Err(ContainerError::General);

--- a/core/launcher/src/manager/view_manager.rs
+++ b/core/launcher/src/manager/view_manager.rs
@@ -185,7 +185,7 @@ impl ViewManager {
                 y: params.y,
                 w: params.w,
                 h: params.h,
-                properties: params.properties.clone().map(|r| r.get_browser_props()),
+                properties: params.properties.map(|r| r.get_browser_props()),
             }))
             .await;
 

--- a/core/main/src/bootstrap/extn/load_extn_metadata_step.rs
+++ b/core/main/src/bootstrap/extn/load_extn_metadata_step.rs
@@ -62,8 +62,8 @@ impl Bootstep<BootstrapState> for LoadExtensionMetadataStep {
     async fn setup(&self, state: BootstrapState) -> Result<(), RippleError> {
         debug!("Starting Extension Library step");
         let manifest = state.platform_state.get_manifest();
-        let default_path = manifest.default_path.clone();
-        let default_extn = manifest.default_extension.clone();
+        let default_path = manifest.default_path;
+        let default_extn = manifest.default_extension;
         let extn_paths: Vec<(String, ExtnManifestEntry)> = manifest
             .extns
             .into_iter()

--- a/core/main/src/bootstrap/extn/load_extn_step.rs
+++ b/core/main/src/bootstrap/extn/load_extn_step.rs
@@ -51,10 +51,10 @@ impl Bootstep<BootstrapState> for LoadExtensionsStep {
         let mut device_channels: Vec<PreLoadedExtnChannel> = Vec::new();
         let mut jsonrpsee_extns: Methods = Methods::new();
         let mut open_rpcs: Vec<OpenRPCParser> = Vec::new();
-        let main_sender = state.clone().extn_state.get_sender();
+        let main_sender = state.extn_state.clone().get_sender();
         for extn in loaded_extensions.iter() {
             unsafe {
-                let path = extn.entry.clone().path;
+                let path = extn.entry.path.clone();
                 let library = &extn.library;
                 info!(
                     "path {} with # of symbols {}",
@@ -101,9 +101,9 @@ impl Bootstep<BootstrapState> for LoadExtensionsStep {
                             let extn_sender = ExtnSender::new(
                                 main_sender.clone(),
                                 extn_id,
-                                extension.clone().uses,
-                                extension.clone().fulfills,
-                                extension.clone().config,
+                                extension.uses,
+                                extension.fulfills,
+                                extension.config,
                             );
                             if let Some(open_rpc) = (builder.get_extended_capabilities)() {
                                 match serde_json::from_str(&open_rpc) {

--- a/core/main/src/bootstrap/extn/start_extn_channel_step.rs
+++ b/core/main/src/bootstrap/extn/start_extn_channel_step.rs
@@ -34,7 +34,7 @@ fn start_preloaded_channel(
 ) -> RippleResponse {
     let client = state.platform_state.get_client();
 
-    if let Err(e) = state.clone().extn_state.start_channel(channel, client) {
+    if let Err(e) = state.extn_state.clone().start_channel(channel, client) {
         error!("Error during Device channel bootstrap");
         return Err(e);
     }
@@ -58,7 +58,7 @@ impl Bootstep<BootstrapState> for StartExtnChannelsStep {
             let mut device_channels = state.extn_state.device_channels.write().unwrap();
             while let Some(device_channel) = device_channels.pop() {
                 let id = device_channel.extn_id.clone();
-                extn_ids.push(id.clone());
+                extn_ids.push(id);
                 if let Err(e) = start_preloaded_channel(&state, device_channel) {
                     error!("Error during Device channel bootstrap");
                     return Err(e);
@@ -70,7 +70,7 @@ impl Bootstep<BootstrapState> for StartExtnChannelsStep {
             let mut deferred_channels = state.extn_state.deferred_channels.write().unwrap();
             while let Some(deferred_channel) = deferred_channels.pop() {
                 let id = deferred_channel.extn_id.clone();
-                extn_ids.push(id.clone());
+                extn_ids.push(id);
                 if let Err(e) = start_preloaded_channel(&state, deferred_channel) {
                     error!("Error during channel bootstrap");
                     return Err(e);

--- a/core/main/src/bootstrap/setup_extn_client_step.rs
+++ b/core/main/src/bootstrap/setup_extn_client_step.rs
@@ -52,15 +52,15 @@ impl Bootstep<BootstrapState> for SetupExtnClientStep {
         client.add_request_processor(ConfigRequestProcessor::new(state.platform_state.clone()));
         client.add_request_processor(PinProcessor::new(state.platform_state.clone()));
         client.add_request_processor(KeyboardProcessor::new(state.platform_state.clone()));
-        client.add_event_processor(ExtnStatusProcessor::new(state.clone().extn_state));
+        client.add_event_processor(ExtnStatusProcessor::new(state.extn_state.clone()));
         client.add_event_processor(AppEventsProcessor::new(state.platform_state.clone()));
         client.add_request_processor(StorageManagerProcessor::new(state.platform_state.clone()));
         client.add_request_processor(StoreUserGrantsProcessor::new(state.platform_state.clone()));
         client.add_request_processor(StorePrivacySettingsProcessor::new(
             state.platform_state.clone(),
         ));
-        client.add_request_processor(AuthorizedInfoProcessor::new(state.clone().platform_state));
-        client.add_request_processor(AccountLinkProcessor::new(state.clone().platform_state));
+        client.add_request_processor(AuthorizedInfoProcessor::new(state.platform_state.clone()));
+        client.add_request_processor(AccountLinkProcessor::new(state.platform_state.clone()));
         client.add_request_processor(SettingsProcessor::new(state.platform_state.clone()));
         client.add_request_processor(MetricsProcessor::new(state.platform_state.clone()));
         client.add_request_processor(OpMetricsProcessor::new(state.platform_state.clone()));

--- a/core/main/src/firebolt/handlers/account_rpc.rs
+++ b/core/main/src/firebolt/handlers/account_rpc.rs
@@ -57,7 +57,7 @@ impl AccountServer for AccountImpl {
     async fn session(&self, _ctx: CallContext, a_t_r: AccountSessionTokenRequest) -> RpcResult<()> {
         self.platform_state
             .session_state
-            .insert_session_token(a_t_r.clone().token);
+            .insert_session_token(a_t_r.token.clone());
         let resp = self
             .platform_state
             .get_client()

--- a/core/main/src/firebolt/handlers/device_rpc.rs
+++ b/core/main/src/firebolt/handlers/device_rpc.rs
@@ -304,7 +304,7 @@ impl DeviceServer for DeviceImpl {
     }
 
     async fn uid(&self, ctx: CallContext) -> RpcResult<String> {
-        get_uid(&self.state, ctx.app_id.clone()).await
+        get_uid(&self.state, ctx.app_id).await
     }
 
     async fn platform(&self, _ctx: CallContext) -> RpcResult<String> {
@@ -320,7 +320,7 @@ impl DeviceServer for DeviceImpl {
         );
         os.readable = format!("Firebolt OS v{}", env!("CARGO_PKG_VERSION"));
 
-        let firmware = self.firmware_info(ctx.clone()).await?;
+        let firmware = self.firmware_info(ctx).await?;
 
         let open_rpc_state = self.state.clone().open_rpc_state;
         let api = open_rpc_state.get_open_rpc().info;

--- a/core/main/src/firebolt/handlers/voice_guidance_rpc.rs
+++ b/core/main/src/firebolt/handlers/voice_guidance_rpc.rs
@@ -261,9 +261,9 @@ impl VoiceguidanceServer for VoiceguidanceImpl {
         request: ListenRequest,
     ) -> RpcResult<ListenerResponse> {
         voice_guidance_settings_enabled_changed(
-            &self.state.clone(),
-            &ctx.clone(),
-            &request.clone(),
+            &self.state,
+            &ctx,
+            &request,
             Some(Box::new(VGEnabledEventDecorator {})),
         )
         .await

--- a/core/main/src/processor/app_events_processor.rs
+++ b/core/main/src/processor/app_events_processor.rs
@@ -70,7 +70,7 @@ impl ExtnEventProcessor for AppEventsProcessor {
     ) -> Option<bool> {
         match extracted_message.clone() {
             AppEventRequest::Emit(event) => {
-                if let Some(app_id) = event.clone().app_id {
+                if let Some(app_id) = event.app_id {
                     let event_name = &event.event_name;
                     let result = &event.result;
                     AppEvents::emit_to_app(&state, app_id, event_name, result).await;

--- a/core/main/src/processor/authorized_info_processor.rs
+++ b/core/main/src/processor/authorized_info_processor.rs
@@ -72,7 +72,7 @@ impl ExtnRequestProcessor for AuthorizedInfoProcessor {
         msg: ExtnMessage,
         extracted_message: Self::VALUE,
     ) -> bool {
-        match extracted_message.clone() {
+        match extracted_message {
             CapsRequest::Permitted(app_id, request) => {
                 let result = state
                     .cap_state

--- a/core/main/src/processor/config_processor.rs
+++ b/core/main/src/processor/config_processor.rs
@@ -89,7 +89,7 @@ impl ExtnRequestProcessor for ConfigRequestProcessor {
                 let config = LauncherConfig {
                     lifecycle_policy: device_manifest.get_lifecycle_policy(),
                     retention_policy: device_manifest.get_retention_policy(),
-                    app_library_state: state.clone().app_library_state,
+                    app_library_state: state.app_library_state.clone(),
                 };
                 if let ExtnPayload::Response(r) = config.get_extn_payload() {
                     r
@@ -107,22 +107,22 @@ impl ExtnRequestProcessor for ConfigRequestProcessor {
                 ExtnResponse::DefaultApp(state.app_library_state.get_default_app().unwrap())
             }
             Config::SavedDir => {
-                ExtnResponse::String(device_manifest.clone().configuration.saved_dir)
+                ExtnResponse::String(device_manifest.configuration.saved_dir.clone())
             }
             Config::FormFactor => ExtnResponse::String(device_manifest.get_form_factor()),
             Config::DistributorExperienceId => {
                 ExtnResponse::String(device_manifest.get_distributor_experience_id())
             }
             Config::DistributorServices => {
-                if let Some(v) = device_manifest.clone().configuration.distributor_services {
-                    ExtnResponse::Value(v)
+                if let Some(v) = &device_manifest.configuration.distributor_services {
+                    ExtnResponse::Value(v.clone())
                 } else {
                     ExtnResponse::None(())
                 }
             }
             Config::IdSalt => {
-                if let Some(v) = device_manifest.clone().configuration.distribution_id_salt {
-                    ExtnResponse::Config(ConfigResponse::IdSalt(v))
+                if let Some(v) = &device_manifest.configuration.distribution_id_salt {
+                    ExtnResponse::Config(ConfigResponse::IdSalt(v.clone()))
                 } else {
                     ExtnResponse::None(())
                 }

--- a/core/main/src/processor/metrics_processor.rs
+++ b/core/main/src/processor/metrics_processor.rs
@@ -251,7 +251,7 @@ impl ExtnRequestProcessor for OpMetricsProcessor {
         msg: ExtnMessage,
         extracted_message: Self::VALUE,
     ) -> bool {
-        let requestor = msg.clone().requestor.to_string();
+        let requestor = msg.requestor.to_string();
         match extracted_message {
             OperationalMetricRequest::Subscribe => state
                 .metrics

--- a/core/main/src/processor/settings_processor.rs
+++ b/core/main/src/processor/settings_processor.rs
@@ -112,7 +112,7 @@ impl SettingsProcessor {
             let mut settings = HashMap::default();
             for sk in request.keys.clone() {
                 use SettingKey::*;
-                let val = match sk.clone() {
+                let val = match sk {
                     VoiceGuidanceEnabled => {
                         let enabled = voice_guidance_settings_enabled(state)
                             .await
@@ -191,15 +191,15 @@ impl SettingsProcessor {
         request: SettingsRequestParam,
     ) -> bool {
         let mut resp = true;
-        let ctx = request.context.clone();
+        let ctx = &request.context;
         debug!("Incoming subscribe request");
-        for key in request.keys.clone() {
+        for key in &request.keys {
             debug!("Checking Key {:?}", key);
             match key {
                 SettingKey::VoiceGuidanceEnabled => {
                     if voice_guidance_settings_enabled_changed(
                         state,
-                        &ctx,
+                        ctx,
                         &ListenRequest { listen: true },
                         Some(Box::new(SettingsChangeEventDecorator {
                             request: request.clone(),
@@ -231,7 +231,7 @@ impl SettingsProcessor {
                     if PrivacyImpl::listen_content_policy_changed(
                         state,
                         true,
-                        &ctx,
+                        ctx,
                         EVENT_ALLOW_PERSONALIZATION_CHANGED,
                         Some(ContentListenRequest {
                             listen: true,
@@ -250,7 +250,7 @@ impl SettingsProcessor {
                     if PrivacyImpl::listen_content_policy_changed(
                         state,
                         true,
-                        &ctx,
+                        ctx,
                         EVENT_ALLOW_WATCH_HISTORY_CHANGED,
                         Some(ContentListenRequest {
                             listen: true,

--- a/core/main/src/state/cap/cap_state.rs
+++ b/core/main/src/state/cap/cap_state.rs
@@ -73,9 +73,9 @@ impl CapState {
         request: CapListenRPCRequest,
     ) {
         let mut r = ps.cap_state.primed_listeners.write().unwrap();
-        if let Some(cap) = FireboltCap::parse(request.clone().capability) {
+        if let Some(cap) = FireboltCap::parse(request.capability) {
             let check = CapEventEntry {
-                app_id: call_context.clone().app_id,
+                app_id: call_context.app_id.clone(),
                 cap,
                 event: event.clone(),
                 role: request.role,
@@ -118,8 +118,8 @@ impl CapState {
         debug!("primed entries {:?}", r);
         if r.iter().any(|x| {
             if x.event == event && x.cap == cap {
-                if let Some(a) = app_id.clone() {
-                    x.app_id.eq(&a)
+                if let Some(a) = &app_id {
+                    x.app_id.eq(a)
                 } else {
                     true
                 }
@@ -138,14 +138,12 @@ impl CapState {
         cap: FireboltCap,
         role: Option<CapabilityRole>,
     ) {
-        match event.clone() {
+        match &event {
             CapEvent::OnAvailable => ps
-                .clone()
                 .cap_state
                 .generic
                 .ingest_availability(vec![cap.clone()], true),
             CapEvent::OnUnavailable => ps
-                .clone()
                 .cap_state
                 .generic
                 .ingest_availability(vec![cap.clone()], true),
@@ -153,12 +151,11 @@ impl CapState {
         }
         // check if given event and capability needs emitting
         if Self::check_primed(ps, event.clone(), cap.clone(), None) {
-            let f = cap.clone().as_str();
-            debug!("preparing cap event emit {}", f);
+            debug!("preparing cap event emit {}", cap.as_str());
             // if its a grant or revoke it could be done per app
             // these require additional
             let is_app_check_necessary =
-                matches!(event.clone(), CapEvent::OnGranted | CapEvent::OnRevoked);
+                matches!(&event, CapEvent::OnGranted | CapEvent::OnRevoked);
             let event_name = format!(
                 "{}.{}",
                 "capabilities",
@@ -177,7 +174,7 @@ impl CapState {
                 let cc = listener.call_ctx.clone();
                 // Step 2: Check if the given event is valid for the app
                 if is_app_check_necessary
-                    && !Self::check_primed(ps, event.clone(), cap.clone(), Some(cc.clone().app_id))
+                    && !Self::check_primed(ps, event.clone(), cap.clone(), Some(cc.app_id.clone()))
                 {
                     continue;
                 }

--- a/core/main/src/state/cap/permitted_state.rs
+++ b/core/main/src/state/cap/permitted_state.rs
@@ -76,7 +76,7 @@ impl PermittedState {
     }
 
     fn get_all_permissions(&self) -> HashMap<String, Vec<FireboltPermission>> {
-        self.permitted.read().unwrap().clone().value
+        self.permitted.read().unwrap().value.clone()
     }
     fn has_cached_permissions(&self, app_id: &String) -> bool {
         // check if the app has permissions cached
@@ -103,7 +103,7 @@ impl PermittedState {
         let mut map = HashMap::new();
         for role_info in request {
             map.insert(
-                role_info.clone().capability.as_str(),
+                role_info.capability.as_str(),
                 if let Ok(v) = self.check_cap_role(app_id, &role_info) {
                     v
                 } else {
@@ -198,15 +198,14 @@ impl PermissionHandler {
         // Create a HashSet to track unique permissions
         let mut unique_permissions = HashSet::new();
 
-        for p in permissions.clone() {
-            if let Some(dependent_list) = dep_lookup.get(&p) {
+        for p in permissions.iter() {
+            if let Some(dependent_list) = dep_lookup.get(p) {
                 deps.extend(dependent_list.iter().cloned());
             }
         }
 
         // Filter out duplicates and insert only unique permissions
-        let unique_deps: Vec<FireboltPermission> = deps.into_iter().collect();
-        for permission in unique_deps {
+        for permission in deps {
             if !unique_permissions.contains(&permission) {
                 permissions.push(permission.clone()); // Clone the permission to avoid the moved value error
                 unique_permissions.insert(permission);

--- a/core/main/src/state/extn_state.rs
+++ b/core/main/src/state/extn_state.rs
@@ -69,7 +69,7 @@ impl LoadedLibrary {
             .symbols
             .iter()
             .filter(|x| x.id.is_channel())
-            .map(|x| x.id.clone().to_string())
+            .map(|x| x.id.to_string())
             .collect();
         info!(
             "getting channels {} lib_metadata={:?} extn_metadata={:?}",
@@ -78,10 +78,10 @@ impl LoadedLibrary {
             self.entry
         );
         self.entry
-            .clone()
             .symbols
-            .into_iter()
+            .iter()
             .filter(|x| extn_ids.contains(&x.id))
+            .cloned()
             .collect()
     }
 
@@ -91,13 +91,13 @@ impl LoadedLibrary {
             .symbols
             .iter()
             .filter(|x| x.id.is_extn())
-            .map(|x| x.id.clone().to_string())
+            .map(|x| x.id.to_string())
             .collect();
         self.entry
-            .clone()
             .symbols
-            .into_iter()
+            .iter()
             .filter(|x| extn_ids.contains(&x.id))
+            .cloned()
             .collect()
     }
 
@@ -196,9 +196,9 @@ impl ExtnState {
         let extn_sender = ExtnSender::new(
             sender,
             extn_id.clone(),
-            symbol.clone().uses,
-            symbol.clone().fulfills,
-            symbol.clone().config,
+            symbol.uses.clone(),
+            symbol.fulfills.clone(),
+            symbol.config.clone(),
         );
         let (extn_tx, extn_rx) = ChannelsState::get_iec_channel();
         let extn_channel = channel.channel;

--- a/core/main/src/state/metrics_state.rs
+++ b/core/main/src/state/metrics_state.rs
@@ -186,7 +186,6 @@ impl MetricsState {
         self.operational_telemetry_listeners
             .read()
             .unwrap()
-            .clone()
             .iter()
             .map(|x| x.to_owned())
             .collect()

--- a/core/main/src/state/openrpc_state.rs
+++ b/core/main/src/state/openrpc_state.rs
@@ -57,7 +57,7 @@ impl OpenRpcState {
         }
 
         for m in addl_rpc.unwrap().methods {
-            rpc.methods.push(m.clone());
+            rpc.methods.push(m);
         }
     }
     pub fn new(exclusory: Option<ExclusoryImpl>) -> OpenRpcState {
@@ -69,8 +69,8 @@ impl OpenRpcState {
         Self::load_additional_rpc(&mut ripple_open_rpc, ripple_rpc_file);
 
         OpenRpcState {
-            firebolt_cap_map: Arc::new(RwLock::new(firebolt_open_rpc.clone().get_methods_caps())),
-            ripple_cap_map: Arc::new(RwLock::new(ripple_open_rpc.clone().get_methods_caps())),
+            firebolt_cap_map: Arc::new(RwLock::new(firebolt_open_rpc.get_methods_caps())),
+            ripple_cap_map: Arc::new(RwLock::new(ripple_open_rpc.get_methods_caps())),
             exclusory,
             cap_policies: Arc::new(RwLock::new(version_manifest.capabilities)),
             open_rpc: firebolt_open_rpc,

--- a/core/main/src/state/session_state.rs
+++ b/core/main/src/state/session_state.rs
@@ -72,7 +72,7 @@ impl Session {
     }
 
     pub fn get_transport(&self) -> EffectiveTransport {
-        self.data.clone().transport
+        self.data.transport.clone()
     }
 }
 

--- a/core/sdk/src/api/device/device_user_grants_data.rs
+++ b/core/sdk/src/api/device/device_user_grants_data.rs
@@ -175,18 +175,18 @@ impl GrantPolicies {
     pub fn get_policy(&self, permission: &FireboltPermission) -> Option<GrantPolicy> {
         match permission.role {
             CapabilityRole::Use => {
-                if self.use_.is_some() {
-                    return Some(self.use_.clone().unwrap());
+                if let Some(value) = &self.use_ {
+                    return Some(value.clone());
                 }
             }
             CapabilityRole::Manage => {
-                if self.manage.is_some() {
-                    return Some(self.manage.clone().unwrap());
+                if let Some(manage) = &self.manage {
+                    return Some(manage.clone());
                 }
             }
             CapabilityRole::Provide => {
-                if self.provide.is_some() {
-                    return Some(self.provide.clone().unwrap());
+                if let Some(provide) = &self.provide {
+                    return Some(provide.clone());
                 }
             }
         }

--- a/core/sdk/src/api/settings.rs
+++ b/core/sdk/src/api/settings.rs
@@ -93,8 +93,8 @@ impl SettingsRequestParam {
     }
 
     pub fn get_alias(&self, key: &SettingKey) -> String {
-        if let Some(alias) = self.alias_map.clone() {
-            if let Some(s) = alias.get(key.to_string().as_str()) {
+        if let Some(alias) = &self.alias_map {
+            if let Some(s) = alias.get(&key.to_string()) {
                 return s.to_owned();
             }
         }

--- a/core/sdk/src/extn/client/extn_processor.rs
+++ b/core/sdk/src/extn/client/extn_processor.rs
@@ -216,12 +216,12 @@ pub trait ExtnRequestProcessor: ExtnStreamProcessor + Send + Sync + 'static {
         });
     }
 
-    async fn handle_error(extn_client: ExtnClient, req: ExtnMessage, error: RippleError) -> bool {
-        if let Err(e) = extn_client
-            .clone()
-            .respond(req, ExtnResponse::Error(error))
-            .await
-        {
+    async fn handle_error(
+        mut extn_client: ExtnClient,
+        req: ExtnMessage,
+        error: RippleError,
+    ) -> bool {
+        if let Err(e) = extn_client.respond(req, ExtnResponse::Error(error)).await {
             error!("Error during responding {:?}", e);
         }
         // to support return chaining in processors

--- a/core/sdk/src/extn/client/extn_sender.rs
+++ b/core/sdk/src/extn/client/extn_sender.rs
@@ -86,7 +86,7 @@ impl ExtnSender {
     }
 
     pub fn get_config(&self, key: &str) -> Option<String> {
-        if let Some(c) = self.config.clone() {
+        if let Some(c) = &self.config {
             if let Some(v) = c.get(key) {
                 return Some(v.clone());
             }

--- a/core/sdk/src/extn/extn_client_message.rs
+++ b/core/sdk/src/extn/extn_client_message.rs
@@ -100,7 +100,7 @@ impl ExtnMessage {
     ///
     /// Note: If used in a processor this method can be safely unwrapped
     pub fn get_response(&self, response: ExtnResponse) -> Result<ExtnMessage, RippleError> {
-        match self.clone().payload {
+        match self.payload {
             ExtnPayload::Request(_) => Ok(ExtnMessage {
                 callback: self.callback.clone(),
                 id: self.id.clone(),

--- a/core/sdk/src/extn/ffi/ffi_library.rs
+++ b/core/sdk/src/extn/ffi/ffi_library.rs
@@ -86,7 +86,7 @@ impl From<ExtnMetadata> for CExtnMetadata {
         let mut metadata: Vec<CExtnSymbolMetadata> = Vec::new();
         for data in value.symbols {
             metadata.push(CExtnSymbolMetadata {
-                id: data.clone().id.to_string(),
+                id: data.id.to_string(),
                 fulfills: data.clone().fulfills.into(),
                 required_version: data.get_version().to_string(),
             });

--- a/device/thunder_ripple_sdk/src/bootstrap/setup_thunder_processors.rs
+++ b/device/thunder_ripple_sdk/src/bootstrap/setup_thunder_processors.rs
@@ -46,7 +46,7 @@ impl SetupThunderProcessor {
         extn_client.add_request_processor(ThunderWifiRequestProcessor::new(state.clone().state));
         extn_client.add_request_processor(ThunderStorageRequestProcessor::new(state.clone().state));
         extn_client.add_request_processor(ThunderWindowManagerRequestProcessor::new(
-            state.clone().state,
+            state.state.clone(),
         ));
         extn_client.add_request_processor(ThunderRemoteAccessoryRequestProcessor::new(
             state.clone().state,

--- a/distributor/general/src/general_advertising_processor.rs
+++ b/distributor/general/src/general_advertising_processor.rs
@@ -75,14 +75,13 @@ impl ExtnRequestProcessor for DistributorAdvertisingProcessor {
         self.client.clone()
     }
     async fn process_request(
-        state: Self::STATE,
+        mut state: Self::STATE,
         msg: ripple_sdk::extn::extn_client_message::ExtnMessage,
         extracted_message: Self::VALUE,
     ) -> bool {
         match extracted_message {
             AdvertisingRequest::ResetAdIdentifier(_session) => {
                 if let Err(e) = state
-                    .clone()
                     .respond(
                         msg,
                         ripple_sdk::extn::extn_client_message::ExtnResponse::None(()),
@@ -117,7 +116,6 @@ impl ExtnRequestProcessor for DistributorAdvertisingProcessor {
             };
 
                 if let Err(e) = state
-                    .clone()
                     .respond(
                         msg,
                         if let ExtnPayload::Response(r) =
@@ -145,7 +143,6 @@ impl ExtnRequestProcessor for DistributorAdvertisingProcessor {
                     lmt: "0".into(),
                 };
                 if let Err(e) = state
-                    .clone()
                     .respond(
                         msg,
                         if let ExtnPayload::Response(r) =

--- a/distributor/general/src/general_discovery_processor.rs
+++ b/distributor/general/src/general_discovery_processor.rs
@@ -69,12 +69,11 @@ impl ExtnRequestProcessor for DistributorDiscoveryProcessor {
         self.client.clone()
     }
     async fn process_request(
-        state: Self::STATE,
+        mut state: Self::STATE,
         msg: ripple_sdk::extn::extn_client_message::ExtnMessage,
         _: Self::VALUE,
     ) -> bool {
         state
-            .clone()
             .respond(
                 msg,
                 ripple_sdk::extn::extn_client_message::ExtnResponse::None(()),

--- a/distributor/general/src/general_media_events_processor.rs
+++ b/distributor/general/src/general_media_events_processor.rs
@@ -69,12 +69,11 @@ impl ExtnRequestProcessor for DistributorMediaEventProcessor {
         self.client.clone()
     }
     async fn process_request(
-        state: Self::STATE,
+        mut state: Self::STATE,
         msg: ripple_sdk::extn::extn_client_message::ExtnMessage,
         _: Self::VALUE,
     ) -> bool {
         state
-            .clone()
             .respond(
                 msg,
                 ripple_sdk::extn::extn_client_message::ExtnResponse::None(()),

--- a/distributor/general/src/general_metrics_processor.rs
+++ b/distributor/general/src/general_metrics_processor.rs
@@ -70,14 +70,13 @@ impl ExtnRequestProcessor for DistributorMetricsProcessor {
         self.client.clone()
     }
     async fn process_request(
-        state: Self::STATE,
+        mut state: Self::STATE,
         msg: ripple_sdk::extn::extn_client_message::ExtnMessage,
         extracted_message: Self::VALUE,
     ) -> bool {
         match extracted_message.clone().payload {
             BehavioralMetricPayload::Ready(_) => {
                 if let Err(e) = state
-                    .clone()
                     .respond(
                         msg,
                         ripple_sdk::extn::extn_client_message::ExtnResponse::Boolean(true),
@@ -155,12 +154,11 @@ impl ExtnRequestProcessor for DistributorMetricsProcessor {
 
 /// listener for events any events.
 pub async fn mock_metrics_response(
-    state: ExtnClient,
+    mut state: ExtnClient,
     msg: ripple_sdk::extn::extn_client_message::ExtnMessage,
     _extracted_message: BehavioralMetricRequest,
 ) -> bool {
     if let Err(e) = state
-        .clone()
         .respond(
             msg,
             ripple_sdk::extn::extn_client_message::ExtnResponse::Boolean(true),

--- a/distributor/general/src/general_permission_processor.rs
+++ b/distributor/general/src/general_permission_processor.rs
@@ -100,7 +100,7 @@ impl ExtnRequestProcessor for DistributorPermissionProcessor {
         self.state.client.clone()
     }
     async fn process_request(
-        state: Self::STATE,
+        mut state: Self::STATE,
         msg: ripple_sdk::extn::extn_client_message::ExtnMessage,
         extracted_message: Self::VALUE,
     ) -> bool {
@@ -111,7 +111,6 @@ impl ExtnRequestProcessor for DistributorPermissionProcessor {
             );
             if let Err(e) = state
                 .client
-                .clone()
                 .respond(msg, ExtnResponse::Permission(v.clone()))
                 .await
             {

--- a/distributor/general/src/general_securestorage_processor.rs
+++ b/distributor/general/src/general_securestorage_processor.rs
@@ -76,14 +76,13 @@ impl ExtnRequestProcessor for DistributorSecureStorageProcessor {
         self.client.clone()
     }
     async fn process_request(
-        state: Self::STATE,
+        mut state: Self::STATE,
         msg: ripple_sdk::extn::extn_client_message::ExtnMessage,
         extracted_message: Self::VALUE,
     ) -> bool {
         match extracted_message {
             SecureStorageRequest::Set(_req, _session) => {
                 if let Err(e) = state
-                    .clone()
                     .respond(
                         msg,
                         ripple_sdk::extn::extn_client_message::ExtnResponse::SecureStorage(
@@ -103,7 +102,6 @@ impl ExtnRequestProcessor for DistributorSecureStorageProcessor {
                 };
 
                 if let Err(e) = state
-                    .clone()
                     .respond(
                         msg,
                         if let ExtnPayload::Response(r) =
@@ -126,7 +124,6 @@ impl ExtnRequestProcessor for DistributorSecureStorageProcessor {
 
             SecureStorageRequest::Remove(_req, _session) => {
                 if let Err(e) = state
-                    .clone()
                     .respond(
                         msg,
                         ripple_sdk::extn::extn_client_message::ExtnResponse::SecureStorage(
@@ -143,7 +140,6 @@ impl ExtnRequestProcessor for DistributorSecureStorageProcessor {
 
             SecureStorageRequest::Clear(_req, _session) => {
                 if let Err(e) = state
-                    .clone()
                     .respond(
                         msg,
                         ripple_sdk::extn::extn_client_message::ExtnResponse::SecureStorage(

--- a/distributor/general/src/general_session_processor.rs
+++ b/distributor/general/src/general_session_processor.rs
@@ -101,7 +101,7 @@ impl DistributorSessionProcessor {
             return false;
         }
 
-        Self::handle_error(state.clone().client, msg, RippleError::ExtnError).await
+        Self::handle_error(state.client, msg, RippleError::ExtnError).await
     }
 
     async fn set_token(
@@ -187,7 +187,7 @@ impl ExtnStreamProcessor for DistributorSessionProcessor {
 #[async_trait]
 impl ExtnRequestProcessor for DistributorSessionProcessor {
     fn get_client(&self) -> ExtnClient {
-        self.state.clone().client
+        self.state.client.clone()
     }
     async fn process_request(
         state: Self::STATE,
@@ -195,13 +195,11 @@ impl ExtnRequestProcessor for DistributorSessionProcessor {
         extracted_message: Self::VALUE,
     ) -> bool {
         match extracted_message {
-            AccountSessionRequest::Get => Self::get_token(state.clone(), msg).await,
-            AccountSessionRequest::Provision(p) => Self::provision(state.clone(), msg, p).await,
+            AccountSessionRequest::Get => Self::get_token(state, msg).await,
+            AccountSessionRequest::Provision(p) => Self::provision(state, msg, p).await,
             AccountSessionRequest::SetAccessToken(s) => Self::set_token(state, msg, s).await,
-            AccountSessionRequest::GetAccessToken => {
-                Self::get_accesstoken(state.clone(), msg).await
-            }
-            AccountSessionRequest::Subscribe => Self::ack(state.clone().client, msg).await.is_ok(),
+            AccountSessionRequest::GetAccessToken => Self::get_accesstoken(state, msg).await,
+            AccountSessionRequest::Subscribe => Self::ack(state.client, msg).await.is_ok(),
         }
     }
 }


### PR DESCRIPTION
* Remove unnecessary clones

Removes unnecessary clones by:
  1) Removing the clone() call 2) Borrowing the value instead 3) Defering the clone() call on the item that needs to be cloned and not the whole containing datastructure

* Fixed lint and formatting issues

