### PR TITLE
Thunder plugin handling

### DIFF
--- a/core/main/src/bootstrap/extn/start_extn_channel_step.rs
+++ b/core/main/src/bootstrap/extn/start_extn_channel_step.rs
@@ -83,7 +83,7 @@ impl Bootstep<BootstrapState> for StartExtnChannelsStep {
             {
                 while let Some(v) = tr.recv().await {
                     match v {
-                        ExtnStatus::Ready => continue,
+                        ExtnStatus::Ready => break,
                         // When Extension is in this state means it has minimal success criteria for continuing
                         // yet not fully ready due to some errors.
                         // Expectation of the system here progressive to wait for an eventual success

--- a/core/main/src/bootstrap/extn/start_extn_channel_step.rs
+++ b/core/main/src/bootstrap/extn/start_extn_channel_step.rs
@@ -15,14 +15,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use std::time::Duration;
-
 use ripple_sdk::{
     api::status_update::ExtnStatus,
     async_trait::async_trait,
     framework::{bootstrap::Bootstep, RippleResponse},
-    log::error,
-    tokio::{sync::mpsc, time::timeout},
+    log::{error, warn},
+    tokio::sync::mpsc,
     utils::error::RippleError,
 };
 
@@ -77,27 +75,24 @@ impl Bootstep<BootstrapState> for StartExtnChannelsStep {
                 }
             }
         }
-        let t = state.platform_state.get_manifest().get_timeout();
         for extn_id in extn_ids {
             let (tx, mut tr) = mpsc::channel(1);
             if !state
                 .extn_state
                 .add_extn_status_listener(extn_id.clone(), tx)
             {
-                match timeout(Duration::from_millis(t), tr.recv()).await {
-                    Ok(Some(v)) => {
-                        state.extn_state.clear_status_listener(extn_id);
-                        match v {
-                            ExtnStatus::Ready => continue,
-                            _ => return Err(RippleError::BootstrapError),
+                while let Some(v) = tr.recv().await {
+                    match v {
+                        ExtnStatus::Ready => continue,
+                        // When Extension is in this state means it has minimal success criteria for continuing
+                        // yet not fully ready due to some errors.
+                        // Expectation of the system here progressive to wait for an eventual success
+                        // without exiting with the error
+                        ExtnStatus::Interrupted => warn!("{} extension is interrupted state. Bootstrap currently paused until extension becomes ready.", extn_id.to_string()),
+                        ExtnStatus::Error => {
+                            error!("{} extension failed to load. Ripple needs to be restarted.",extn_id.to_string());
+                            return Err(RippleError::BootstrapError);
                         }
-                    }
-                    Ok(None) => {
-                        error!("Extn={:?} dropped its memory", extn_id);
-                    }
-                    Err(_) => {
-                        error!("Extn={:?} failed to load timeout occurred", extn_id);
-                        return Err(RippleError::BootstrapError);
                     }
                 }
             }

--- a/core/sdk/src/api/device/device_request.rs
+++ b/core/sdk/src/api/device/device_request.rs
@@ -162,7 +162,7 @@ impl FromStr for NetworkType {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct HDCPStatus {
     pub is_connected: bool,

--- a/device/thunder_ripple_sdk/src/bootstrap/setup_thunder_pool_step.rs
+++ b/device/thunder_ripple_sdk/src/bootstrap/setup_thunder_pool_step.rs
@@ -15,9 +15,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use std::time::Duration;
+
 use ripple_sdk::{
     api::status_update::ExtnStatus,
-    log::{info, warn},
+    log::{error, info, warn},
     utils::error::RippleError,
 };
 
@@ -45,18 +47,48 @@ impl ThunderPoolStep {
             warn!("Pool size of 1 is not recommended, there will be no dedicated connection for Controller events");
             return Err(RippleError::BootstrapError);
         }
-        let controller_pool =
-            ThunderClientPool::start(url.clone(), None, thunder_connection_state.clone(), 1).await;
+        let controller_pool = ripple_sdk::tokio::time::timeout(
+            Duration::from_secs(10),
+            ThunderClientPool::start(url.clone(), None, thunder_connection_state.clone(), 1),
+        )
+        .await;
+
         if controller_pool.is_err() {
-            if let Err(e) = controller_pool {
-                let _ = state.extn_client.event(ExtnStatus::Error);
-                return Err(e);
-            }
+            error!("Fatal Thunder Unavailability Error: Ripple couldnt connect to Thunder websocket with many retries for a duration of 10 secs.");
+            let _ = state.extn_client.event(ExtnStatus::Error);
         }
+
+        let controller_pool = controller_pool.unwrap();
+        if let Err(e) = controller_pool {
+            error!("Fatal Thunder Unavailability Error: Ripple connection with Thunder is intermittent causing bootstrap errors.");
+            let _ = state.extn_client.event(ExtnStatus::Error);
+            return Err(e);
+        }
+
         let controller_pool = controller_pool.unwrap();
         let expected_plugins = state.plugin_param.clone();
-        let plugin_manager_tx =
-            PluginManager::start(Box::new(controller_pool), expected_plugins).await;
+        let tc = Box::new(controller_pool);
+        let (plugin_manager_tx, failed_plugins) =
+            PluginManager::start(tc, expected_plugins.clone()).await;
+
+        if !failed_plugins.is_empty() {
+            error!("Mandatory Plugin activation for {:?} failed after 30 secs. Thunder Bootstrap delayed...", failed_plugins);
+            loop {
+                let failed_plugins = PluginManager::activate_mandatory_plugins(
+                    expected_plugins.clone(),
+                    plugin_manager_tx.clone(),
+                )
+                .await;
+                if !failed_plugins.is_empty() {
+                    error!("Mandatory Plugin activation for {:?} failed after 30 secs. Thunder Bootstrap delayed...", failed_plugins);
+                    let _ = state.extn_client.event(ExtnStatus::Interrupted);
+                    continue;
+                } else {
+                    break;
+                }
+            }
+        }
+
         let client = ThunderClientPool::start(
             url,
             Some(plugin_manager_tx),

--- a/device/thunder_ripple_sdk/src/client/plugin_manager.rs
+++ b/device/thunder_ripple_sdk/src/client/plugin_manager.rs
@@ -16,6 +16,7 @@
 //
 
 use std::collections::{HashMap, HashSet};
+use std::time::Duration;
 
 use ripple_sdk::tokio;
 use ripple_sdk::{
@@ -141,10 +142,10 @@ impl PluginActivatedResult {
             PluginActivatedResult::Ready => true,
             PluginActivatedResult::Error => false,
             PluginActivatedResult::Pending(sub_rx) => {
-                if let Ok(v) = sub_rx.await {
-                    v.is_activated()
-                } else {
-                    false
+                // Fail after 2 secs of expecting a Plugin to be activated
+                match tokio::time::timeout(Duration::from_millis(2000), sub_rx).await {
+                    Ok(Ok(v)) => v.is_activated(),
+                    _ => false,
                 }
             }
         }

--- a/device/thunder_ripple_sdk/src/client/plugin_manager.rs
+++ b/device/thunder_ripple_sdk/src/client/plugin_manager.rs
@@ -247,16 +247,7 @@ impl PluginManager {
                 }
             }
         });
-        let mut plugins = Vec::new();
-        match &plugin_request.activate_on_boot {
-            ThunderPluginParam::Default => {
-                for p in ThunderPlugin::activate_on_boot_plugins() {
-                    plugins.push(p.callsign().to_string())
-                }
-            }
-            ThunderPluginParam::Custom(p) => plugins.extend(p.clone()),
-            ThunderPluginParam::None => {}
-        }
+
         let failed_plugins =
             Self::activate_mandatory_plugins(plugin_request.clone(), tx.clone()).await;
         (tx, failed_plugins)

--- a/device/thunder_ripple_sdk/src/client/plugin_manager.rs
+++ b/device/thunder_ripple_sdk/src/client/plugin_manager.rs
@@ -18,7 +18,7 @@
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
-use jsonrpsee::tracing::info;
+use ripple_sdk::log::info;
 use ripple_sdk::tokio;
 use ripple_sdk::{
     api::device::device_operator::{DeviceCallRequest, DeviceSubscribeRequest},

--- a/device/thunder_ripple_sdk/src/client/thunder_client.rs
+++ b/device/thunder_ripple_sdk/src/client/thunder_client.rs
@@ -54,6 +54,7 @@ use serde::{Deserialize, Serialize};
 use url::Url;
 
 use crate::thunder_state::ThunderConnectionState;
+use crate::utils::get_error_value;
 
 use super::thunder_client_pool::ThunderPoolCommand;
 use super::{
@@ -515,7 +516,9 @@ impl ThunderClientBuilder {
                 .build(url_with_token.to_string())
                 .await;
             if client.is_err() {
-                warn!("Attempt to connect to thunder, retrying");
+                error!(
+                    "Thunder Websocket is not available. Attempt to connect to thunder, retrying"
+                );
                 sleep(delay_duration).await;
                 if delay_duration < tokio::time::Duration::from_secs(3) {
                     delay_duration *= 2;
@@ -708,7 +711,7 @@ impl ThunderNoParamRequest {
         let result = client.request(&self.method, None).await;
         if let Err(e) = result {
             error!("send_request: Error: e={}", e);
-            return Value::Null;
+            return get_error_value(&e);
         }
         result.unwrap()
     }
@@ -725,7 +728,7 @@ impl<'a> ThunderParamRequest<'a> {
         let result = client.request(self.method, self.get_params()).await;
         if let Err(e) = result {
             error!("send_request: Error: e={}", e);
-            return Value::Null;
+            return get_error_value(&e);
         }
         result.unwrap()
     }

--- a/device/thunder_ripple_sdk/src/processors/thunder_device_info.rs
+++ b/device/thunder_ripple_sdk/src/processors/thunder_device_info.rs
@@ -431,9 +431,9 @@ impl ThunderDeviceInfoRequestProcessor {
                 if resp.is_none() {
                     return "".to_string();
                 }
-                let mac = resp.unwrap().to_string();
+                let mac = resp.unwrap().as_str().unwrap().trim_matches('"');
                 state.update_mac_address(mac.to_string());
-                mac
+                mac.to_string()
             }
         }
     }
@@ -495,7 +495,7 @@ impl ThunderDeviceInfoRequestProcessor {
                 if resp.is_none() {
                     return "NA".to_owned();
                 }
-                let resp = resp.unwrap().to_string();
+                let resp = resp.unwrap().as_str().unwrap().trim_matches('"');
                 let split_string: Vec<&str> = resp.split('_').collect();
                 let model = String::from(split_string[0]);
                 state.update_model(model.clone());
@@ -549,9 +549,9 @@ impl ThunderDeviceInfoRequestProcessor {
                 if r.is_none() {
                     "".into()
                 } else {
-                    let make = r.unwrap().to_string();
-                    state.update_make(make.clone());
-                    make
+                    let make = r.unwrap().as_str().unwrap().trim_matches('"');
+                    state.update_make(make.to_string());
+                    make.to_string()
                 }
             }
         }

--- a/device/thunder_ripple_sdk/src/processors/thunder_device_info.rs
+++ b/device/thunder_ripple_sdk/src/processors/thunder_device_info.rs
@@ -1476,7 +1476,7 @@ impl ThunderDeviceInfoRequestProcessor {
                 params: None,
             })
             .await;
-
+        println!("{:?}", resp);
         if let Ok(tsv) = serde_json::from_value::<SystemVersion>(resp.message) {
             let release_regex = Regex::new(r"([^_]*)_(.*)_(VBN|PROD[^_]*)_(.*)").unwrap();
             let non_release_regex =
@@ -1713,7 +1713,7 @@ pub mod tests {
             test_platform_build_info_with_build_name($build_name, Arc::new(|msg: ThunderCallMessage| {
                 oneshot_send_and_log(
                     msg.callback,
-                    DeviceResponseMessage::call(json!({"success" : true, "stbVersion": $build_name })),
+                    DeviceResponseMessage::call(json!({"success" : true, "stbVersion": $build_name, "receiverVersion": $build_name, "stbTimestamp": "".to_owned() })),
                     "",
                 );
             })).await;
@@ -1778,6 +1778,7 @@ pub mod tests {
         .await;
         let msg: ExtnMessage = r.recv().await.unwrap().try_into().unwrap();
         let resp_opt = msg.payload.extract::<DeviceResponse>();
+        println!("{:?}", resp_opt);
         if let Some(DeviceResponse::PlatformBuildInfo(info)) = resp_opt {
             let exp = tests.iter().find(|x| x.build_name == build_name).unwrap();
             assert_eq!(info, exp.info);

--- a/device/thunder_ripple_sdk/src/processors/thunder_device_info.rs
+++ b/device/thunder_ripple_sdk/src/processors/thunder_device_info.rs
@@ -629,7 +629,7 @@ impl ThunderDeviceInfoRequestProcessor {
             })
             .await;
         info!("{}", response.message);
-        if check_thunder_response_success(&response) {
+        if !check_thunder_response_success(&response) {
             error!("{}", response.message);
             return HashMap::new();
         }
@@ -829,7 +829,7 @@ impl ThunderDeviceInfoRequestProcessor {
             .await;
         info!("{}", response.message);
 
-        if check_thunder_response_success(&response) {
+        if !check_thunder_response_success(&response) {
             error!("{}", response.message);
             return Vec::new();
         }
@@ -864,7 +864,7 @@ impl ThunderDeviceInfoRequestProcessor {
                 params: None,
             })
             .await;
-        if check_thunder_response_success(&response) {
+        if !check_thunder_response_success(&response) {
             error!("{}", response.message);
             return Err(());
         }
@@ -881,7 +881,7 @@ impl ThunderDeviceInfoRequestProcessor {
                 params: None,
             })
             .await;
-        if check_thunder_response_success(&response) {
+        if !check_thunder_response_success(&response) {
             error!("{}", response.message);
             return Err(());
         }

--- a/device/thunder_ripple_sdk/src/tests/thunder_client_pool_test_utility.rs
+++ b/device/thunder_ripple_sdk/src/tests/thunder_client_pool_test_utility.rs
@@ -17,7 +17,7 @@
 use crate::client::jsonrpc_method_locator::JsonRpcMethodLocator;
 use futures::SinkExt;
 use futures::StreamExt;
-use jsonrpsee::tracing::info;
+use ripple_sdk::log::info;
 use ripple_sdk::{futures, serde_json, tokio};
 use serde_json::{json, Value};
 use std::net::SocketAddr;


### PR DESCRIPTION
## What

The current handling of Thunder plugins does not take into account activation states

## Why

Thunder client cannot make calls to a plugin that is not yet activated.

## How

Established a new struct we can build this more going forward for any incoming messages

```#[derive(Debug, Deserialize)]
pub struct ThunderError {
    pub code: i32,
    pub message: String,
}

impl ThunderError {
    pub fn get_plugin_state(&self) -> PluginState {
        match self.message.as_str() {
            "ERROR_INPROGRESS" | "ERROR_PENDING_CONDITIONS" => PluginState::InProgress,
            "ERROR_UNKNOWN_KEY" => PluginState::Missing,
            _ => PluginState::Unknown,
        }
    }
}
```
2. Updated the Ready method to serve more value. This will now add timeout logic
```
pub async fn ready(self) { -> pub async fn ready(self) -> bool
```
3. Activate Plugin now returns the status for In progress
4. If the plugin is in error state i added a custom error message for the
```
json!({"error": "pre send error"}
```

5. Fixed the bad parsing inside thunder_device_info

## Test

How has this been tested? How can a reviewer test it?

## Checklist

- [ ] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
