### PR TITLE
feat: Remove Clone trait from ExtnMessage

### DIFF
--- a/core/launcher/src/launcher_state.rs
+++ b/core/launcher/src/launcher_state.rs
@@ -63,7 +63,7 @@ impl LauncherState {
         let extn_message_response: Result<ExtnMessage, RippleError> =
             extn_client.request(Config::LauncherConfig).await;
         if let Ok(message) = extn_message_response {
-            if let Some(config) = message.payload.extract() {
+            if let Some(config) = message.extract() {
                 return Ok(LauncherState {
                     config,
                     view_state: ViewState::default(),

--- a/core/launcher/src/manager/app_launcher.rs
+++ b/core/launcher/src/manager/app_launcher.rs
@@ -357,7 +357,7 @@ impl AppLauncher {
             .send_extn_request(DeviceInfoRequest::AvailableMemory)
             .await
         {
-            if let Some(ExtnResponse::Value(v)) = msg.payload.extract() {
+            if let Some(ExtnResponse::Value(v)) = msg.extract() {
                 if let Some(memory) = v.as_u64() {
                     return Ok(memory);
                 }
@@ -582,7 +582,7 @@ impl AppLauncher {
             return Err(AppError::NotSupported);
         }
         match resp {
-            Ok(response) => match response.payload.extract::<AppResponse>() {
+            Ok(response) => match response.extract::<AppResponse>() {
                 Some(Ok(AppManagerResponse::Session(SessionResponse::Completed(val)))) => {
                     sessionid = val.session_id;
                     debug!("session id : {:?} ", sessionid);
@@ -634,12 +634,11 @@ impl AppLauncher {
             return Err(AppError::NotSupported);
         }
 
-        let callsign =
-            if let Some(ExtnResponse::String(callsign)) = response.unwrap().payload.extract() {
-                callsign
-            } else {
-                return Err(AppError::NotSupported);
-            };
+        let callsign = if let Some(ExtnResponse::String(callsign)) = response.unwrap().extract() {
+            callsign
+        } else {
+            return Err(AppError::NotSupported);
+        };
 
         let intent = request
             .intent

--- a/core/main/src/firebolt/firebolt_gateway.rs
+++ b/core/main/src/firebolt/firebolt_gateway.rs
@@ -112,7 +112,7 @@ impl FireboltGateway {
                 }
                 HandleRpc { request } => self.handle(request, None).await,
                 HandleRpcForExtn { msg } => {
-                    if let Some(request) = msg.payload.clone().extract() {
+                    if let Some(request) = msg.extract() {
                         self.handle(request, Some(msg)).await
                     } else {
                         error!("Not a valid RPC Request {:?}", msg);

--- a/core/main/src/firebolt/handlers/accessory_rpc.rs
+++ b/core/main/src/firebolt/handlers/accessory_rpc.rs
@@ -68,7 +68,7 @@ impl AccessoryServer for AccessoryImpl {
             .await
         {
             if let Some(RemoteAccessoryResponse::RemoteAccessoryListResponse(value)) =
-                response.payload.extract()
+                response.extract()
             {
                 return Ok(value);
             }
@@ -94,9 +94,7 @@ impl AccessoryServer for AccessoryImpl {
             .send_extn_request(RemoteAccessoryRequest::Pair(pair_request))
             .await
         {
-            if let Some(RemoteAccessoryResponse::AccessoryPairResponse(v)) =
-                response.payload.extract()
-            {
+            if let Some(RemoteAccessoryResponse::AccessoryPairResponse(v)) = response.extract() {
                 return Ok(v);
             }
         }

--- a/core/main/src/firebolt/handlers/account_rpc.rs
+++ b/core/main/src/firebolt/handlers/account_rpc.rs
@@ -84,7 +84,7 @@ impl AccountServer for AccountImpl {
                     })
                     .await
                 {
-                    if let Some(ExtnResponse::String(s)) = resp.payload.extract() {
+                    if let Some(ExtnResponse::String(s)) = resp.extract() {
                         return Ok(s);
                     }
                 }

--- a/core/main/src/firebolt/handlers/advertising_rpc.rs
+++ b/core/main/src/firebolt/handlers/advertising_rpc.rs
@@ -301,7 +301,7 @@ impl AdvertisingServer for AdvertisingImpl {
 
             if let Ok(payload) = resp {
                 if let Some(AdvertisingResponse::AdIdObject(obj)) =
-                    payload.payload.extract::<AdvertisingResponse>()
+                    payload.extract::<AdvertisingResponse>()
                 {
                     let ad_id = AdvertisingId {
                         ifa: obj.ifa,
@@ -383,7 +383,7 @@ impl AdvertisingServer for AdvertisingImpl {
             .send_extn_request(advertising_request)
             .await
         {
-            Ok(message) => match message.payload.extract() {
+            Ok(message) => match message.extract() {
                 Some(advertising_resp) => match advertising_resp {
                     AdvertisingResponse::AdConfig(resp) => resp,
                     _ => {

--- a/core/main/src/firebolt/handlers/authentication_rpc.rs
+++ b/core/main/src/firebolt/handlers/authentication_rpc.rs
@@ -202,7 +202,7 @@ impl AuthenticationImpl {
             }
         };
         match resp {
-            Ok(payload) => match payload.payload.extract().unwrap() {
+            Ok(payload) => match payload.extract().unwrap() {
                 ExtnResponse::Token(t) => Ok(TokenResult {
                     value: t.value,
                     expires: t.expires,

--- a/core/main/src/firebolt/handlers/device_rpc.rs
+++ b/core/main/src/firebolt/handlers/device_rpc.rs
@@ -203,9 +203,7 @@ pub async fn get_uid(state: &PlatformState, app_id: String) -> RpcResult<String>
                 })
                 .await
             {
-                if let Some(ExtnResponse::String(enc_device_id)) =
-                    resp.payload.extract::<ExtnResponse>()
-                {
+                if let Some(ExtnResponse::String(enc_device_id)) = resp.extract::<ExtnResponse>() {
                     return Ok(enc_device_id);
                 }
             }
@@ -222,7 +220,7 @@ pub async fn get_ll_mac_addr(state: PlatformState) -> RpcResult<String> {
         .send_extn_request(DeviceInfoRequest::MacAddress)
         .await;
     match resp {
-        Ok(response) => match response.payload.extract().unwrap() {
+        Ok(response) => match response.extract().unwrap() {
             ExtnResponse::String(value) => Ok(filter_mac(value)),
             _ => Err(jsonrpsee::core::Error::Custom(String::from(
                 "MAC Info error response TBD",
@@ -256,7 +254,7 @@ impl DeviceImpl {
             .await;
 
         match resp {
-            Ok(dab_payload) => match dab_payload.payload.extract().unwrap() {
+            Ok(dab_payload) => match dab_payload.extract().unwrap() {
                 DeviceResponse::FirmwareInfo(value) => Ok(value),
                 _ => Err(jsonrpsee::core::Error::Custom(String::from(
                     "Firmware Info error response TBD",
@@ -342,7 +340,7 @@ impl DeviceServer for DeviceImpl {
             .send_extn_request(DeviceInfoRequest::Model)
             .await
         {
-            if let Some(ExtnResponse::String(v)) = response.payload.extract() {
+            if let Some(ExtnResponse::String(v)) = response.extract() {
                 if let Some(f) = self
                     .state
                     .get_device_manifest()
@@ -364,7 +362,7 @@ impl DeviceServer for DeviceImpl {
             .send_extn_request(DeviceInfoRequest::Model)
             .await
         {
-            if let Some(ExtnResponse::String(v)) = response.payload.extract() {
+            if let Some(ExtnResponse::String(v)) = response.extract() {
                 return Ok(v);
             }
         }
@@ -379,7 +377,7 @@ impl DeviceServer for DeviceImpl {
             .await;
 
         match resp {
-            Ok(payload) => match payload.payload.extract().unwrap() {
+            Ok(payload) => match payload.extract().unwrap() {
                 DeviceResponse::HdcpSupportResponse(value) => Ok(value),
                 _ => Err(jsonrpsee::core::Error::Custom(String::from(
                     "Hdcp capabilities error response TBD",
@@ -433,7 +431,7 @@ impl DeviceServer for DeviceImpl {
             .await;
 
         match resp {
-            Ok(response) => match response.payload.extract().unwrap() {
+            Ok(response) => match response.extract().unwrap() {
                 DeviceResponse::HdrResponse(value) => Ok(value),
                 _ => Err(jsonrpsee::core::Error::Custom(String::from(
                     "Hdr capabilities error response TBD",
@@ -487,7 +485,7 @@ impl DeviceServer for DeviceImpl {
         )
         .await
         {
-            if let Some(DeviceResponse::ScreenResolutionResponse(value)) = resp.payload.extract() {
+            if let Some(DeviceResponse::ScreenResolutionResponse(value)) = resp.extract() {
                 return Ok(value);
             }
         }
@@ -539,7 +537,7 @@ impl DeviceServer for DeviceImpl {
         )
         .await
         {
-            if let Some(DeviceResponse::VideoResolutionResponse(value)) = resp.payload.extract() {
+            if let Some(DeviceResponse::VideoResolutionResponse(value)) = resp.extract() {
                 return Ok(value);
             }
         }
@@ -589,7 +587,7 @@ impl DeviceServer for DeviceImpl {
             .send_extn_request(DeviceInfoRequest::Make)
             .await
         {
-            if let Some(ExtnResponse::String(v)) = response.payload.extract() {
+            if let Some(ExtnResponse::String(v)) = response.extract() {
                 return Ok(v);
             }
         }
@@ -608,7 +606,7 @@ impl DeviceServer for DeviceImpl {
             .await;
 
         match resp {
-            Ok(response) => match response.payload.extract().unwrap() {
+            Ok(response) => match response.extract().unwrap() {
                 DeviceResponse::AudioProfileResponse(audio) => Ok(audio),
                 _ => Err(jsonrpsee::core::Error::Custom(String::from(
                     "Audio error response TBD",
@@ -665,7 +663,7 @@ impl DeviceServer for DeviceImpl {
             .await;
 
         match resp {
-            Ok(response) => match response.payload.extract().unwrap() {
+            Ok(response) => match response.extract().unwrap() {
                 ExtnResponse::NetworkResponse(value) => Ok(value),
                 _ => Err(jsonrpsee::core::Error::Custom(String::from(
                     "Network Status error response TBD",
@@ -726,7 +724,7 @@ impl DeviceServer for DeviceImpl {
             .send_extn_request(AccountSessionRequest::Provision(provision_request))
             .await;
         match resp {
-            Ok(payload) => match payload.payload.extract().unwrap() {
+            Ok(payload) => match payload.extract().unwrap() {
                 ExtnResponse::None(()) => Ok(()),
                 _ => Err(rpc_err("Provision Status error response TBD")),
             },

--- a/core/main/src/firebolt/handlers/discovery_rpc.rs
+++ b/core/main/src/firebolt/handlers/discovery_rpc.rs
@@ -268,7 +268,6 @@ impl DiscoveryImpl {
         let def_lang = match result {
             Ok(extn_message) => {
                 match extn_message
-                    .payload
                     .extract()
                     .unwrap_or_else(|| ExtnResponse::String("en".to_owned()))
                 {
@@ -478,7 +477,7 @@ impl DiscoveryServer for DiscoveryImpl {
             .send_extn_request(AccountLinkRequest::Watched(request))
             .await
         {
-            if let Some(ExtnResponse::Boolean(v)) = response.payload.extract() {
+            if let Some(ExtnResponse::Boolean(v)) = response.extract() {
                 return Ok(v);
             }
         }
@@ -511,7 +510,7 @@ impl DiscoveryServer for DiscoveryImpl {
             .send_extn_request(AccountLinkRequest::Watched(request))
             .await
         {
-            if let Some(ExtnResponse::Boolean(v)) = response.payload.extract() {
+            if let Some(ExtnResponse::Boolean(v)) = response.extract() {
                 return Ok(v);
             }
         }

--- a/core/main/src/firebolt/handlers/localization_rpc.rs
+++ b/core/main/src/firebolt/handlers/localization_rpc.rs
@@ -509,7 +509,7 @@ impl LocalizationServer for LocalizationImpl {
                 "timezone_set: error response TBD",
             )));
         }
-        if let Some(ExtnResponse::AvailableTimezones(timezones)) = resp.unwrap().payload.extract() {
+        if let Some(ExtnResponse::AvailableTimezones(timezones)) = resp.unwrap().extract() {
             if !timezones.contains(&set_request.value) {
                 error!(
                     "timezone_set: Unsupported timezone: tz={}",
@@ -546,7 +546,7 @@ impl LocalizationServer for LocalizationImpl {
             .send_extn_request(DeviceInfoRequest::GetTimezone)
             .await
         {
-            if let Some(ExtnResponse::String(v)) = response.payload.extract() {
+            if let Some(ExtnResponse::String(v)) = response.extract() {
                 return Ok(v);
             }
         }

--- a/core/main/src/firebolt/handlers/privacy_rpc.rs
+++ b/core/main/src/firebolt/handlers/privacy_rpc.rs
@@ -513,8 +513,8 @@ impl PrivacyImpl {
                 let payload = PrivacySettingsStoreRequest::GetPrivacySettings(property);
                 let response = platform_state.get_client().send_extn_request(payload).await;
                 if let Ok(extn_msg) = response {
-                    match extn_msg.payload {
-                        ExtnPayload::Response(res) => match res {
+                    match extn_msg.get_extn_payload() {
+                        Ok(ExtnPayload::Response(res)) => match res {
                             ExtnResponse::Boolean(val) => RpcResult::Ok(val),
                             _ => RpcResult::Err(jsonrpsee::core::Error::Custom(
                                 "Unable to fetch".to_owned(),
@@ -537,7 +537,7 @@ impl PrivacyImpl {
                         dist_session,
                     });
                     if let Ok(resp) = platform_state.get_client().send_extn_request(request).await {
-                        if let Some(ExtnResponse::Boolean(b)) = resp.payload.extract() {
+                        if let Some(ExtnResponse::Boolean(b)) = resp.extract() {
                             return Ok(b);
                         }
                     }
@@ -570,8 +570,8 @@ impl PrivacyImpl {
                 let payload = PrivacySettingsStoreRequest::SetPrivacySettings(property, value);
                 let response = platform_state.get_client().send_extn_request(payload).await;
                 if let Ok(extn_msg) = response {
-                    match extn_msg.payload {
-                        ExtnPayload::Response(res) => match res {
+                    match extn_msg.get_extn_payload() {
+                        Ok(ExtnPayload::Response(res)) => match res {
                             ExtnResponse::None(_) => RpcResult::Ok(()),
                             _ => RpcResult::Err(jsonrpsee::core::Error::Custom(
                                 "Unable to fetch".to_owned(),
@@ -1032,7 +1032,7 @@ impl PrivacyServer for PrivacyImpl {
                 if let Some(dist_session) = self.state.session_state.get_account_session() {
                     let request = PrivacyCloudRequest::GetProperties(dist_session);
                     if let Ok(resp) = self.state.get_client().send_extn_request(request).await {
-                        if let Some(b) = resp.payload.extract() {
+                        if let Some(b) = resp.extract() {
                             return Ok(b);
                         }
                     }

--- a/core/main/src/firebolt/handlers/profile_rpc.rs
+++ b/core/main/src/firebolt/handlers/profile_rpc.rs
@@ -73,7 +73,7 @@ impl ProfileServer for ProfileImpl {
             .send_extn_request(pin_request)
             .await
         {
-            if let Some(ExtnResponse::PinChallenge(v)) = response.payload.extract() {
+            if let Some(ExtnResponse::PinChallenge(v)) = response.extract() {
                 return Ok(v.granted.map_or(false, |inner| inner));
             }
         }
@@ -99,7 +99,7 @@ impl ProfileServer for ProfileImpl {
             .send_extn_request(pin_request)
             .await
         {
-            if let Some(ExtnResponse::PinChallenge(v)) = response.payload.extract() {
+            if let Some(ExtnResponse::PinChallenge(v)) = response.extract() {
                 return Ok(v.granted.map_or(false, |inner| inner));
             }
         }

--- a/core/main/src/firebolt/handlers/secure_storage_rpc.rs
+++ b/core/main/src/firebolt/handlers/secure_storage_rpc.rs
@@ -117,7 +117,7 @@ impl SecureStorageImpl {
                 .await
             {
                 Ok(response) => {
-                    if let Some(ExtnResponse::SecureStorage(_r)) = response.payload.extract() {
+                    if let Some(ExtnResponse::SecureStorage(_r)) = response.extract() {
                         Ok(())
                     } else {
                         Err(get_err_msg(RippleError::ExtnError))
@@ -139,7 +139,7 @@ impl SecureStorageImpl {
                 .await
             {
                 Ok(response) => {
-                    if let Some(ExtnResponse::SecureStorage(_r)) = response.payload.extract() {
+                    if let Some(ExtnResponse::SecureStorage(_r)) = response.extract() {
                         Ok(())
                     } else {
                         Err(get_err_msg(RippleError::ExtnError))
@@ -160,7 +160,7 @@ impl SecureStorageImpl {
                 .await
             {
                 Ok(response) => {
-                    if let Some(ExtnResponse::SecureStorage(_r)) = response.payload.extract() {
+                    if let Some(ExtnResponse::SecureStorage(_r)) = response.extract() {
                         Ok(())
                     } else {
                         Err(get_err_msg(RippleError::ExtnError))
@@ -190,7 +190,7 @@ impl SecureStorageServer for SecureStorageImpl {
             {
                 Ok(response) => {
                     if let Some(ExtnResponse::SecureStorage(SecureStorageResponse::Get(v))) =
-                        response.payload.extract()
+                        response.extract()
                     {
                         Ok(v.value)
                     } else {

--- a/core/main/src/firebolt/handlers/voice_guidance_rpc.rs
+++ b/core/main/src/firebolt/handlers/voice_guidance_rpc.rs
@@ -127,7 +127,7 @@ pub async fn voice_guidance_settings_enabled(state: &PlatformState) -> RpcResult
         .await;
     match resp {
         Ok(value) => {
-            if let Some(ExtnResponse::Boolean(v)) = value.payload.extract() {
+            if let Some(ExtnResponse::Boolean(v)) = value.extract() {
                 Ok(v)
             } else {
                 Err(jsonrpsee::core::Error::Custom(String::from(
@@ -148,7 +148,7 @@ pub async fn voice_guidance_settings_speed(state: &PlatformState) -> RpcResult<f
         .await;
     match resp {
         Ok(value) => {
-            if let Some(ExtnResponse::Float(v)) = value.payload.extract() {
+            if let Some(ExtnResponse::Float(v)) = value.extract() {
                 Ok(v)
             } else {
                 Err(jsonrpsee::core::Error::Custom(String::from(

--- a/core/main/src/firebolt/handlers/wifi_rpc.rs
+++ b/core/main/src/firebolt/handlers/wifi_rpc.rs
@@ -72,7 +72,7 @@ impl WifiServer for WifiImpl {
             .send_extn_request(WifiRequest::Scan(scan_time.timeout))
             .await
         {
-            match response.payload.extract() {
+            match response.extract() {
                 Some(WifiResponse::WifiScanListResponse(v)) => Ok(v),
                 _ => Err(rpc_err("Wifi scan error response TBD")),
             }
@@ -91,7 +91,7 @@ impl WifiServer for WifiImpl {
         let scan_process = client.send_extn_request(WifiRequest::Connect(connect_request));
 
         match scan_process.await {
-            Ok(response) => match response.payload.extract() {
+            Ok(response) => match response.extract() {
                 Some(WifiResponse::WifiConnectSuccessResponse(v)) => Ok(v),
                 Some(WifiResponse::CustomError(s)) => Err(rpc_err(s)),
                 _ => Err(rpc_err("Wifi scan response unknown format")),

--- a/core/main/src/processor/account_link_processor.rs
+++ b/core/main/src/processor/account_link_processor.rs
@@ -91,7 +91,7 @@ impl AccountLinkProcessor {
         let resp = state.get_client().send_extn_request(payload).await;
 
         if let Ok(v) = resp {
-            if let Some(ExtnResponse::None(())) = v.payload.extract() {
+            if let Some(ExtnResponse::None(())) = v.extract() {
                 return Self::respond(
                     state.get_client().get_extn_client(),
                     msg,
@@ -167,7 +167,7 @@ impl AccountLinkProcessor {
 
         let resp = state.get_client().send_extn_request(payload).await;
         if let Ok(v) = resp {
-            if let Some(ExtnResponse::None(())) = v.payload.extract() {
+            if let Some(ExtnResponse::None(())) = v.extract() {
                 return Self::respond(
                     state.get_client().get_extn_client(),
                     msg,
@@ -207,7 +207,7 @@ impl AccountLinkProcessor {
 
         let resp = state.get_client().send_extn_request(payload).await;
         if let Ok(v) = resp {
-            if let Some(ExtnResponse::None(())) = v.payload.extract() {
+            if let Some(ExtnResponse::None(())) = v.extract() {
                 return Self::respond(
                     state.get_client().get_extn_client(),
                     msg,

--- a/core/main/src/processor/config_processor.rs
+++ b/core/main/src/processor/config_processor.rs
@@ -146,7 +146,7 @@ impl ExtnRequestProcessor for ConfigRequestProcessor {
                         .send_extn_request(RfcRequest { flag })
                         .await
                     {
-                        if let Some(ExtnResponse::Value(v)) = v.payload.extract() {
+                        if let Some(ExtnResponse::Value(v)) = v.extract() {
                             resp = ExtnResponse::Value(v);
                         }
                     }

--- a/core/main/src/processor/main_context_processor.rs
+++ b/core/main/src/processor/main_context_processor.rs
@@ -90,7 +90,7 @@ impl MainContextProcessor {
             .send_extn_request(AccountSessionRequest::Get)
             .await
         {
-            if let Some(session) = response.payload.extract() {
+            if let Some(session) = response.extract() {
                 state.session_state.insert_account_session(session);
                 MetricsState::update_account_session(state).await;
                 event = CapEvent::OnAvailable;
@@ -104,7 +104,7 @@ impl MainContextProcessor {
                     {
                         if let Some(ExtnResponse::AccountSession(
                             AccountSessionResponse::AccountSessionToken(token),
-                        )) = response.payload.extract::<ExtnResponse>()
+                        )) = response.extract::<ExtnResponse>()
                         {
                             state_c.get_client().get_extn_client().context_update(
                                 ripple_sdk::api::context::RippleContextUpdateRequest::Token(token),

--- a/core/main/src/processor/storage/storage_manager.rs
+++ b/core/main/src/processor/storage/storage_manager.rs
@@ -482,7 +482,7 @@ impl StorageManager {
 
         match result {
             Ok(msg) => {
-                if let Some(m) = msg.payload.extract() {
+                if let Some(m) = msg.extract() {
                     Ok(m)
                 } else {
                     Err(RippleError::ParseError)
@@ -508,7 +508,7 @@ impl StorageManager {
             .await;
         match result {
             Ok(msg) => {
-                if let Some(m) = msg.payload.extract() {
+                if let Some(m) = msg.extract() {
                     Ok(m)
                 } else {
                     Err(RippleError::ParseError)

--- a/core/main/src/service/apps/apps_updater.rs
+++ b/core/main/src/service/apps/apps_updater.rs
@@ -283,25 +283,18 @@ pub async fn update(mut state: AppsUpdaterState, apps_catalog_update: AppsCatalo
         .client
         .request(AppsRequest::GetInstalledApps(None))
         .await;
-    if let Err(e) = resp {
-        error!("update: Could not retrieve app list: e={:?}", e);
+    if resp.is_err() {
+        error!("update: Could not retrieve app list: e={:?}", resp.err());
         return;
     }
 
-    let installed_apps = match resp.unwrap().payload {
-        ExtnPayload::Response(response) => match response {
-            ExtnResponse::InstalledApps(apps) => apps,
-            _ => {
-                error!("update: Unexpected response");
-                return;
-            }
-        },
+    let installed_apps = match resp.unwrap().get_extn_payload() {
+        Ok(ExtnPayload::Response(ExtnResponse::InstalledApps(apps))) => apps,
         _ => {
-            error!("update: Unexpected payload");
+            error!("update: Unexpected response");
             return;
         }
     };
-
     debug!(
         "update: apps_update={:?}, installed_apps={:?}",
         apps_catalog_update,

--- a/core/main/src/service/context_manager.rs
+++ b/core/main/src/service/context_manager.rs
@@ -99,9 +99,7 @@ impl ContextManager {
                 .send_extn_request(DeviceInfoRequest::PowerState)
                 .await
             {
-                if let Some(DeviceResponse::PowerState(p)) =
-                    resp.payload.extract::<DeviceResponse>()
-                {
+                if let Some(DeviceResponse::PowerState(p)) = resp.extract::<DeviceResponse>() {
                     ps_c.get_client().get_extn_client().context_update(
                         RippleContextUpdateRequest::PowerState(SystemPowerState {
                             current_power_state: p.clone(),
@@ -122,7 +120,7 @@ impl ContextManager {
             {
                 ripple_sdk::log::debug!("[RIPPLE CONTEXT] Sending OnInternetConnected request");
                 if let Some(DeviceResponse::InternetConnectionStatus(s)) =
-                    resp.payload.extract::<DeviceResponse>()
+                    resp.extract::<DeviceResponse>()
                 {
                     ripple_sdk::log::debug!(
                         "[RIPPLE CONTEXT] OnInternetConnected response: {:?}",
@@ -145,7 +143,7 @@ impl ContextManager {
                 .await
             {
                 if let Some(ExtnResponse::TimezoneWithOffset(tz, offset)) =
-                    resp.payload.extract::<ExtnResponse>()
+                    resp.extract::<ExtnResponse>()
                 {
                     ps_c.get_client().get_extn_client().context_update(
                         RippleContextUpdateRequest::TimeZone(TimeZone {
@@ -164,7 +162,7 @@ impl ContextManager {
             {
                 if let Some(ExtnResponse::AccountSession(
                     AccountSessionResponse::AccountSessionToken(account_token),
-                )) = resp.payload.extract::<ExtnResponse>()
+                )) = resp.extract::<ExtnResponse>()
                 {
                     ps_c.get_client()
                         .get_extn_client()
@@ -185,7 +183,7 @@ impl ContextManager {
             {
                 if let Some(ExtnResponse::AccountSession(
                     AccountSessionResponse::AccountSessionToken(token),
-                )) = response.payload.extract::<ExtnResponse>()
+                )) = response.extract::<ExtnResponse>()
                 {
                     state_c.get_client().get_extn_client().context_update(
                         ripple_sdk::api::context::RippleContextUpdateRequest::Token(token),

--- a/core/main/src/service/data_governance.rs
+++ b/core/main/src/service/data_governance.rs
@@ -192,7 +192,7 @@ impl DataGovernance {
                 .send_extn_request(PrivacyCloudRequest::GetPartnerExclusions(session))
                 .await
             {
-                if let Some(excl) = response.payload.clone().extract::<ExclusionPolicy>() {
+                if let Some(excl) = response.extract::<ExclusionPolicy>() {
                     DataGovernance::update_local_exclusion_policy(
                         &state.data_governance,
                         excl.clone(),

--- a/core/main/src/state/cap/permitted_state.rs
+++ b/core/main/src/state/cap/permitted_state.rs
@@ -186,8 +186,7 @@ impl PermissionHandler {
                 .ok()
             {
                 Some(extn_response) => {
-                    if let Some(permission_response) =
-                        extn_response.payload.extract::<PermissionResponse>()
+                    if let Some(permission_response) = extn_response.extract::<PermissionResponse>()
                     {
                         let mut permission_response_copy = permission_response;
                         return Self::process_permissions(
@@ -215,8 +214,8 @@ impl PermissionHandler {
             .request(AppsRequest::GetFireboltPermissions(app_id.to_string()))
             .await?;
 
-        let mut permissions = match resp.payload {
-            ExtnPayload::Response(response) => match response {
+        let mut permissions = match resp.get_extn_payload() {
+            Ok(ExtnPayload::Response(response)) => match response {
                 ExtnResponse::Permission(perms) => perms,
                 ExtnResponse::Error(e) => {
                     error!("device_fetch_and_store: e={:?}", e);

--- a/core/main/src/state/metrics_state.rs
+++ b/core/main/src/state/metrics_state.rs
@@ -96,7 +96,7 @@ impl MetricsState {
             .send_extn_request(DeviceInfoRequest::MacAddress)
             .await
         {
-            if let Some(ExtnResponse::String(mac)) = resp.payload.extract() {
+            if let Some(ExtnResponse::String(mac)) = resp.extract() {
                 let _ = mac_address.insert(mac);
             }
         }
@@ -107,7 +107,7 @@ impl MetricsState {
             .send_extn_request(DeviceInfoRequest::SerialNumber)
             .await
         {
-            if let Some(ExtnResponse::String(sn)) = resp.payload.extract() {
+            if let Some(ExtnResponse::String(sn)) = resp.extract() {
                 let _ = serial_number.insert(sn);
             }
         }
@@ -118,7 +118,7 @@ impl MetricsState {
             .send_extn_request(DeviceInfoRequest::Model)
             .await
         {
-            if let Some(ExtnResponse::String(model)) = resp.payload.extract() {
+            if let Some(ExtnResponse::String(model)) = resp.extract() {
                 let _ = device_model.insert(model);
             }
         }
@@ -149,7 +149,7 @@ impl MetricsState {
             .send_extn_request(DeviceInfoRequest::GetTimezoneWithOffset)
             .await
         {
-            if let Some(ExtnResponse::TimezoneWithOffset(tz, offset)) = resp.payload.extract() {
+            if let Some(ExtnResponse::TimezoneWithOffset(tz, offset)) = resp.extract() {
                 timezone = Some(format!("{} {}", tz, offset));
             }
         }
@@ -160,7 +160,7 @@ impl MetricsState {
             .await
         {
             Ok(resp) => {
-                if let Some(DeviceResponse::PlatformBuildInfo(info)) = resp.payload.extract() {
+                if let Some(DeviceResponse::PlatformBuildInfo(info)) = resp.extract() {
                     info.name
                 } else {
                     String::default()
@@ -215,7 +215,7 @@ impl MetricsState {
             .await
         {
             Ok(message) => {
-                if let Some(DeviceResponse::FirmwareInfo(info)) = message.payload.extract() {
+                if let Some(DeviceResponse::FirmwareInfo(info)) = message.extract() {
                     Ok(info)
                 } else {
                     Err(RippleError::InvalidOutput)

--- a/core/sdk/src/api/context.rs
+++ b/core/sdk/src/api/context.rs
@@ -79,8 +79,12 @@ pub enum RippleContextUpdateType {
 }
 
 impl RippleContext {
-    pub fn is_ripple_context(msg: &ExtnPayload) -> Option<Self> {
-        RippleContext::get_from_payload(msg.clone())
+    pub fn is_ripple_context(msg: &ExtnMessage) -> Option<Self> {
+        if let Ok(v) = msg.get_extn_payload() {
+            RippleContext::get_from_payload(v)
+        } else {
+            None
+        }
     }
 
     pub fn update(&mut self, request: RippleContextUpdateRequest) -> bool {
@@ -181,7 +185,7 @@ impl RippleContext {
             requestor: ExtnId::get_main_target("ripple_context".to_owned()),
             target: RippleContract::RippleContext,
             target_id: None,
-            payload: self.get_extn_payload(),
+            payload: self.get_extn_payload().as_value(),
             callback: None,
             ts: None,
         }
@@ -229,8 +233,12 @@ pub enum RippleContextUpdateRequest {
 }
 
 impl RippleContextUpdateRequest {
-    pub fn is_ripple_context_update(msg: &ExtnPayload) -> Option<RippleContextUpdateRequest> {
-        RippleContextUpdateRequest::get_from_payload(msg.clone())
+    pub fn is_ripple_context_update(msg: &ExtnMessage) -> Option<RippleContextUpdateRequest> {
+        if let Ok(v) = msg.get_extn_payload() {
+            RippleContextUpdateRequest::get_from_payload(v)
+        } else {
+            None
+        }
     }
 }
 

--- a/core/sdk/src/api/device/device_info_request.rs
+++ b/core/sdk/src/api/device/device_info_request.rs
@@ -168,7 +168,7 @@ impl DeviceInfo {
         if resp_res.is_err() {
             return false;
         }
-        let device_resp = resp_res.unwrap().payload.extract::<DeviceResponse>();
+        let device_resp = resp_res.unwrap().extract::<DeviceResponse>();
         if device_resp.is_none() {
             return false;
         }

--- a/core/sdk/src/api/distributor/distributor_privacy.rs
+++ b/core/sdk/src/api/distributor/distributor_privacy.rs
@@ -84,6 +84,10 @@ impl PrivacySettings {
             allow_watch_history: false,
         }
     }
+
+    pub fn as_response(&self) -> ExtnResponse {
+        ExtnResponse::Value(serde_json::to_value(self.clone()).unwrap())
+    }
 }
 
 impl Default for PrivacySettings {
@@ -147,9 +151,7 @@ impl ExtnPayloadProvider for PrivacySettings {
     }
 
     fn get_extn_payload(&self) -> ExtnPayload {
-        ExtnPayload::Response(ExtnResponse::Value(
-            serde_json::to_value(self.clone()).unwrap(),
-        ))
+        ExtnPayload::Response(self.as_response())
     }
 
     fn contract() -> crate::framework::ripple_contract::RippleContract {
@@ -262,6 +264,12 @@ pub struct ExclusionPolicy {
     pub watch_history: Option<ExclusionPolicyData>,
 }
 
+impl ExclusionPolicy {
+    pub fn as_response(&self) -> ExtnResponse {
+        ExtnResponse::Value(serde_json::to_value(self.clone()).unwrap())
+    }
+}
+
 impl ExtnPayloadProvider for ExclusionPolicy {
     fn get_from_payload(payload: ExtnPayload) -> Option<Self> {
         if let ExtnPayload::Response(ExtnResponse::Value(v)) = payload {
@@ -274,9 +282,7 @@ impl ExtnPayloadProvider for ExclusionPolicy {
     }
 
     fn get_extn_payload(&self) -> ExtnPayload {
-        ExtnPayload::Response(ExtnResponse::Value(
-            serde_json::to_value(self.clone()).unwrap(),
-        ))
+        ExtnPayload::Response(self.as_response())
     }
 
     fn contract() -> crate::framework::ripple_contract::RippleContract {

--- a/core/sdk/src/api/manifest/remote_feature.rs
+++ b/core/sdk/src/api/manifest/remote_feature.rs
@@ -35,7 +35,7 @@ impl RemoteFeature {
         let rfc_res = extn_client.request(Config::RFC(key.clone())).await;
         let mut val = flag_cfg.default;
         if let Ok(resp) = rfc_res {
-            if let Some(ExtnResponse::Value(v)) = resp.payload.extract::<ExtnResponse>() {
+            if let Some(ExtnResponse::Value(v)) = resp.extract::<ExtnResponse>() {
                 info!("RFC Value for {} = {}", key, v);
                 val = val_to_bool_parse(v, flag_cfg.default);
             } else {

--- a/core/sdk/src/extn/client/extn_client.rs
+++ b/core/sdk/src/extn/client/extn_client.rs
@@ -1622,7 +1622,7 @@ pub mod tests {
             requestor: ExtnId::get_main_target("main".into()),
             target: RippleContract::Internal,
             target_id: None,
-            payload: ExtnPayload::Response(exp_resp.clone()).as_value(),
+            payload: ExtnPayload::Response(exp_resp).as_value(),
             callback: None,
             ts: Some(Utc::now().timestamp_millis()),
         };
@@ -1790,7 +1790,7 @@ pub mod tests {
         };
 
         let response = ExtnResponse::String("test_make".to_string());
-        let result = extn_client.respond(req.clone(), response.clone()).await;
+        let result = extn_client.respond(req.clone(), response).await;
         assert!(result.is_ok());
 
         if let Ok(received_msg) = mock_rx.recv().await {

--- a/core/sdk/src/extn/client/extn_processor.rs
+++ b/core/sdk/src/extn/client/extn_processor.rs
@@ -230,7 +230,7 @@ pub trait ExtnRequestProcessor: ExtnStreamProcessor + Send + Sync + 'static {
     }
 
     async fn ack(mut extn_client: ExtnClient, request: ExtnMessage) -> RippleResponse {
-        return extn_client.send_message(request.ack()).await;
+        extn_client.send_message(request.ack()).await
     }
 
     async fn run(&mut self) {

--- a/core/sdk/src/extn/client/extn_processor.rs
+++ b/core/sdk/src/extn/client/extn_processor.rs
@@ -574,7 +574,7 @@ pub mod tests {
         let result = MockEventProcessor::process_event(
             processor.get_state(),
             mock_message.clone(),
-            mock_extracted_message.clone(),
+            mock_extracted_message,
         )
         .await;
 
@@ -668,9 +668,9 @@ pub mod tests {
         assert!(!MockEventProcessor::check_message_type(&request_message));
     }
 
-    #[rstest(exp_resp, case(Some(ExtnResponse::Boolean(true))))]
+    #[rstest(exp_resp, case(true))]
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_request_processor_run(exp_resp: Option<ExtnResponse>) {
+    async fn test_request_processor_run(exp_resp: bool) {
         let (mock_sender, receiver) = ExtnSender::mock();
         let mut extn_client = ExtnClient::new(receiver, mock_sender.clone());
         let processor = MockRequestProcessor {
@@ -692,7 +692,7 @@ pub mod tests {
             .request(MockRequest {
                 app_id: "test_app_id".to_string(),
                 contract: RippleContract::Internal,
-                expected_response: exp_resp.clone(),
+                expected_response: Some(ExtnResponse::Boolean(exp_resp)),
             })
             .await;
 
@@ -703,7 +703,7 @@ pub mod tests {
                     requestor: ExtnId::get_main_target("main".into()),
                     target: RippleContract::Internal,
                     target_id: None,
-                    payload: ExtnPayload::Response(exp_resp.clone().unwrap()).as_value(),
+                    payload: ExtnPayload::Response(ExtnResponse::Boolean(exp_resp)).as_value(),
                     callback: None,
                     ts: Some(Utc::now().timestamp_millis()),
                 };

--- a/core/sdk/src/extn/client/wait_for_service_processor.rs
+++ b/core/sdk/src/extn/client/wait_for_service_processor.rs
@@ -137,7 +137,7 @@ mod tests {
             requestor: ExtnId::new_channel(ExtnClassId::Device, "info".to_string()),
             target: RippleContract::Internal,
             target_id: Some(ExtnId::get_main_target("main".into())),
-            payload: ExtnPayload::Request(ExtnRequest::Config(Config::DefaultName)),
+            payload: ExtnPayload::Request(ExtnRequest::Config(Config::DefaultName)).as_value(),
             callback: None,
             ts: Some(1234567890),
         };
@@ -187,7 +187,7 @@ mod tests {
             requestor: ExtnId::new_channel(ExtnClassId::Device, "other".to_string()),
             target: RippleContract::Internal,
             target_id: Some(ExtnId::get_main_target("main".into())),
-            payload: ExtnPayload::Request(ExtnRequest::Config(Config::DefaultName)),
+            payload: ExtnPayload::Request(ExtnRequest::Config(Config::DefaultName)).as_value(),
             callback: None,
             ts: Some(1234567890),
         };
@@ -242,7 +242,7 @@ mod tests {
             requestor: ExtnId::new_channel(ExtnClassId::Device, "other".to_string()),
             target: RippleContract::Internal,
             target_id: Some(ExtnId::get_main_target("main".into())),
-            payload: ExtnPayload::Request(ExtnRequest::Config(Config::DefaultName)),
+            payload: ExtnPayload::Request(ExtnRequest::Config(Config::DefaultName)).as_value(),
             callback: None,
             ts: Some(1234567890),
         };
@@ -279,7 +279,7 @@ mod tests {
             requestor: ExtnId::new_channel(ExtnClassId::Device, "info".to_string()),
             target: RippleContract::Internal,
             target_id: Some(ExtnId::get_main_target("main".into())),
-            payload: ExtnPayload::Request(ExtnRequest::Config(Config::DefaultName)),
+            payload: ExtnPayload::Request(ExtnRequest::Config(Config::DefaultName)).as_value(),
             callback: None,
             ts: Some(1234567890),
         };

--- a/core/sdk/src/extn/extn_client_message.rs
+++ b/core/sdk/src/extn/extn_client_message.rs
@@ -111,7 +111,13 @@ impl ExtnMessage {
     }
 
     pub fn get_extn_payload(&self) -> Result<ExtnPayload, RippleError> {
-        serde_json::from_value(self.payload.clone()).unwrap_or(Err(RippleError::ParseError))
+        match serde_json::from_value(self.payload.clone()) {
+            Ok(v) => Ok(v),
+            Err(e) => {
+                error!("Error in get_extn_payload {:?}", e);
+                Err(RippleError::ParseError)
+            }
+        }
     }
 
     /// This method can be used to create [ExtnResponse] payload message from a given [ExtnRequest]

--- a/core/sdk/src/extn/extn_client_message.rs
+++ b/core/sdk/src/extn/extn_client_message.rs
@@ -295,7 +295,7 @@ where
     fn contract() -> RippleContract;
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum ExtnRequest {
     Config(Config),
     Rpc(RpcRequest),
@@ -333,7 +333,7 @@ pub enum ExtnRequest {
 
 impl ExtnPayloadProvider for ExtnRequest {
     fn get_extn_payload(&self) -> ExtnPayload {
-        ExtnPayload::Request(self.clone())
+        ExtnPayload::Request(serde_json::from_value(serde_json::to_value(self).unwrap()).unwrap())
     }
 
     fn get_from_payload(payload: ExtnPayload) -> Option<Self> {
@@ -398,7 +398,7 @@ impl ExtnPayloadProvider for ExtnResponse {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum ExtnEvent {
     String(String),
     Value(Value),
@@ -414,7 +414,7 @@ pub enum ExtnEvent {
 
 impl ExtnPayloadProvider for ExtnEvent {
     fn get_extn_payload(&self) -> ExtnPayload {
-        ExtnPayload::Event(self.clone())
+        ExtnPayload::Event(serde_json::from_value(serde_json::to_value(self).unwrap()).unwrap())
     }
 
     fn get_from_payload(payload: ExtnPayload) -> Option<Self> {
@@ -606,9 +606,12 @@ mod tests {
     #[test]
     fn test_get_from_payload_with_valid_payload() {
         let event_payload = ExtnEvent::String("Event".to_string());
-        let extn_payload = ExtnPayload::Event(event_payload.clone());
+        let extn_payload = ExtnPayload::Event(event_payload);
         let extracted_event: Option<ExtnEvent> = ExtnEvent::get_from_payload(extn_payload);
-        assert_eq!(extracted_event, Some(event_payload));
+        assert_eq!(
+            extracted_event,
+            Some(ExtnEvent::String("Event".to_string()))
+        );
     }
 
     #[test]

--- a/core/sdk/src/extn/ffi/ffi_message.rs
+++ b/core/sdk/src/extn/ffi/ffi_message.rs
@@ -46,7 +46,7 @@ pub struct CExtnMessage {
 
 impl From<ExtnMessage> for CExtnMessage {
     fn from(value: ExtnMessage) -> Self {
-        let payload: String = value.payload.into();
+        let payload: String = value.payload.to_string();
         CExtnMessage {
             callback: value.callback,
             id: value.id,
@@ -88,7 +88,7 @@ impl TryInto<ExtnMessage> for CExtnMessage {
         if payload.is_err() {
             return Err(RippleError::ParseError);
         }
-        let payload = payload.unwrap();
+        let payload = serde_json::to_value(payload.unwrap()).unwrap();
         let ts = Some(self.ts);
         Ok(ExtnMessage {
             callback: self.callback,
@@ -121,7 +121,7 @@ mod tests {
             requestor: ExtnId::new_channel(ExtnClassId::Device, "info".to_string()),
             target: RippleContract::Internal,
             target_id: Some(ExtnId::get_main_target("main".into())),
-            payload: ExtnPayload::Request(ExtnRequest::Config(Config::DefaultName)),
+            payload: ExtnPayload::Request(ExtnRequest::Config(Config::DefaultName)).as_value(),
             callback: None,
             ts: Some(1234567890),
         };
@@ -208,7 +208,7 @@ mod tests {
                     assert_eq!(extn_message.target, RippleContract::DeviceInfo);
                     assert_eq!(extn_message.target_id, None);
                     assert_eq!(
-                        extn_message.payload,
+                        extn_message.get_extn_payload().unwrap(),
                         ExtnPayload::Request(ExtnRequest::Config(
                             crate::api::config::Config::DefaultName
                         ))

--- a/core/sdk/src/extn/mock_extension_client.rs
+++ b/core/sdk/src/extn/mock_extension_client.rs
@@ -200,7 +200,7 @@ impl MockExtnClient {
         ExtnMessage {
             callback: None,
             id: Uuid::new_v4().to_string(),
-            payload: ExtnPayload::Request(req),
+            payload: ExtnPayload::Request(req).as_value(),
             requestor: ExtnId::new_channel(ExtnClassId::Internal, "test".into()),
             target: contract,
             target_id: None,

--- a/core/sdk/src/utils/mock_utils.rs
+++ b/core/sdk/src/utils/mock_utils.rs
@@ -111,8 +111,8 @@ pub fn get_mock_message(payload_type: PayloadType) -> ExtnMessage {
         target: RippleContract::Internal,
         target_id: Some(ExtnId::get_main_target("main".into())),
         payload: match payload_type {
-            PayloadType::Event => get_mock_event_payload(),
-            PayloadType::Request => get_mock_request_payload(),
+            PayloadType::Event => get_mock_event_payload().as_value(),
+            PayloadType::Request => get_mock_request_payload().as_value(),
         },
         callback: None,
         ts: Some(Utc::now().timestamp_millis()),

--- a/core/sdk/src/utils/mock_utils.rs
+++ b/core/sdk/src/utils/mock_utils.rs
@@ -28,7 +28,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct MockEvent {
     pub event_name: String,
     pub result: Value,
@@ -39,9 +39,7 @@ pub struct MockEvent {
 
 impl ExtnPayloadProvider for MockEvent {
     fn get_extn_payload(&self) -> ExtnPayload {
-        ExtnPayload::Event(ExtnEvent::Value(
-            serde_json::to_value(self.clone()).unwrap(),
-        ))
+        ExtnPayload::Event(ExtnEvent::Value(serde_json::to_value(self).unwrap()))
     }
 
     fn get_from_payload(payload: ExtnPayload) -> Option<Self> {
@@ -59,7 +57,7 @@ impl ExtnPayloadProvider for MockEvent {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct MockRequest {
     pub app_id: String,
     pub contract: RippleContract,
@@ -77,9 +75,7 @@ impl ExtnPayloadProvider for MockRequest {
     }
 
     fn get_extn_payload(&self) -> ExtnPayload {
-        ExtnPayload::Request(ExtnRequest::Extn(
-            serde_json::to_value(self.clone()).unwrap(),
-        ))
+        ExtnPayload::Request(ExtnRequest::Extn(serde_json::to_value(self).unwrap()))
     }
 
     fn get_contract(&self) -> RippleContract {

--- a/device/thunder_ripple_sdk/src/bootstrap/get_config_step.rs
+++ b/device/thunder_ripple_sdk/src/bootstrap/get_config_step.rs
@@ -66,7 +66,7 @@ impl ThunderGetConfigStep {
         let extn_message_response: Result<ExtnMessage, RippleError> =
             state.request(Config::PlatformParameters).await;
         if let Ok(message) = extn_message_response {
-            if let Some(ExtnResponse::Value(v)) = message.payload.extract() {
+            if let Some(ExtnResponse::Value(v)) = message.extract() {
                 let mut pool_size = POOL_SIZE_DEFAULT;
                 let tp_res: Result<ThunderPlatformParameters, Error> = serde_json::from_value(v);
                 let mut gateway_url = url::Url::parse(GATEWAY_DEFAULT).unwrap();

--- a/device/thunder_ripple_sdk/src/events/thunder_event_processor.rs
+++ b/device/thunder_ripple_sdk/src/events/thunder_event_processor.rs
@@ -320,14 +320,11 @@ impl ThunderEventProcessor {
 
     pub fn add_last_event(&self, event_name: &str, value: &ExtnEvent) {
         let mut last_event_map = self.last_event.write().unwrap();
-        last_event_map.insert(
-            event_name.to_string(),
-            serde_json::to_value(value.clone()).unwrap(),
-        );
+        last_event_map.insert(event_name.to_string(), serde_json::to_value(value).unwrap());
     }
 
     pub fn check_last_event(&self, event_name: &str, value: &ExtnEvent) -> bool {
-        let ref_value = serde_json::to_value(value.clone()).unwrap();
+        let ref_value = serde_json::to_value(value).unwrap();
         let last_event_map = self.last_event.read().unwrap();
         if let Some(last_event) = last_event_map.get(event_name) {
             return last_event.eq(&ref_value);

--- a/device/thunder_ripple_sdk/src/processors/thunder_device_info.rs
+++ b/device/thunder_ripple_sdk/src/processors/thunder_device_info.rs
@@ -901,7 +901,7 @@ impl ThunderDeviceInfoRequestProcessor {
             return resolution;
         }
         if let Ok(response) = state.get_client().request(Config::DefaultValues).await {
-            if let Some(ExtnResponse::Value(value)) = response.payload.extract() {
+            if let Some(ExtnResponse::Value(value)) = response.extract() {
                 if let Ok(default_values) = serde_json::from_value::<DefaultValues>(value) {
                     return default_values.video_dimensions;
                 }
@@ -1753,7 +1753,7 @@ pub mod tests {
         )
         .await;
         let msg: ExtnMessage = r.recv().await.unwrap().try_into().unwrap();
-        let resp_opt = msg.payload.extract::<DeviceResponse>();
+        let resp_opt = msg.extract::<DeviceResponse>();
         if let Some(DeviceResponse::PlatformBuildInfo(info)) = resp_opt {
             let exp = tests.iter().find(|x| x.build_name == build_name).unwrap();
             assert_eq!(info, exp.info);

--- a/device/thunder_ripple_sdk/src/tests/contracts/contract_utils.rs
+++ b/device/thunder_ripple_sdk/src/tests/contracts/contract_utils.rs
@@ -153,7 +153,7 @@ pub fn get_extn_msg(payload: ExtnPayload) -> ExtnMessage {
     ExtnMessage {
         callback: None,
         id: "SomeId".into(),
-        payload,
+        payload: payload.as_value(),
         requestor: ExtnId::new_channel(ExtnClassId::Device, "pact".into()),
         target: RippleContract::DeviceInfo,
         target_id: None,

--- a/distributor/general/src/distributor_general_ffi.rs
+++ b/distributor/general/src/distributor_general_ffi.rs
@@ -90,7 +90,7 @@ fn start_launcher(sender: ExtnSender, receiver: CReceiver<CExtnMessage>) {
         let client_c = client.clone();
         tokio::spawn(async move {
             if let Ok(response) = client.request(Config::SavedDir).await {
-                if let Some(ExtnResponse::String(value)) = response.payload.extract() {
+                if let Some(ExtnResponse::String(value)) = response.extract() {
                     client.add_request_processor(DistributorPrivacyProcessor::new(
                         client.clone(),
                         value.clone(),

--- a/examples/rpc_extn/src/rpc/legacy_jsonrpsee_extn.rs
+++ b/examples/rpc_extn/src/rpc/legacy_jsonrpsee_extn.rs
@@ -83,7 +83,7 @@ impl LegacyServer for LegacyImpl {
             params_json: RpcRequest::prepend_ctx(Some(serde_json::Value::Null), &new_ctx),
         };
         if let Ok(msg) = client.request(rpc_request).await {
-            if let Some(ExtnResponse::Value(v)) = msg.payload.extract() {
+            if let Some(ExtnResponse::Value(v)) = msg.extract() {
                 if let Some(v) = v.as_str() {
                     return Ok(v.into());
                 }


### PR DESCRIPTION
## What

Removes the Clone trait from Extn Messages 

## Why

Based on a cargo bloat Run ExtnMessage and its enums have the most size in the executable. Major contributor for this is the Clone Trait

## How

Given Serialization and Deserialization is already inherent in the ExtnMessage clone trait is redundant. 

## Test

Run Cargo bloat again and validate the results  with and without these changes

## Checklist

- [ ] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
