### PR TITLE
Intent forgiving

### DIFF
--- a/core/sdk/src/api/device/entertainment_data.rs
+++ b/core/sdk/src/api/device/entertainment_data.rs
@@ -310,7 +310,7 @@ impl ProviderResult {
     pub fn new(entries: HashMap<String, Vec<String>>) -> Self {
         ProviderResult { entries }
     }
-}Pr
+}
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
 #[serde(rename_all = "camelCase")]

--- a/core/sdk/src/api/device/entertainment_data.rs
+++ b/core/sdk/src/api/device/entertainment_data.rs
@@ -204,6 +204,7 @@ impl Default for EntityInfo {
 pub const SYNOPSIS: &str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Pulvinar sapien et ligula ullamcorper malesuada proin libero nunc.";
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
 pub enum ProgramType {
     Movie,
     Episode,
@@ -309,7 +310,7 @@ impl ProviderResult {
     pub fn new(entries: HashMap<String, Vec<String>>) -> Self {
         ProviderResult { entries }
     }
-}
+}Pr
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
## What

Makes intents deseralization more forgiving

## Why

Some systems may be sending intents that are not 100% to the firebolt spec with minor differences. Such as casing of enumeration values or leaving off fields that can be easily assumed. It is better for Ripple to not fail on these cases

## How

If an intent is missing the field entityType, but has the field programType. We can infer that entityType should be "program" and parse as if it is a program entity.

Make programType handle some other common casing options for the enumeration value. For example before this change, Ripple would only accept intents with programType=movie, after the change it can accept Movie and MOVIE.

## Test

Have an app subscript to Discovery.onNavigateTo.
Call LifecycleManagement.session with an intent like:
```
{
  "action": "entity",
  "data": {
    "entityId": "abc",
    "programType": "Movie"
  },
  "context": {
    "source": "device"
  }
}
```

Notice how the data is missing "entityType" but has programType=Movie.

This should result in the onNavigateTo event to fire with intent:
```
{
  "action": "entity",
  "context": {
    "source": "device"
  },
  "data": {
    "entityId": "abc",
    "entityType": "program",
    "programType": "movie"
  }
}
```

## Checklist

- [x] I have self-reviewed this PR
- [x] I have added tests that prove the feature works or the fix is effective
