### PR TITLE
fix: internal.initialize response

### DIFF
--- a/core/main/src/firebolt/handlers/metrics_rpc.rs
+++ b/core/main/src/firebolt/handlers/metrics_rpc.rs
@@ -49,8 +49,6 @@ use crate::{
     utils::rpc_utils::rpc_err,
 };
 
-use ripple_sdk::api::firebolt::fb_metrics::SemanticVersion;
-
 //const LAUNCH_COMPLETED_SEGMENT: &'static str = "LAUNCH_COMPLETED";
 
 #[derive(Deserialize, Debug)]
@@ -426,10 +424,7 @@ impl MetricsServer for MetricsImpl {
             readable: readable_result,
         };
         Ok(InternalInitializeResponse {
-            name: String::from("Default Result"),
-            value: SemanticVersion {
-                version: internal_initialize_resp,
-            },
+            version: internal_initialize_resp,
         })
     }
     async fn media_load_start(

--- a/core/sdk/src/api/firebolt/fb_metrics.rs
+++ b/core/sdk/src/api/firebolt/fb_metrics.rs
@@ -76,8 +76,7 @@ pub struct InternalInitializeParams {
 
 #[derive(Deserialize, Debug, Clone, Serialize)]
 pub struct InternalInitializeResponse {
-    pub name: String,
-    pub value: SemanticVersion,
+    pub version: Version,
 }
 
 #[async_trait]


### PR DESCRIPTION
## What

The API response is returned as the following currently:
```
{
	"name": "Default Result",
	"value": {
		"version": {
		"major": 1,
		"minor": 0,
		"patch": 0,
		"readable": "Firebolt FEE 1.0.0"
	}
} 
```


This PR fixes internal.initialize response to be like:
```
{
      "version": { 
      "major": 1, 
      "minor": 0, 
      "patch": 0, 
      "readable": 
      "Firebolt FEE 1.0.0" 
      } 
}
```


## Why

To compliant with the Firebolt specification

## How

How do these changes achieve the goal?

## Test

How has this been tested? How can a reviewer test it?

## Checklist

- [x] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
