### PR TITLE
fix: Privacy data Call Optimization, caching privacy settings values

### DIFF
--- a/core/main/src/firebolt/handlers/privacy_rpc.rs
+++ b/core/main/src/firebolt/handlers/privacy_rpc.rs
@@ -18,8 +18,8 @@
 use crate::processor::storage::storage_manager::StorageManager;
 use crate::service::apps::app_events::AppEventDecorator;
 use crate::{
-    firebolt::rpc::RippleRPCProvider, processor::storage::storage_manager::StorageManagerError,
-    service::apps::app_events::AppEvents, state::platform_state::PlatformState,
+    firebolt::rpc::RippleRPCProvider, service::apps::app_events::AppEvents,
+    state::platform_state::PlatformState,
 };
 use jsonrpsee::{
     core::{async_trait, RpcResult},

--- a/core/main/src/firebolt/handlers/privacy_rpc.rs
+++ b/core/main/src/firebolt/handlers/privacy_rpc.rs
@@ -278,7 +278,7 @@ pub async fn get_allow_app_content_ad_targeting_settings(
     scope_option: Option<&ScopeOption>,
     caller_app: &String,
 ) -> HashMap<String, String> {
-    let mut data = StorageProperty::AllowAppContentAdTargeting.as_data();
+    let mut data = StorageProperty::AllowAppContentAdTargeting;
     if let Some(scope_opt) = scope_option {
         if let Some(scope) = &scope_opt.scope {
             let primary_app = platform_state
@@ -288,27 +288,20 @@ pub async fn get_allow_app_content_ad_targeting_settings(
                 .main;
             if primary_app == *caller_app.to_string() {
                 if scope._type.as_string() == "browse" {
-                    data = StorageProperty::AllowPrimaryBrowseAdTargeting.as_data();
+                    data = StorageProperty::AllowPrimaryBrowseAdTargeting;
                 } else if scope._type.as_string() == "content" {
-                    data = StorageProperty::AllowPrimaryContentAdTargeting.as_data();
+                    data = StorageProperty::AllowPrimaryContentAdTargeting;
                 }
             }
         }
     }
-    match StorageManager::get_bool_from_namespace(
-        platform_state,
-        data.namespace.to_string(),
-        data.key,
+
+    AllowAppContentAdTargetingSettings::new(
+        StorageManager::get_bool(platform_state, data)
+            .await
+            .unwrap_or(true),
     )
-    .await
-    {
-        Ok(resp) => AllowAppContentAdTargetingSettings::new(resp.as_value())
-            .get_allow_app_content_ad_targeting_settings(),
-        Err(StorageManagerError::NotFound) => AllowAppContentAdTargetingSettings::default()
-            .get_allow_app_content_ad_targeting_settings(),
-        _ => AllowAppContentAdTargetingSettings::new(true)
-            .get_allow_app_content_ad_targeting_settings(),
-    }
+    .get_allow_app_content_ad_targeting_settings()
 }
 
 #[derive(Debug)]

--- a/core/main/src/processor/storage/storage_manager.rs
+++ b/core/main/src/processor/storage/storage_manager.rs
@@ -77,7 +77,7 @@ pub struct StorageManager;
 impl StorageManager {
     pub async fn get_bool(state: &PlatformState, property: StorageProperty) -> RpcResult<bool> {
         if property.is_a_privacy_setting_property() {
-            // check if the privacy setting property is avaiale in cache
+            // check if the privacy setting property is available in cache
             let privacy_settings_cache = state.ripple_cache.get_privacy_settings_cache();
             let val_opt = property.get_privacy_setting_value(&privacy_settings_cache);
             if let Some(val) = val_opt {
@@ -114,6 +114,18 @@ impl StorageManager {
     ) -> RpcResult<()> {
         let data = property.as_data();
         debug!("Storage property: {:?} as data: {:?}", property, data);
+        if property.is_a_privacy_setting_property() {
+            // check if the privacy setting property is available in cache.
+            // If yes, check if the value is same as the one being set
+            let privacy_settings_cache = state.ripple_cache.get_privacy_settings_cache();
+            let val_opt = property.get_privacy_setting_value(&privacy_settings_cache);
+            if let Some(val) = val_opt {
+                if val == value {
+                    return Ok(());
+                }
+            }
+        }
+
         match StorageManager::set_in_namespace(
             state,
             data.namespace.to_string(),

--- a/core/main/src/processor/store_privacy_settings_processor.rs
+++ b/core/main/src/processor/store_privacy_settings_processor.rs
@@ -19,7 +19,13 @@ use crate::state::platform_state::PlatformState;
 use ripple_sdk::{
     api::{
         distributor::distributor_privacy::{PrivacySettingsData, PrivacySettingsStoreRequest},
-        storage_property::StorageProperty,
+        storage_property::StorageProperty::{
+            self, AllowAcrCollection, AllowAppContentAdTargeting, AllowBusinessAnalytics,
+            AllowCameraAnalytics, AllowPersonalization, AllowPrimaryBrowseAdTargeting,
+            AllowPrimaryContentAdTargeting, AllowProductAnalytics, AllowRemoteDiagnostics,
+            AllowResumePoints, AllowUnentitledPersonalization, AllowUnentitledResumePoints,
+            AllowWatchHistory,
+        },
     },
     async_trait::async_trait,
     extn::{
@@ -119,193 +125,71 @@ impl StorePrivacySettingsProcessor {
         privacy_settings_data: PrivacySettingsData,
     ) -> bool {
         let mut err = false;
-        if let Some(allow_acr_collection) = privacy_settings_data.allow_acr_collection {
-            let res = StorageManager::set_bool(
-                state,
-                StorageProperty::AllowAcrCollection,
-                allow_acr_collection,
-                None,
-            )
-            .await;
-            if let Err(e) = res {
-                error!("Unable to set property allow_resume_points error: {:?}", e);
-                err = true;
-            }
+
+        macro_rules! set_property {
+            ($property:ident, $value:expr) => {
+                if let Some(value) = $value {
+                    let res = StorageManager::set_bool(state, $property, value, None).await;
+                    if let Err(e) = res {
+                        error!("Unable to set property {:?} error: {:?}", $property, e);
+                        err = true;
+                    }
+                }
+            };
         }
-        if let Some(allow_resume_points) = privacy_settings_data.allow_resume_points {
-            let res = StorageManager::set_bool(
-                state,
-                StorageProperty::AllowResumePoints,
-                allow_resume_points,
-                None,
-            )
-            .await;
-            if let Err(e) = res {
-                error!("Unable to set property allow_resume_points error: {:?}", e);
-                err = true;
-            }
-        }
-        if let Some(allow_app_content_ad_targeting) =
+
+        set_property!(
+            AllowAcrCollection,
+            privacy_settings_data.allow_acr_collection
+        );
+        set_property!(AllowResumePoints, privacy_settings_data.allow_resume_points);
+        set_property!(
+            AllowAppContentAdTargeting,
             privacy_settings_data.allow_app_content_ad_targeting
-        {
-            let res = StorageManager::set_bool(
-                state,
-                StorageProperty::AllowAppContentAdTargeting,
-                allow_app_content_ad_targeting,
-                None,
-            )
-            .await;
-            if let Err(e) = res {
-                error!(
-                    "Unable to set property allow_primary_browse_ad_targetting: {:?}",
-                    e
-                );
-                err = true;
-            }
+        );
+
+        // business analytics is a special case, if it is not set, we set it to true
+        if privacy_settings_data.allow_business_analytics.is_none() {
+            set_property!(AllowBusinessAnalytics, Some(true));
+        } else {
+            set_property!(
+                AllowBusinessAnalytics,
+                privacy_settings_data.allow_business_analytics
+            );
         }
-        if let Some(allow_camera_analytics) = privacy_settings_data.allow_camera_analytics {
-            let res = StorageManager::set_bool(
-                state,
-                StorageProperty::AllowCameraAnalytics,
-                allow_camera_analytics,
-                None,
-            )
-            .await;
-            if let Err(e) = res {
-                error!(
-                    "Unable to set property allow_primary_browse_ad_targetting: {:?}",
-                    e
-                );
-                err = true;
-            }
-        }
-        if let Some(allow_personalization) = privacy_settings_data.allow_personalization {
-            let res = StorageManager::set_bool(
-                state,
-                StorageProperty::AllowPersonalization,
-                allow_personalization,
-                None,
-            )
-            .await;
-            if let Err(e) = res {
-                error!("Unable to set property allow_resume_points error: {:?}", e);
-                err = true;
-            }
-        }
-        if let Some(allow_primary_browse_ad_targeting) =
+        set_property!(
+            AllowCameraAnalytics,
+            privacy_settings_data.allow_camera_analytics
+        );
+        set_property!(
+            AllowPersonalization,
+            privacy_settings_data.allow_personalization
+        );
+        set_property!(
+            AllowPrimaryBrowseAdTargeting,
             privacy_settings_data.allow_primary_browse_ad_targeting
-        {
-            let res = StorageManager::set_bool(
-                state,
-                StorageProperty::AllowPrimaryBrowseAdTargeting,
-                allow_primary_browse_ad_targeting,
-                None,
-            )
-            .await;
-            if let Err(e) = res {
-                error!(
-                    "Unable to set property allow_primary_browse_ad_targetting: {:?}",
-                    e
-                );
-                err = true;
-            }
-        }
-        if let Some(allow_primary_content_ad_targeting) =
+        );
+        set_property!(
+            AllowPrimaryContentAdTargeting,
             privacy_settings_data.allow_primary_content_ad_targeting
-        {
-            let res = StorageManager::set_bool(
-                state,
-                StorageProperty::AllowPrimaryContentAdTargeting,
-                allow_primary_content_ad_targeting,
-                None,
-            )
-            .await;
-            if let Err(e) = res {
-                error!(
-                    "Unable to set property allow_primary_browse_ad_targetting: {:?}",
-                    e
-                );
-                err = true;
-            }
-        }
-        if let Some(allow_product_analytics) = privacy_settings_data.allow_product_analytics {
-            let res = StorageManager::set_bool(
-                state,
-                StorageProperty::AllowProductAnalytics,
-                allow_product_analytics,
-                None,
-            )
-            .await;
-            if let Err(e) = res {
-                error!("Unable to set property allow_resume_points error: {:?}", e);
-                err = true;
-            }
-        }
-        if let Some(allow_remote_diagnostics) = privacy_settings_data.allow_remote_diagnostics {
-            let res = StorageManager::set_bool(
-                state,
-                StorageProperty::AllowRemoteDiagnostics,
-                allow_remote_diagnostics,
-                None,
-            )
-            .await;
-            if let Err(e) = res {
-                error!(
-                    "Unable to set property allow_primary_browse_ad_targetting: {:?}",
-                    e
-                );
-                err = true;
-            }
-        }
-        if let Some(allow_unentitled_personalization) =
+        );
+        set_property!(
+            AllowProductAnalytics,
+            privacy_settings_data.allow_product_analytics
+        );
+        set_property!(
+            AllowRemoteDiagnostics,
+            privacy_settings_data.allow_remote_diagnostics
+        );
+        set_property!(
+            AllowUnentitledPersonalization,
             privacy_settings_data.allow_unentitled_personalization
-        {
-            let res = StorageManager::set_bool(
-                state,
-                StorageProperty::AllowUnentitledPersonalization,
-                allow_unentitled_personalization,
-                None,
-            )
-            .await;
-            if let Err(e) = res {
-                error!(
-                    "Unable to set property allow_primary_browse_ad_targetting: {:?}",
-                    e
-                );
-                err = true;
-            }
-        }
-        if let Some(allow_unentitled_resume_points) =
+        );
+        set_property!(
+            AllowUnentitledResumePoints,
             privacy_settings_data.allow_unentitled_resume_points
-        {
-            let res = StorageManager::set_bool(
-                state,
-                StorageProperty::AllowUnentitledResumePoints,
-                allow_unentitled_resume_points,
-                None,
-            )
-            .await;
-            if let Err(e) = res {
-                error!("Unable to set property allow_resume_points error: {:?}", e);
-                err = true;
-            }
-        }
-        if let Some(allow_watch_history) = privacy_settings_data.allow_watch_history {
-            let res = StorageManager::set_bool(
-                state,
-                StorageProperty::AllowWatchHistory,
-                allow_watch_history,
-                None,
-            )
-            .await;
-            if let Err(e) = res {
-                error!(
-                    "Unable to set property allow_primary_browse_ad_targetting: {:?}",
-                    e
-                );
-                err = true;
-            }
-        }
+        );
+        set_property!(AllowWatchHistory, privacy_settings_data.allow_watch_history);
 
         if err {
             return Self::handle_error(

--- a/core/main/src/processor/store_privacy_settings_processor.rs
+++ b/core/main/src/processor/store_privacy_settings_processor.rs
@@ -125,7 +125,6 @@ impl StorePrivacySettingsProcessor {
         privacy_settings_data: PrivacySettingsData,
     ) -> bool {
         let mut err = false;
-
         macro_rules! set_property {
             ($property:ident, $value:expr) => {
                 if let Some(value) = $value {

--- a/core/main/src/service/data_governance.rs
+++ b/core/main/src/service/data_governance.rs
@@ -117,28 +117,9 @@ impl DataGovernance {
                     .collect();
                 tags.extend(tags_to_add);
             } else {
-                // check if the privacy setting property is avaiale in cache
-                let mut privacy_settings_cache = state.metrics.get_privacy_settings_cache();
-                let val_opt = tag
-                    .setting
-                    .get_privacy_setting_value(&privacy_settings_cache);
-
-                let val = if val_opt.is_none() {
-                    // get the value from storage manager and update the privacy settings cache in metrics state
-                    let tmp_val = StorageManager::get_bool(state, tag.setting.clone())
-                        .await
-                        .unwrap_or(false);
-                    tag.setting
-                        .set_privacy_setting_value(&mut privacy_settings_cache, tmp_val);
-                    state
-                        .metrics
-                        .update_privacy_settings_cache(&privacy_settings_cache);
-                    tmp_val
-                } else {
-                    // cache hit, safe to unwrap here.
-                    val_opt.unwrap()
-                };
-
+                let val = StorageManager::get_bool(state, tag.setting.clone())
+                    .await
+                    .unwrap_or(false);
                 if val == tag.enforcement_value {
                     let tags_to_add: HashSet<DataTagInfo> = tag
                         .tags

--- a/core/main/src/state/metrics_state.rs
+++ b/core/main/src/state/metrics_state.rs
@@ -25,7 +25,6 @@ use ripple_sdk::{
     api::{
         context::RippleContextUpdateRequest,
         device::device_info_request::{DeviceInfoRequest, DeviceResponse},
-        distributor::distributor_privacy::PrivacySettingsData,
         firebolt::{fb_metrics::MetricsContext, fb_openrpc::FireboltSemanticVersion},
         storage_property::StorageProperty,
     },
@@ -46,7 +45,6 @@ include!(concat!(env!("OUT_DIR"), "/version.rs"));
 pub struct MetricsState {
     pub start_time: DateTime<Utc>,
     pub context: Arc<RwLock<MetricsContext>>,
-    pub privacy_settings_cache: Arc<RwLock<PrivacySettingsData>>,
     operational_telemetry_listeners: Arc<RwLock<HashSet<String>>>,
 }
 
@@ -67,13 +65,6 @@ impl MetricsState {
 
     pub fn get_context(&self) -> MetricsContext {
         self.context.read().unwrap().clone()
-    }
-    pub fn get_privacy_settings_cache(&self) -> PrivacySettingsData {
-        self.privacy_settings_cache.read().unwrap().clone()
-    }
-    pub fn update_privacy_settings_cache(&self, value: &PrivacySettingsData) {
-        let mut cache = self.privacy_settings_cache.write().unwrap();
-        *cache = value.clone();
     }
     pub async fn initialize(state: &PlatformState) {
         let metrics_percentage = state

--- a/core/main/src/state/platform_state.rs
+++ b/core/main/src/state/platform_state.rs
@@ -48,7 +48,7 @@ use crate::{
 
 use super::{
     cap::cap_state::CapState, metrics_state::MetricsState, openrpc_state::OpenRpcState,
-    session_state::SessionState,
+    ripple_cache::RippleCache, session_state::SessionState,
 };
 
 /// Platform state encapsulates the internal state of the Ripple Main application.
@@ -103,6 +103,7 @@ pub struct PlatformState {
     pub data_governance: DataGovernanceState,
     pub metrics: MetricsState,
     pub device_session_id: DeviceSessionIdentifier,
+    pub ripple_cache: RippleCache,
 }
 
 impl PlatformState {
@@ -129,6 +130,7 @@ impl PlatformState {
             data_governance: DataGovernanceState::default(),
             metrics: MetricsState::default(),
             device_session_id: DeviceSessionIdentifier::default(),
+            ripple_cache: RippleCache::default(),
         }
     }
 

--- a/core/main/src/state/ripple_cache.rs
+++ b/core/main/src/state/ripple_cache.rs
@@ -16,19 +16,34 @@
 //
 use std::sync::{Arc, RwLock};
 
-use ripple_sdk::api::distributor::distributor_privacy::PrivacySettingsData;
+use ripple_sdk::api::{
+    distributor::distributor_privacy::PrivacySettingsData, storage_property::StorageProperty,
+};
 
 #[derive(Debug, Clone, Default)]
 pub struct RippleCache {
-    pub privacy_settings_cache: Arc<RwLock<PrivacySettingsData>>,
+    // Cache for privacy settings
+    privacy_settings_cache: Arc<RwLock<PrivacySettingsData>>,
+    // Add more caches for other settings as required
 }
 
 impl RippleCache {
-    pub fn get_privacy_settings_cache(&self) -> PrivacySettingsData {
-        self.privacy_settings_cache.read().unwrap().clone()
+    pub fn get_cached_bool_storage_property(&self, property: &StorageProperty) -> Option<bool> {
+        if property.is_a_privacy_setting_property() {
+            // check if the privacy setting property is available in cache
+            let cache = self.privacy_settings_cache.read().unwrap();
+            property.get_privacy_setting_value(&cache)
+        } else {
+            // We can add caching support for non-privacy setting properties in future
+            None
+        }
     }
-    pub fn update_privacy_settings_cache(&self, value: &PrivacySettingsData) {
-        let mut cache = self.privacy_settings_cache.write().unwrap();
-        *cache = value.clone();
+
+    pub fn update_cached_bool_storage_property(&self, property: &StorageProperty, value: bool) {
+        if property.is_a_privacy_setting_property() {
+            // update the privacy setting property in cache
+            let mut cache = self.privacy_settings_cache.write().unwrap();
+            property.set_privacy_setting_value(&mut cache, value);
+        }
     }
 }

--- a/core/main/src/state/ripple_cache.rs
+++ b/core/main/src/state/ripple_cache.rs
@@ -14,16 +14,21 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //
+use std::sync::{Arc, RwLock};
 
-pub mod bootstrap_state;
-pub mod extn_state;
-pub mod metrics_state;
-pub mod openrpc_state;
-pub mod platform_state;
-pub mod ripple_cache;
-pub mod session_state;
-pub mod cap {
-    pub mod cap_state;
-    pub mod generic_cap_state;
-    pub mod permitted_state;
+use ripple_sdk::api::distributor::distributor_privacy::PrivacySettingsData;
+
+#[derive(Debug, Clone, Default)]
+pub struct RippleCache {
+    pub privacy_settings_cache: Arc<RwLock<PrivacySettingsData>>,
+}
+
+impl RippleCache {
+    pub fn get_privacy_settings_cache(&self) -> PrivacySettingsData {
+        self.privacy_settings_cache.read().unwrap().clone()
+    }
+    pub fn update_privacy_settings_cache(&self, value: &PrivacySettingsData) {
+        let mut cache = self.privacy_settings_cache.write().unwrap();
+        *cache = value.clone();
+    }
 }

--- a/core/sdk/src/api/distributor/distributor_privacy.rs
+++ b/core/sdk/src/api/distributor/distributor_privacy.rs
@@ -288,6 +288,7 @@ impl ExtnPayloadProvider for ExclusionPolicy {
 pub enum DataEventType {
     Watched,
     BusinessIntelligence,
+    Unknown,
 }
 
 impl FromStr for DataEventType {
@@ -295,7 +296,8 @@ impl FromStr for DataEventType {
     fn from_str(input: &str) -> Result<DataEventType, Self::Err> {
         match input {
             "Watch_History" => Ok(DataEventType::Watched),
-            _ => Err(()),
+            "Product_Analytics" => Ok(DataEventType::BusinessIntelligence),
+            _ => Ok(DataEventType::Unknown),
         }
     }
 }

--- a/device/thunder_ripple_sdk/src/tests/thunder_client_pool_test_utility.rs
+++ b/device/thunder_ripple_sdk/src/tests/thunder_client_pool_test_utility.rs
@@ -17,7 +17,7 @@
 use crate::client::jsonrpc_method_locator::JsonRpcMethodLocator;
 use futures::SinkExt;
 use futures::StreamExt;
-use jsonrpsee::tracing::info;
+use ripple_sdk::log::info;
 use ripple_sdk::{futures, serde_json, tokio};
 use serde_json::{json, Value};
 use std::net::SocketAddr;


### PR DESCRIPTION
## What

Privacy data Call Optimization, caching privacy settings values

## Why

In order to increase the resiliency and improve the latency of critical calls related to app launching we would require Ripple to Synchronize the values for privacy on boot and during linchpin updates in Platform State.

We expect some performance improvements in terms of latency for Privacy related api calls like
```
          Parameters.initialization
          Privacy Settings
          Badger calls related to privacy.
```

## How
Use cache for privacy settings storage properties 

## How do these changes achieve the goal?

## Test

How has this been tested? How can a reviewer test it?

## Checklist

- [ ] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
