### PR TITLE
fix: Fix for marking unsupported caps as unavailable.

### DIFF
--- a/core/main/src/state/cap/generic_cap_state.rs
+++ b/core/main/src/state/cap/generic_cap_state.rs
@@ -107,10 +107,17 @@ impl GenericCapState {
         Ok(())
     }
 
+    /*
+     * Actually we are not maintaining the available capability list.
+     * We are maintaining only non-available list.
+     * The notion is all supported caps are intrinsically available
+     * unless made as unavailable during initialization.
+     */
     pub fn check_available(
         &self,
         request: &Vec<FireboltPermission>,
     ) -> Result<(), DenyReasonWithCap> {
+        self.check_supported(request)?;
         let not_available = self.not_available.read().unwrap();
         let mut result: Vec<FireboltCap> = Vec::new();
         for fb_perm in request {
@@ -133,7 +140,6 @@ impl GenericCapState {
         &self,
         permissions: &Vec<FireboltPermission>,
     ) -> Result<(), DenyReasonWithCap> {
-        self.check_supported(permissions)?;
         self.check_available(permissions)
     }
 


### PR DESCRIPTION
## What

This PR changes are for properly marking the availability of capability

## Why

When a cap is not supported it should be marked as unavailable. 

## How

Before checking for availability it checks if it is supported. 

## Test

How has this been tested? How can a reviewer test it?

## Checklist

- [x] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
