### PR TITLE
feat: histogram support for ops metrics

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main", "1.2.0.rc" ]
+    branches: [ "main", "1.2.0.rc","1.3.0.rc" ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/CODEOWNERS.md
+++ b/CODEOWNERS.md
@@ -1,0 +1,2 @@
+@rdkcentral/ripple-core
+@rdkcentral/ripple-qa

--- a/core/main/src/service/telemetry_builder.rs
+++ b/core/main/src/service/telemetry_builder.rs
@@ -20,7 +20,7 @@ use ripple_sdk::{
         firebolt::{
             fb_metrics::{
                 get_metrics_tags, ErrorParams, InteractionType, InternalInitializeParams,
-                SystemErrorParams, Tag, Timer,
+                SystemErrorParams, Tag, Timer, TimerType,
             },
             fb_telemetry::{
                 AppLoadStart, AppLoadStop, FireboltInteraction, InternalInitialize,
@@ -219,7 +219,11 @@ impl TelemetryBuilder {
 
         debug!("start_firebolt_metrics_timer: {}: {:?}", name, metrics_tags);
 
-        Some(Timer::start(name, Some(metrics_tags)))
+        Some(Timer::start(
+            name,
+            Some(metrics_tags),
+            Some(TimerType::Local),
+        ))
     }
 
     pub async fn stop_and_send_firebolt_metrics_timer(

--- a/core/sdk/src/api/firebolt/fb_metrics.rs
+++ b/core/sdk/src/api/firebolt/fb_metrics.rs
@@ -472,6 +472,20 @@ pub enum TimeUnit {
     Millis,
     Seconds,
 }
+/*
+Type to indicate if the timer is local or remote, used for bucket sizing in downstreams
+*/
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+pub enum TimerType {
+    /*
+    Local metrics are generated for local, on device service calls
+    */
+    Local,
+    /*
+    Remote metrics are generated for remote, off device service calls
+    */
+    Remote,
+}
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct Timer {
     pub name: String,
@@ -481,17 +495,29 @@ pub struct Timer {
     pub stop: Option<std::time::Instant>,
     pub tags: Option<HashMap<String, String>>,
     pub time_unit: TimeUnit,
+    pub timer_type: TimerType,
 }
 impl Timer {
-    pub fn start(name: String, tags: Option<HashMap<String, String>>) -> Timer {
-        Timer::new(name, std::time::Instant::now(), tags, TimeUnit::Millis)
+    pub fn start(
+        name: String,
+        tags: Option<HashMap<String, String>>,
+        timer_type: Option<TimerType>,
+    ) -> Timer {
+        Timer::new(
+            name,
+            std::time::Instant::now(),
+            tags,
+            TimeUnit::Millis,
+            timer_type,
+        )
     }
     pub fn start_with_time_unit(
         name: String,
         tags: Option<HashMap<String, String>>,
         time_unit: TimeUnit,
+        timer_type: Option<TimerType>,
     ) -> Timer {
-        Timer::new(name, std::time::Instant::now(), tags, time_unit)
+        Timer::new(name, std::time::Instant::now(), tags, time_unit, timer_type)
     }
 
     pub fn new(
@@ -499,6 +525,7 @@ impl Timer {
         start: std::time::Instant,
         tags: Option<HashMap<String, String>>,
         time_unit: TimeUnit,
+        timer_type: Option<TimerType>,
     ) -> Timer {
         Timer {
             name,
@@ -506,6 +533,7 @@ impl Timer {
             stop: None,
             tags,
             time_unit,
+            timer_type: timer_type.unwrap_or_else(|| TimerType::Local),
         }
     }
 

--- a/core/sdk/src/api/firebolt/fb_metrics.rs
+++ b/core/sdk/src/api/firebolt/fb_metrics.rs
@@ -533,7 +533,7 @@ impl Timer {
             stop: None,
             tags,
             time_unit,
-            timer_type: timer_type.unwrap_or_else(|| TimerType::Local),
+            timer_type: timer_type.unwrap_or(TimerType::Local),
         }
     }
 

--- a/core/sdk/src/api/firebolt/fb_metrics.rs
+++ b/core/sdk/src/api/firebolt/fb_metrics.rs
@@ -533,6 +533,7 @@ impl Timer {
             stop: None,
             tags,
             time_unit,
+            /*most will probably be local, so default as such*/
             timer_type: timer_type.unwrap_or(TimerType::Local),
         }
     }

--- a/core/sdk/src/api/firebolt/fb_metrics.rs
+++ b/core/sdk/src/api/firebolt/fb_metrics.rs
@@ -944,7 +944,7 @@ mod tests {
     }
     #[test]
     pub fn test_timer() {
-        let mut timer = super::Timer::start("test".to_string(), None);
+        let mut timer = super::Timer::start("test".to_string(), None, None);
         std::thread::sleep(std::time::Duration::from_millis(101));
         timer.stop();
         assert!(timer.elapsed().as_millis() > 100);

--- a/core/sdk/src/api/observability/metrics_util.rs
+++ b/core/sdk/src/api/observability/metrics_util.rs
@@ -3,7 +3,8 @@ use log::{debug, error};
 use crate::{
     api::firebolt::{
         fb_metrics::{
-            get_metrics_tags, InteractionType, Tag, Timer, SERVICE_METRICS_SEND_REQUEST_TIMEOUT_MS,
+            get_metrics_tags, InteractionType, Tag, Timer, TimerType,
+            SERVICE_METRICS_SEND_REQUEST_TIMEOUT_MS,
         },
         fb_telemetry::OperationalMetricRequest,
     },
@@ -22,7 +23,11 @@ pub fn start_service_metrics_timer(extn_client: &ExtnClient, name: String) -> Op
 
     debug!("start_service_metrics_timer: {}: {:?}", name, metrics_tags);
 
-    Some(Timer::start(name, Some(metrics_tags)))
+    Some(Timer::start(
+        name,
+        Some(metrics_tags),
+        Some(TimerType::Remote),
+    ))
 }
 
 pub async fn stop_and_send_service_metrics_timer(

--- a/device/thunder_ripple_sdk/Cargo.toml
+++ b/device/thunder_ripple_sdk/Cargo.toml
@@ -46,7 +46,7 @@ pact_consumer = { version = "1.0.0", optional = true }
 reqwest = { version = "0.11", optional = true }
 expectest = { version = "0.12.0", optional = true }
 maplit = { version = "1.0.2", optional = true }
-test-log = { version = "0.2.11", optional = true }
+test-log = { version = "=0.2.11", optional = true }
 csv = "=1.1.5"
 base64 = "0.13.0"
 home = { version = "=0.5.5", optional = true}


### PR DESCRIPTION
## What

Changes to support describing ops metrics histograms

## Why

Support of differentiated bucket distributions for firebolt vs service interaction metrics

## How

Type/parameter added to allow caller to denote which type (firebolt,svc) of metric is being created

## Test
Manually tested locally against dev otel endpoint

## Checklist

- [X ] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
