### PR TITLE
fix: Handling Thunder status for plugin

### DIFF
--- a/device/thunder_ripple_sdk/src/bootstrap/setup_thunder_pool_step.rs
+++ b/device/thunder_ripple_sdk/src/bootstrap/setup_thunder_pool_step.rs
@@ -72,7 +72,10 @@ impl ThunderPoolStep {
             PluginManager::start(tc, expected_plugins.clone()).await;
 
         if !failed_plugins.is_empty() {
-            error!("Mandatory Plugin activation for {:?} failed after 30 secs. Thunder Bootstrap delayed...", failed_plugins);
+            error!(
+                "Mandatory Plugin activation for {:?} failed. Thunder Bootstrap delayed...",
+                failed_plugins
+            );
             loop {
                 let failed_plugins = PluginManager::activate_mandatory_plugins(
                     expected_plugins.clone(),
@@ -80,7 +83,10 @@ impl ThunderPoolStep {
                 )
                 .await;
                 if !failed_plugins.is_empty() {
-                    error!("Mandatory Plugin activation for {:?} failed after 30 secs. Thunder Bootstrap delayed...", failed_plugins);
+                    error!(
+                        "Mandatory Plugin activation for {:?} failed. Thunder Bootstrap delayed...",
+                        failed_plugins
+                    );
                     let _ = state.extn_client.event(ExtnStatus::Interrupted);
                     continue;
                 } else {

--- a/device/thunder_ripple_sdk/src/client/plugin_manager.rs
+++ b/device/thunder_ripple_sdk/src/client/plugin_manager.rs
@@ -87,8 +87,7 @@ impl PluginStatus {
             "deactivated" => PluginState::Deactivated,
             "deactivation" => PluginState::Deactivation,
             "activation" | "precondition" => PluginState::Activation,
-            "unavailable" | "hibernated" => PluginState::Unavailable,
-            _ => PluginState::Missing,
+            _ => PluginState::Unavailable,
         }
     }
 }
@@ -595,7 +594,7 @@ mod tests {
         ));
         assert!(matches!(
             get_plugin_status("").to_plugin_state(),
-            PluginState::Missing
+            PluginState::Unavailable
         ));
     }
 }


### PR DESCRIPTION
## What

Increase the support for handling Thunder states provided by the status call for a Thunder plugin

## Why

Ripple has to be aware of the thunder state before making a call to Thunder.

## How

Including all the states listed under https://rdkcentral.github.io/Thunder/plugin/lifecycle/

## Test

Unit tests are included this will be tested in an environment where Thunder Plugins have a delayed startedup.

## Checklist

- [ ] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
