### PR TITLE
fix: Add support for Dynamic Plugins

### DIFF
--- a/device/thunder_ripple_sdk/src/client/plugin_manager.rs
+++ b/device/thunder_ripple_sdk/src/client/plugin_manager.rs
@@ -134,6 +134,10 @@ pub enum PluginManagerCommand {
     ReactivatePluginState {
         tx: oneshot::Sender<PluginActivatedResult>,
     },
+    WaitForActivationForDynamicPlugin {
+        callsign: String,
+        tx: oneshot::Sender<PluginActivatedResult>,
+    },
 }
 
 #[derive(Debug)]
@@ -250,6 +254,10 @@ impl PluginManager {
                         let res = pm.reactivate_plugin_state().await;
                         oneshot_send_and_log(tx, res, "ReactivatePluginState");
                     }
+                    PluginManagerCommand::WaitForActivationForDynamicPlugin { callsign, tx } => {
+                        let res = pm.wait_for_activation_for_dynamic(callsign).await;
+                        oneshot_send_and_log(tx, res, "ReactivatePluginState");
+                    }
                 }
             }
         });
@@ -316,6 +324,20 @@ impl PluginManager {
                 "NotifyPluginStateListeners",
             );
         }
+    }
+
+    pub async fn wait_for_activation_for_dynamic(
+        &mut self,
+        callsign: String,
+    ) -> PluginActivatedResult {
+        // Some thunder plugins are related to Apps and they become available when the app is launched.
+        let (sub_tx, sub_rx) = oneshot::channel::<PluginState>();
+
+        self.state_subscribers.push(ActivationSubscriber {
+            callsign,
+            callback: sub_tx,
+        });
+        PluginActivatedResult::Pending(sub_rx)
     }
 
     pub async fn wait_for_activation(

--- a/device/thunder_ripple_sdk/src/client/thunder_client_pool.rs
+++ b/device/thunder_ripple_sdk/src/client/thunder_client_pool.rs
@@ -234,6 +234,13 @@ mod tests {
                     PluginManagerCommand::WaitForActivation { callsign: _, tx } => {
                         oneshot_send_and_log(tx, PluginActivatedResult::Ready, "WaitForActivation");
                     }
+                    PluginManagerCommand::WaitForActivationForDynamicPlugin { callsign: _, tx } => {
+                        oneshot_send_and_log(
+                            tx,
+                            PluginActivatedResult::Ready,
+                            "WaitForActivationForDynamic",
+                        );
+                    }
                     PluginManagerCommand::ReactivatePluginState { tx } => {
                         oneshot_send_and_log(
                             tx,


### PR DESCRIPTION
## What

Some Thunder plugins are created dynamically. Ripple needs to understand these plugins and have support for their activation

## Why

To support Thunder plugins which are added dynamically to the framework.

## How

Uses the existing subscriber mechanism to setup state subscribers and provide the support.

## Test

Using a dynamic app plugin launched by RDKShell.launch

## Checklist

- [ ] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
