### PR TITLE
Rdk 6.1 fixes for FCA test failures.

### DIFF
--- a/distributor/general/src/distributor_general_ffi.rs
+++ b/distributor/general/src/distributor_general_ffi.rs
@@ -42,13 +42,15 @@ use ripple_sdk::{
 use crate::{
     general_advertising_processor::DistributorAdvertisingProcessor,
     general_discovery_processor::DistributorDiscoveryProcessor,
+    general_distributor_token_processor::DistributorTokenProcessor,
     general_media_events_processor::DistributorMediaEventProcessor,
     general_metrics_processor::DistributorMetricsProcessor,
+    general_paltform_token_processor::PlatformTokenProcessor,
     general_permission_processor::DistributorPermissionProcessor,
     general_privacy_processor::DistributorPrivacyProcessor,
     general_securestorage_processor::DistributorSecureStorageProcessor,
     general_session_processor::DistributorSessionProcessor,
-    general_token_processor::DistributorTokenProcessor,
+    general_token_processor::GeneralTokenProcessor,
 };
 
 fn init_library() -> CExtnMetadata {
@@ -67,6 +69,8 @@ fn init_library() -> CExtnMetadata {
             RippleContract::Session(SessionAdjective::Device),
             RippleContract::Discovery,
             RippleContract::MediaEvents,
+            RippleContract::Session(SessionAdjective::Distributor),
+            RippleContract::Session(SessionAdjective::Platform),
         ]),
         Version::new(1, 1, 0),
     );
@@ -106,9 +110,11 @@ fn start_launcher(sender: ExtnSender, receiver: CReceiver<CExtnMessage>) {
             client.add_request_processor(DistributorSecureStorageProcessor::new(client.clone()));
             client.add_request_processor(DistributorAdvertisingProcessor::new(client.clone()));
             client.add_request_processor(DistributorMetricsProcessor::new(client.clone()));
-            client.add_request_processor(DistributorTokenProcessor::new(client.clone()));
+            client.add_request_processor(GeneralTokenProcessor::new(client.clone()));
             client.add_request_processor(DistributorDiscoveryProcessor::new(client.clone()));
             client.add_request_processor(DistributorMediaEventProcessor::new(client.clone()));
+            client.add_request_processor(DistributorTokenProcessor::new(client.clone()));
+            client.add_request_processor(PlatformTokenProcessor::new(client.clone()));
 
             // Lets Main know that the distributor channel is ready
             let _ = client.event(ExtnStatus::Ready);

--- a/distributor/general/src/general_distributor_token_processor.rs
+++ b/distributor/general/src/general_distributor_token_processor.rs
@@ -17,8 +17,9 @@
 
 use ripple_sdk::{
     api::{
+        distributor::distributor_token::DistributorTokenRequest,
         firebolt::fb_authentication::TokenResult,
-        session::{SessionAdjective, SessionTokenRequest},
+        session::{SessionAdjective, TokenType},
     },
     async_trait::async_trait,
     extn::{
@@ -33,23 +34,23 @@ use ripple_sdk::{
     framework::ripple_contract::RippleContract,
 };
 
-pub struct GeneralTokenProcessor {
+pub struct DistributorTokenProcessor {
     client: ExtnClient,
     streamer: DefaultExtnStreamer,
 }
 
-impl GeneralTokenProcessor {
-    pub fn new(client: ExtnClient) -> GeneralTokenProcessor {
-        GeneralTokenProcessor {
+impl DistributorTokenProcessor {
+    pub fn new(client: ExtnClient) -> DistributorTokenProcessor {
+        DistributorTokenProcessor {
             client,
             streamer: DefaultExtnStreamer::new(),
         }
     }
 }
 
-impl ExtnStreamProcessor for GeneralTokenProcessor {
+impl ExtnStreamProcessor for DistributorTokenProcessor {
     type STATE = ExtnClient;
-    type VALUE = SessionTokenRequest;
+    type VALUE = DistributorTokenRequest;
 
     fn get_state(&self) -> Self::STATE {
         self.client.clone()
@@ -72,24 +73,21 @@ impl ExtnStreamProcessor for GeneralTokenProcessor {
     fn fulfills_mutiple(
         &self,
     ) -> Option<Vec<ripple_sdk::framework::ripple_contract::RippleContract>> {
-        Some(vec![
-            RippleContract::Session(SessionAdjective::Root),
-            RippleContract::Session(SessionAdjective::Device),
-        ])
+        Some(vec![RippleContract::Session(SessionAdjective::Distributor)])
     }
 }
 
 #[async_trait]
-impl ExtnRequestProcessor for GeneralTokenProcessor {
+impl ExtnRequestProcessor for DistributorTokenProcessor {
     fn get_client(&self) -> ExtnClient {
         self.client.clone()
     }
     async fn process_request(
         state: Self::STATE,
         msg: ripple_sdk::extn::extn_client_message::ExtnMessage,
-        extracted_message: Self::VALUE,
+        _extracted_message: Self::VALUE,
     ) -> bool {
-        let token = ExtnResponse::Token(TokenResult {_type:extracted_message.clone().token_type,expires:None,value:"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c".into(),scope:None,expires_in:None, token_type: None });
+        let token = ExtnResponse::Token(TokenResult {_type:TokenType::Distributor,expires:None,value:"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c".into(),scope:None,expires_in:None, token_type: None });
         Self::respond(state.clone(), msg, token).await.is_ok()
     }
 }

--- a/distributor/general/src/general_paltform_token_processor.rs
+++ b/distributor/general/src/general_paltform_token_processor.rs
@@ -17,8 +17,9 @@
 
 use ripple_sdk::{
     api::{
+        distributor::distributor_platform::PlatformTokenRequest,
         firebolt::fb_authentication::TokenResult,
-        session::{SessionAdjective, SessionTokenRequest},
+        session::{SessionAdjective, TokenType},
     },
     async_trait::async_trait,
     extn::{
@@ -33,23 +34,23 @@ use ripple_sdk::{
     framework::ripple_contract::RippleContract,
 };
 
-pub struct GeneralTokenProcessor {
+pub struct PlatformTokenProcessor {
     client: ExtnClient,
     streamer: DefaultExtnStreamer,
 }
 
-impl GeneralTokenProcessor {
-    pub fn new(client: ExtnClient) -> GeneralTokenProcessor {
-        GeneralTokenProcessor {
+impl PlatformTokenProcessor {
+    pub fn new(client: ExtnClient) -> PlatformTokenProcessor {
+        PlatformTokenProcessor {
             client,
             streamer: DefaultExtnStreamer::new(),
         }
     }
 }
 
-impl ExtnStreamProcessor for GeneralTokenProcessor {
+impl ExtnStreamProcessor for PlatformTokenProcessor {
     type STATE = ExtnClient;
-    type VALUE = SessionTokenRequest;
+    type VALUE = PlatformTokenRequest;
 
     fn get_state(&self) -> Self::STATE {
         self.client.clone()
@@ -72,24 +73,21 @@ impl ExtnStreamProcessor for GeneralTokenProcessor {
     fn fulfills_mutiple(
         &self,
     ) -> Option<Vec<ripple_sdk::framework::ripple_contract::RippleContract>> {
-        Some(vec![
-            RippleContract::Session(SessionAdjective::Root),
-            RippleContract::Session(SessionAdjective::Device),
-        ])
+        Some(vec![RippleContract::Session(SessionAdjective::Platform)])
     }
 }
 
 #[async_trait]
-impl ExtnRequestProcessor for GeneralTokenProcessor {
+impl ExtnRequestProcessor for PlatformTokenProcessor {
     fn get_client(&self) -> ExtnClient {
         self.client.clone()
     }
     async fn process_request(
         state: Self::STATE,
         msg: ripple_sdk::extn::extn_client_message::ExtnMessage,
-        extracted_message: Self::VALUE,
+        _extracted_message: Self::VALUE,
     ) -> bool {
-        let token = ExtnResponse::Token(TokenResult {_type:extracted_message.clone().token_type,expires:None,value:"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c".into(),scope:None,expires_in:None, token_type: None });
+        let token = ExtnResponse::Token(TokenResult {_type:TokenType::Distributor,expires:None,value:"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c".into(),scope:None,expires_in:None, token_type: None });
         Self::respond(state.clone(), msg, token).await.is_ok()
     }
 }

--- a/distributor/general/src/lib.rs
+++ b/distributor/general/src/lib.rs
@@ -18,8 +18,10 @@
 mod distributor_general_ffi;
 mod general_advertising_processor;
 mod general_discovery_processor;
+mod general_distributor_token_processor;
 mod general_media_events_processor;
 mod general_metrics_processor;
+mod general_paltform_token_processor;
 mod general_permission_processor;
 mod general_privacy_processor;
 mod general_securestorage_processor;

--- a/examples/reference-manifest/IpStb/firebolt-device-manifest.json
+++ b/examples/reference-manifest/IpStb/firebolt-device-manifest.json
@@ -50,6 +50,9 @@
           ],
           "refui": [
             "*"
+          ],
+          "comcast.test.firecert": [
+            "*"
           ]
         }
       },
@@ -130,7 +133,12 @@
       "xrn:firebolt:capability:usergrant:acknowledgechallenge",
       "xrn:firebolt:capability:input:keyboard",
       "xrn:firebolt:capability:remote:ble",
-      "xrn:firebolt:capability:storage:secure"
+      "xrn:firebolt:capability:storage:secure",
+      "xrn:firebolt:capability:token:account",
+      "xrn:firebolt:capability:token:platform",
+      "xrn:firebolt:capability:token:device",
+      "xrn:firebolt:capability:token:session",
+      "xrn:firebolt:capability:token:root"
     ],
     "grantPolicies": {
       "xrn:firebolt:capability:device:id": {

--- a/examples/reference-manifest/IpStb/firebolt-device-manifest.json
+++ b/examples/reference-manifest/IpStb/firebolt-device-manifest.json
@@ -1,4 +1,4 @@
-{
+  {
   "configuration": {
     "ws_configuration": {
       "enabled": true,
@@ -49,9 +49,6 @@
             "*"
           ],
           "refui": [
-            "*"
-          ],
-          "comcast.test.firecert": [
             "*"
           ]
         }

--- a/examples/reference-manifest/IpStb/firebolt-extn-manifest.json
+++ b/examples/reference-manifest/IpStb/firebolt-extn-manifest.json
@@ -31,7 +31,8 @@
                         "network.device_events",
                         "internet.device_events",
                         "audio.device_events",
-                        "system_power_state.device_events"
+                        "system_power_state.device_events",
+                        "time_zone.device_events"
                     ]
                 }
             ]
@@ -65,6 +66,10 @@
                     "fulfills": [
                         "permissions",
                         "account.session",
+                        "device.session",
+                        "distributor.session",
+                        "platform.session",
+                        "root.session",
                         "secure.storage",
                         "advertising",
                         "media_events",
@@ -90,6 +95,8 @@
         "privacy_settings",
         "metrics",
         "account.session",
+        "device.session",
+        "distributor.session",
         "behavior_metrics"
     ],
     "rpc_aliases": {


### PR DESCRIPTION
## What
few FCA test cases like wifi.scan(), Authentication.token Apis are failing.

## Why
wifi.scan issue:
rdk6 introduced firebolt-supported ResidentAppUI as the home UI,
hence the FCA app runs as a third-party app. In the app manifest, the ResidentAppUI has all the necessary access (referred to as refui in the app manifest).

Authentication.token Apis issue:
we have removed the support for token from the manifest because our device does not support it. However, there have been recent changes on the Ripple side, where they added platform.token and distributor.token hence we can mock the expected response as a reference.

## How

wifi.scan issue:
The FCA app is now launched with the app ID "comcast.test.firecert". provided full access(exclusory).

Authentication.token Apis issue:
Added require contracts and capability in the manifest. also added extn processor processing auth.tocken queries.

## Test

Build and run FCA test cases.
1) wifi.scan should return list of available Wi-Fi networks.
2) Auth.token Api's must pass.

## Checklist

- [x] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
