### PR TITLE
fix: stop updating token in a loop

### DIFF
--- a/core/main/src/bootstrap/extn/load_session_step.rs
+++ b/core/main/src/bootstrap/extn/load_session_step.rs
@@ -41,7 +41,7 @@ impl Bootstep<BootstrapState> for LoadDistributorValuesStep {
         if !s.platform_state.supports_session() {
             return Ok(());
         }
-        MainContextProcessor::initialize_token(&s.platform_state).await;
+        MainContextProcessor::initialize_session(&s.platform_state).await;
         // Session available during startup make sure the context is updated with the token for first time
         if s.platform_state
             .session_state

--- a/core/main/src/bootstrap/extn/load_session_step.rs
+++ b/core/main/src/bootstrap/extn/load_session_step.rs
@@ -42,6 +42,15 @@ impl Bootstep<BootstrapState> for LoadDistributorValuesStep {
             return Ok(());
         }
         MainContextProcessor::initialize_token(&s.platform_state).await;
+        // Session available during startup make sure the context is updated with the token for first time
+        if s.platform_state
+            .session_state
+            .get_account_session()
+            .is_some()
+        {
+            ContextManager::update_context_for_session(s.platform_state.clone());
+        }
+
         s.platform_state
             .get_client()
             .add_event_processor(MainContextProcessor::new(s.platform_state.clone()));

--- a/core/main/src/processor/main_context_processor.rs
+++ b/core/main/src/processor/main_context_processor.rs
@@ -129,7 +129,7 @@ impl MainContextProcessor {
             });
         });
     }
-    pub async fn initialize_token(state: &PlatformState) {
+    pub async fn initialize_session(state: &PlatformState) {
         if !Self::check_account_session_token(state).await {
             error!("Account session still not available");
         } else if state.supports_cloud_sync() {
@@ -218,7 +218,7 @@ impl ExtnEventProcessor for MainContextProcessor {
                     {
                         //Call initialize token only when account session was not initialized the first time
                         if state.state.session_state.get_account_session().is_none() {
-                            Self::initialize_token(&state.state).await
+                            Self::initialize_session(&state.state).await
                         } else {
                             // update the token
                             state

--- a/core/main/src/processor/main_context_processor.rs
+++ b/core/main/src/processor/main_context_processor.rs
@@ -30,14 +30,14 @@ use ripple_sdk::{
         distributor::distributor_sync::{SyncAndMonitorModule, SyncAndMonitorRequest},
         firebolt::fb_capabilities::{CapEvent, FireboltCap},
         manifest::device_manifest::PrivacySettingsStorageType,
-        session::{AccountSessionRequest, AccountSessionResponse},
+        session::AccountSessionRequest,
     },
     async_trait::async_trait,
     extn::{
         client::extn_processor::{
             DefaultExtnStreamer, ExtnEventProcessor, ExtnStreamProcessor, ExtnStreamer,
         },
-        extn_client_message::{ExtnMessage, ExtnResponse},
+        extn_client_message::ExtnMessage,
     },
     log::{debug, error, info},
     tokio::{
@@ -93,31 +93,6 @@ impl MainContextProcessor {
                 state.session_state.insert_account_session(session);
                 MetricsState::update_account_session(state).await;
                 event = CapEvent::OnAvailable;
-                let state_c = state.clone();
-                if !state_c.get_client().get_extn_client().has_token() {
-                    // update ripple context for token asynchronously
-                    tokio::spawn(async move {
-                        if let Ok(response) = state_c
-                            .get_client()
-                            .send_extn_request(AccountSessionRequest::GetAccessToken)
-                            .await
-                        {
-                            if let Some(ExtnResponse::AccountSession(
-                                AccountSessionResponse::AccountSessionToken(token),
-                            )) = response.payload.extract::<ExtnResponse>()
-                            {
-                                state_c.get_client().get_extn_client().context_update(
-                                    ripple_sdk::api::context::RippleContextUpdateRequest::Token(
-                                        token,
-                                    ),
-                                )
-                            } else {
-                                error!("couldnt update the session response")
-                            }
-                        }
-                    });
-                }
-
                 token_available = true;
             }
         }
@@ -130,6 +105,7 @@ impl MainContextProcessor {
         .await;
         token_available
     }
+
     async fn sync_partner_exclusions(state: &PlatformState) {
         let state_for_exclusion = state.clone();
         START_PARTNER_EXCLUSION_SYNC_THREAD.call_once(|| {
@@ -238,9 +214,18 @@ impl ExtnEventProcessor for MainContextProcessor {
         if let Some(update) = &extracted_message.update_type {
             match update {
                 RippleContextUpdateType::TokenChanged => {
-                    if let ActivationStatus::AccountToken(_t) = &extracted_message.activation_status
+                    if let ActivationStatus::AccountToken(t) = &extracted_message.activation_status
                     {
-                        Self::initialize_token(&state.state).await
+                        //Call initialize token only when account session was not initialized the first time
+                        if state.state.session_state.get_account_session().is_none() {
+                            Self::initialize_token(&state.state).await
+                        } else {
+                            // update the token
+                            state
+                                .state
+                                .session_state
+                                .insert_session_token(t.token.clone())
+                        }
                     }
                 }
                 RippleContextUpdateType::PowerStateChanged => {


### PR DESCRIPTION
## What

Changes for #379  Caused an infinite loop of token updates.

## Why

There was no check for tokens before updating it first time.

## How

Checking for the presence of tokens before updating.

## Test

How has this been tested? How can a reviewer test it?

## Checklist

- [ ] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
