### PR TITLE
fix: Context update

### DIFF
--- a/core/main/src/processor/main_context_processor.rs
+++ b/core/main/src/processor/main_context_processor.rs
@@ -30,14 +30,14 @@ use ripple_sdk::{
         distributor::distributor_sync::{SyncAndMonitorModule, SyncAndMonitorRequest},
         firebolt::fb_capabilities::{CapEvent, FireboltCap},
         manifest::device_manifest::PrivacySettingsStorageType,
-        session::AccountSessionRequest,
+        session::{AccountSessionRequest, AccountSessionResponse},
     },
     async_trait::async_trait,
     extn::{
         client::extn_processor::{
             DefaultExtnStreamer, ExtnEventProcessor, ExtnStreamProcessor, ExtnStreamer,
         },
-        extn_client_message::ExtnMessage,
+        extn_client_message::{ExtnMessage, ExtnResponse},
     },
     log::{debug, error, info},
     tokio::{
@@ -77,6 +77,9 @@ impl MainContextProcessor {
         }
     }
 
+    ///
+    /// Method which gets called on bootstrap for a presence of account session
+    ///
     async fn check_account_session_token(state: &PlatformState) -> bool {
         let mut token_available = false;
         let mut event = CapEvent::OnUnavailable;
@@ -90,6 +93,26 @@ impl MainContextProcessor {
                 state.session_state.insert_account_session(session);
                 MetricsState::update_account_session(state).await;
                 event = CapEvent::OnAvailable;
+                let state_c = state.clone();
+                // update ripple context for token asynchronously
+                tokio::spawn(async move {
+                    if let Ok(response) = state_c
+                        .get_client()
+                        .send_extn_request(AccountSessionRequest::GetAccessToken)
+                        .await
+                    {
+                        if let Some(ExtnResponse::AccountSession(
+                            AccountSessionResponse::AccountSessionToken(token),
+                        )) = response.payload.extract::<ExtnResponse>()
+                        {
+                            state_c.get_client().get_extn_client().context_update(
+                                ripple_sdk::api::context::RippleContextUpdateRequest::Token(token),
+                            )
+                        } else {
+                            error!("couldnt update the session response")
+                        }
+                    }
+                });
                 token_available = true;
             }
         }

--- a/core/sdk/src/extn/client/extn_client.rs
+++ b/core/sdk/src/extn/client/extn_client.rs
@@ -311,7 +311,7 @@ impl ExtnClient {
             let senders = self.get_other_senders();
 
             for sender in senders {
-                let send_res = sender.send(c_message.clone());
+                let send_res = sender.try_send(c_message.clone());
                 trace!("Send to other client result: {:?}", send_res);
             }
         }


### PR DESCRIPTION
## What

Fixes context updates broadcasting between main and extensions 

## Why

Extensions need to know when ripple context like Token, PowerChanged, Internet are updated. Recent changes in the IEC channel broke the sender. This change fixes it

## How

Uses try_send method instead of send method which addresses the issue as send returns a future and doesnt actually send the message to the extensions.

## Test

On Ripple startup each extension gets the list of Ripple context updates for Token, InternetStatus and Power status of the device.

## Checklist

- [x] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
