### PR TITLE
Remove unsafe unwraps

### DIFF
--- a/core/launcher/src/manager/container_manager.rs
+++ b/core/launcher/src/manager/container_manager.rs
@@ -194,11 +194,14 @@ impl ContainerManager {
             return Err(ContainerError::NotFound);
         }
 
-        let item = state.container_state.get_container_by_name(&name.into());
-        if item.is_none() {
-            debug!("bring_to_front: Container not found:  name={}", name);
-            return Err(ContainerError::NotFound);
-        }
+        let item = state
+            .container_state
+            .get_container_by_name(&name.into())
+            .ok_or_else(|| {
+                debug!("bring_to_front: Container not found:  name={}", name);
+                ContainerError::NotFound
+            })?;
+
         if prev_props.is_none() {
             let prev_container = state.container_state.get_prev_stack();
             if let Some(pc) = prev_container {
@@ -212,7 +215,7 @@ impl ContainerManager {
 
         state.container_state.bring_stack_to_front(name);
 
-        let props = item.unwrap();
+        let props = item.clone();
         let resp = ViewManager::set_position(state, props.view_id, Position::Front).await;
         if let Err(e) = resp {
             debug!("bring_to_front: error: req_id={:?}", e);
@@ -233,12 +236,8 @@ impl ContainerManager {
 
     async fn focus_top_container(state: &LauncherState) -> Result<ViewId, ContainerError> {
         let item = state.container_state.get_prev_stack();
+        let top_container = item.ok_or(ContainerError::NotFound)?;
 
-        if item.is_none() {
-            return Err(ContainerError::NotFound);
-        }
-
-        let top_container = item.unwrap();
         let p = state
             .container_state
             .get_container_by_name(&top_container)
@@ -276,14 +275,15 @@ impl ContainerManager {
             return Err(ContainerError::General);
         }
 
-        let item = state.container_state.get_container_by_name(&name.into());
+        let item = state
+            .container_state
+            .get_container_by_name(&name.into())
+            .ok_or_else(|| {
+                error!("send_to_back: Container not found:  name={}", name);
+                ContainerError::NotFound
+            })?;
 
-        if item.is_none() {
-            error!("send_to_back: Container not found:  name={}", name);
-            return Err(ContainerError::NotFound);
-        }
-
-        let props = item.unwrap().clone();
+        let props = item.clone();
         state.container_state.send_stack_to_back(name);
         let view_id = props.view_id;
         let mut result = Ok(ResultType::None);
@@ -317,13 +317,14 @@ impl ContainerManager {
             return Err(ContainerError::NotFound);
         }
 
-        let item = state.container_state.get_container_by_name(&name.into());
-        if item.is_none() {
-            debug!("set_visible: Container not found:  name={}", name);
-            return Err(ContainerError::NotFound);
-        }
+        let props = state
+            .container_state
+            .get_container_by_name(&name.into())
+            .ok_or_else(|| {
+                debug!("set_visible: Container not found:  name={}", name);
+                ContainerError::NotFound
+            })?;
 
-        let props = item.unwrap();
         let view_id = props.view_id;
         let resp = ViewManager::set_visibility(state, view_id, visible).await;
         match resp {

--- a/core/launcher/src/manager/view_manager.rs
+++ b/core/launcher/src/manager/view_manager.rs
@@ -88,11 +88,12 @@ impl ViewRequest {
 
     pub fn send_response(&self, response: ViewResponse) -> Result<(), RippleError> {
         let mut sender = self.resp_tx.write().unwrap();
-        if sender.is_some() {
-            oneshot_send_and_log(sender.take().unwrap(), response, "ViewManager response");
-            Ok(())
-        } else {
-            Err(RippleError::SenderMissing)
+        match sender.take() {
+            Some(tx) => {
+                oneshot_send_and_log(tx, response, "ViewManager response");
+                Ok(())
+            }
+            None => Err(RippleError::SenderMissing),
         }
     }
 }

--- a/core/main/src/firebolt/firebolt_gatekeeper.rs
+++ b/core/main/src/firebolt/firebolt_gatekeeper.rs
@@ -66,8 +66,8 @@ impl FireboltGatekeeper {
         let perm_based_on_spec_opt = platform_state
             .open_rpc_state
             .get_perms_for_method(method, api_surface);
-        perm_based_on_spec_opt.as_ref()?;
-        let perm_based_on_spec = perm_based_on_spec_opt.unwrap();
+
+        let perm_based_on_spec = perm_based_on_spec_opt?;
         if perm_based_on_spec.is_empty() {
             return Some(perm_based_on_spec);
         }
@@ -78,15 +78,13 @@ impl FireboltGatekeeper {
     }
     // TODO return Deny Reason into ripple error
     pub async fn gate(state: PlatformState, request: RpcRequest) -> Result<(), DenyReasonWithCap> {
-        let caps_opt =
-            Self::get_resolved_caps_for_method(&state, &request.method, request.ctx.gateway_secure);
-        if caps_opt.is_none() {
-            return Err(DenyReasonWithCap {
-                reason: DenyReason::NotFound,
-                caps: Vec::new(),
-            });
-        }
-        let caps = caps_opt.unwrap();
+        let caps =
+            Self::get_resolved_caps_for_method(&state, &request.method, request.ctx.gateway_secure)
+                .ok_or(DenyReasonWithCap {
+                    reason: DenyReason::NotFound,
+                    caps: Vec::new(),
+                })?;
+
         if caps.is_empty() {
             // Couldnt find any capabilities for the method
             trace!(

--- a/core/main/src/firebolt/firebolt_gatekeeper.rs
+++ b/core/main/src/firebolt/firebolt_gatekeeper.rs
@@ -63,11 +63,10 @@ impl FireboltGatekeeper {
         if !secure {
             api_surface.push(ApiSurface::Ripple);
         }
-        let perm_based_on_spec_opt = platform_state
+        let perm_based_on_spec = platform_state
             .open_rpc_state
-            .get_perms_for_method(method, api_surface);
+            .get_perms_for_method(method, api_surface)?;
 
-        let perm_based_on_spec = perm_based_on_spec_opt?;
         if perm_based_on_spec.is_empty() {
             return Some(perm_based_on_spec);
         }

--- a/core/main/src/firebolt/handlers/closed_captions_rpc.rs
+++ b/core/main/src/firebolt/handlers/closed_captions_rpc.rs
@@ -391,11 +391,14 @@ impl ClosedcaptionsImpl {
         property: SP,
         request: SetPropertyOpt<u32>,
     ) -> RpcResult<()> {
-        if request.value.is_some() && request.value.unwrap() > 100 {
-            return Err(jsonrpsee::core::error::Error::Custom(
-                "Invalid Value for opacity".to_owned(),
-            ));
+        if let Some(value) = request.value {
+            if value > 100 {
+                return Err(jsonrpsee::core::error::Error::Custom(
+                    "Invalid Value for opacity".to_owned(),
+                ));
+            }
         }
+
         ClosedcaptionsImpl::set_u32(ps, property, request).await
     }
 
@@ -497,12 +500,14 @@ impl ClosedcaptionsServer for ClosedcaptionsImpl {
         _ctx: CallContext,
         request: SetPropertyOpt<f32>,
     ) -> RpcResult<()> {
-        if request.value.is_some() && (request.value.unwrap() < 0.5 || request.value.unwrap() > 2.0)
-        {
-            return Err(jsonrpsee::core::error::Error::Custom(
-                "Invalid Value for set font".to_owned(),
-            ));
+        if let Some(value) = request.value {
+            if !(0.5..=2.0).contains(&value) {
+                return Err(jsonrpsee::core::error::Error::Custom(
+                    "Invalid Value for set font".to_owned(),
+                ));
+            }
         }
+
         ClosedcaptionsImpl::set_f32(&self.state, SP::ClosedCaptionsFontSize, request).await
     }
 

--- a/core/main/src/firebolt/handlers/discovery_rpc.rs
+++ b/core/main/src/firebolt/handlers/discovery_rpc.rs
@@ -495,7 +495,7 @@ impl DiscoveryServer for DiscoveryImpl {
     ) -> RpcResult<bool> {
         info!("Discovery.watchNext");
         let watched_info = WatchedInfo {
-            entity_id: watch_next_info.identifiers.entity_id.unwrap(),
+            entity_id: watch_next_info.identifiers.entity_id.unwrap_or_default(),
             progress: 1.0,
             completed: Some(false),
             watched_on: None,

--- a/core/main/src/firebolt/handlers/metrics_rpc.rs
+++ b/core/main/src/firebolt/handlers/metrics_rpc.rs
@@ -542,7 +542,8 @@ impl MetricsServer for MetricsImpl {
         ctx: CallContext,
         media_seeked_params: MediaSeekedParams,
     ) -> RpcResult<bool> {
-        let position = convert_to_media_position_type(media_seeked_params.position).unwrap();
+        let position = convert_to_media_position_type(media_seeked_params.position)
+            .unwrap_or(MediaPositionType::None);
         let media_seeked = BehavioralMetricPayload::MediaSeeked(MediaSeeked {
             context: ctx.clone().into(),
             entity_id: media_seeked_params.entity_id,

--- a/core/main/src/firebolt/handlers/privacy_rpc.rs
+++ b/core/main/src/firebolt/handlers/privacy_rpc.rs
@@ -525,8 +525,16 @@ impl PrivacyImpl {
             }
             PrivacySettingsStorageType::Cloud => {
                 if let Some(dist_session) = platform_state.session_state.get_account_session() {
+                    let setting = match property.as_privacy_setting() {
+                        Some(s) => s,
+                        None => {
+                            return Err(jsonrpsee::core::Error::Custom(
+                                "Property is not a privacy setting".to_owned(),
+                            ))
+                        }
+                    };
                     let request = PrivacyCloudRequest::GetProperty(GetPropertyParams {
-                        setting: property.as_privacy_setting().unwrap(),
+                        setting,
                         dist_session,
                     });
                     if let Ok(resp) = platform_state.get_client().send_extn_request(request).await {

--- a/core/main/src/firebolt/rpc_router.rs
+++ b/core/main/src/firebolt/rpc_router.rs
@@ -218,13 +218,14 @@ impl RpcRouter {
                 let r: SResult<JsonRpcApiResponse> = serde_json::from_str(&msg.jsonrpc_msg);
 
                 if let Ok(resp) = r {
-                    let response_value = if resp.result.is_some() {
-                        resp.result.unwrap()
-                    } else if resp.error.is_some() {
-                        resp.error.unwrap()
+                    let response_value = if let Some(result) = resp.result {
+                        result
+                    } else if let Some(error) = resp.error {
+                        error
                     } else {
                         serde_json::to_value(RippleError::InvalidOutput).unwrap()
                     };
+
                     let return_value = ExtnResponse::Value(response_value);
                     if let Ok(response) = extn_msg.get_response(return_value) {
                         if let Err(e) = callback.try_send(response.into()) {

--- a/core/main/src/firebolt/rpc_router.rs
+++ b/core/main/src/firebolt/rpc_router.rs
@@ -205,12 +205,13 @@ impl RpcRouter {
         req: RpcRequest,
         extn_msg: ExtnMessage,
     ) {
-        if extn_msg.callback.is_none() {
-            // The caller of this function already checks this adding it here none the less.
-            error!("No valid callbacks")
-        }
-
-        let callback = extn_msg.clone().callback.unwrap();
+        let callback = match extn_msg.clone().callback {
+            Some(cb) => cb,
+            None => {
+                error!("No valid callbacks");
+                return;
+            }
+        };
         let methods = state.router_state.get_methods();
         let resources = state.router_state.resources.clone();
         tokio::spawn(async move {

--- a/core/main/src/processor/account_link_processor.rs
+++ b/core/main/src/processor/account_link_processor.rs
@@ -72,13 +72,13 @@ impl AccountLinkProcessor {
         ctx: CallContext,
         is_signed_in: bool,
     ) -> bool {
-        if state.session_state.get_account_session().is_none() {
-            error!("No account session found");
-            return false;
-        }
-
-        // safe to unwrap as we have checked for None above
-        let session = state.session_state.get_account_session().unwrap();
+        let session = match state.session_state.get_account_session() {
+            Some(session) => session,
+            None => {
+                error!("No account session found");
+                return false;
+            }
+        };
 
         let payload = DiscoveryRequest::SignIn(SignInRequestParams {
             session_info: SessionParams {
@@ -116,12 +116,13 @@ impl AccountLinkProcessor {
         ctx: CallContext,
         request: ContentAccessRequest,
     ) -> bool {
-        if state.session_state.get_account_session().is_none() {
-            error!("No account session found");
-            return false;
-        }
-        // safe to unwrap as we have checked for None above
-        let session = state.session_state.get_account_session().unwrap();
+        let session = match state.session_state.get_account_session() {
+            Some(session) => session,
+            None => {
+                error!("No account session found");
+                return false;
+            }
+        };
 
         // If both entitlement & availability are None return EmptyResult
         if request.ids.availabilities.is_none() && request.ids.entitlements.is_none() {
@@ -191,12 +192,13 @@ impl AccountLinkProcessor {
         msg: ExtnMessage,
         ctx: CallContext,
     ) -> bool {
-        if state.session_state.get_account_session().is_none() {
-            error!("No account session found");
-            return false;
-        }
-        // safe to unwrap as we have checked for None above
-        let session = state.session_state.get_account_session().unwrap();
+        let session = match state.session_state.get_account_session() {
+            Some(session) => session,
+            None => {
+                error!("No account session found");
+                return false;
+            }
+        };
 
         let payload = DiscoveryRequest::ClearContent(ClearContentSetParams {
             session_info: SessionParams {

--- a/core/main/src/processor/main_context_processor.rs
+++ b/core/main/src/processor/main_context_processor.rs
@@ -240,12 +240,12 @@ impl MainContextProcessor {
         // internet_state: &InternetConnectionStatus,
     ) {
         debug!("handling internet connection change: {:?}", internet_state);
-        if internet_state.is_some()
-            && !matches!(
-                internet_state.as_ref().unwrap(),
-                InternetConnectionStatus::FullyConnected
-            )
-        {
+        let internet_state = match internet_state {
+            Some(state) => state,
+            None => return,
+        };
+
+        if matches!(internet_state, InternetConnectionStatus::FullyConnected) {
             //Send request to start internet monitoring.
             if let Err(err) = state
                 .get_client()
@@ -258,8 +258,12 @@ impl MainContextProcessor {
     }
     fn handle_power_state(state: &PlatformState, power_state: &Option<SystemPowerState>) {
         // fn handle_power_state(state: &PlatformState, power_state: &SystemPowerState) {
-        if (power_state.is_some()
-            && !matches!(power_state.as_ref().unwrap().power_state, PowerState::On))
+        let power_state = match power_state {
+            Some(state) => state,
+            None => return,
+        };
+
+        if matches!(power_state.power_state, PowerState::On)
             && Self::handle_power_active_cleanup(state)
         {
             // if power_state.power_state != PowerState::On && Self::handle_power_active_cleanup(state) {

--- a/core/main/src/processor/storage/storage_manager_utils.rs
+++ b/core/main/src/processor/storage/storage_manager_utils.rs
@@ -28,12 +28,12 @@ fn storage_error() -> jsonrpsee::core::Error {
 }
 
 fn get_storage_data(resp: Result<ExtnResponse, RippleError>) -> Result<Option<StorageData>, Error> {
-    if resp.is_err() {
-        return Err(storage_error());
-    }
-    match resp.unwrap() {
-        ExtnResponse::StorageData(storage_data) => Ok(Some(storage_data)),
-        _ => Ok(None),
+    match resp {
+        Ok(response) => match response {
+            ExtnResponse::StorageData(storage_data) => Ok(Some(storage_data)),
+            _ => Ok(None),
+        },
+        Err(_) => Err(storage_error()),
     }
 }
 

--- a/core/main/src/processor/storage/storage_manager_utils.rs
+++ b/core/main/src/processor/storage/storage_manager_utils.rs
@@ -49,14 +49,16 @@ fn get_value(resp: Result<ExtnResponse, RippleError>) -> Result<Value, Error> {
     //     Some(value) => Ok(value),
     //     None => Err(storage_error()),
     // }
-
-    match resp.unwrap() {
-        ExtnResponse::Value(value) => Ok(value),
-        ExtnResponse::String(str_val) => match serde_json::from_str(&str_val) {
-            Ok(value) => Ok(value),
-            Err(_) => Err(storage_error()),
+    match resp {
+        Ok(resp) => match resp {
+            ExtnResponse::Value(value) => Ok(value),
+            ExtnResponse::String(str_val) => match serde_json::from_str(&str_val) {
+                Ok(value) => Ok(value),
+                Err(_) => Err(storage_error()),
+            },
+            _ => Err(storage_error()),
         },
-        _ => Err(storage_error()),
+        Err(_) => Err(storage_error()),
     }
 }
 

--- a/core/main/src/service/apps/app_events.rs
+++ b/core/main/src/service/apps/app_events.rs
@@ -233,12 +233,13 @@ impl AppEvents {
         event_context: Option<Value>,
         decorator: Option<Box<dyn AppEventDecorator + Send + Sync>>,
     ) {
-        let session = state.session_state.get_session(&call_ctx);
-        if session.is_none() {
-            error!("No open sessions for id '{:?}'", call_ctx.session_id);
-            return;
-        }
-        let session = session.unwrap();
+        let session = match state.session_state.get_session(&call_ctx) {
+            Some(session) => session,
+            None => {
+                error!("No open sessions for id '{:?}'", call_ctx.session_id);
+                return;
+            }
+        };
         let app_events_state = &state.app_events_state;
         let mut listeners = app_events_state.listeners.write().unwrap();
         let event_ctx_string = event_context.map(|x| x.to_string());

--- a/core/main/src/service/apps/app_events.rs
+++ b/core/main/src/service/apps/app_events.rs
@@ -138,14 +138,14 @@ impl EventListener {
         event_name: &str,
         result: &Value,
     ) -> Result<Value, AppEventDecorationError> {
-        if self.decorator.is_none() {
-            return Ok(result.clone());
+        match &self.decorator {
+            Some(decorator) => {
+                decorator
+                    .decorate(state, &self.call_ctx, event_name, result)
+                    .await
+            }
+            None => Ok(result.clone()),
         }
-        self.decorator
-            .as_ref()
-            .unwrap()
-            .decorate(state, &self.call_ctx, event_name, result)
-            .await
     }
 }
 

--- a/core/main/src/service/apps/delegated_launcher_handler.rs
+++ b/core/main/src/service/apps/delegated_launcher_handler.rs
@@ -967,11 +967,10 @@ impl DelegatedLauncherHandler {
 
     pub async fn emit_completed(platform_state: &PlatformState, app_id: &String) {
         platform_state.session_state.clear_pending_session(app_id);
-        let app_opt = platform_state.app_manager_state.get(app_id);
-        if app_opt.is_none() {
-            return;
-        }
-        let app = app_opt.unwrap();
+        let app = match platform_state.app_manager_state.get(app_id) {
+            Some(app) => app,
+            None => return,
+        };
         let sr = SessionResponse::Completed(Self::to_completed_session(&app));
         AppEvents::emit(
             platform_state,
@@ -1072,13 +1071,14 @@ impl DelegatedLauncherHandler {
     ) -> Result<AppManagerResponse, AppError> {
         debug!("set_state: entry: app_id={}, state={:?}", app_id, state);
         let am_state = &self.platform_state.app_manager_state;
-        let app = am_state.get(app_id);
-        if app.is_none() {
-            warn!("appid:{} Not found", app_id);
-            return Err(AppError::NotFound);
-        }
+        let app = match am_state.get(app_id) {
+            Some(app) => app,
+            None => {
+                warn!("appid:{} Not found", app_id);
+                return Err(AppError::NotFound);
+            }
+        };
 
-        let app = app.unwrap();
         let previous_state = app.state;
 
         if previous_state == state {
@@ -1123,12 +1123,13 @@ impl DelegatedLauncherHandler {
     }
 
     fn ready_check(&self, app_id: &str) -> AppResponse {
-        let app = self.platform_state.app_manager_state.get(app_id);
-        if app.is_none() {
-            warn!("appid:{} Not found", app_id);
-            return Err(AppError::NotFound);
-        }
-        let app = app.unwrap();
+        let app = match self.platform_state.app_manager_state.get(app_id) {
+            Some(app) => app,
+            None => {
+                warn!("appid:{} Not found", app_id);
+                return Err(AppError::NotFound);
+            }
+        };
         match app.state {
             LifecycleState::Initializing => Ok(AppManagerResponse::None),
             _ => Err(AppError::UnexpectedState),
@@ -1136,12 +1137,13 @@ impl DelegatedLauncherHandler {
     }
 
     fn finished_check(&self, app_id: &str) -> AppResponse {
-        let app = self.platform_state.app_manager_state.get(app_id);
-        if app.is_none() {
-            warn!("appid:{} Not found", app_id);
-            return Err(AppError::NotFound);
-        }
-        let app = app.unwrap();
+        let app = match self.platform_state.app_manager_state.get(app_id) {
+            Some(app) => app,
+            None => {
+                warn!("appid:{} Not found", app_id);
+                return Err(AppError::NotFound);
+            }
+        };
         match app.state {
             LifecycleState::Unloading => Ok(AppManagerResponse::None),
             _ => Err(AppError::UnexpectedState),

--- a/core/main/src/service/apps/delegated_launcher_handler.rs
+++ b/core/main/src/service/apps/delegated_launcher_handler.rs
@@ -767,12 +767,11 @@ impl DelegatedLauncherHandler {
         emit_event: bool,
     ) {
         let app_id = session.app.id.clone();
-        let app_opt = platform_state.app_manager_state.get(&app_id);
-        if app_opt.is_none() {
-            return;
-        }
-        // safe to unwrap here as app_opt is not None
-        let app = app_opt.unwrap();
+        let app = match platform_state.app_manager_state.get(&app_id) {
+            Some(app) => app,
+            None => return,
+        };
+
         if app.active_session_id.is_none() {
             platform_state
                 .app_manager_state
@@ -898,8 +897,8 @@ impl DelegatedLauncherHandler {
             "get the list of grant policies from device manifest file:{:?}",
             grant_polices_map_opt
         );
-        grant_polices_map_opt.as_ref()?;
-        let grant_polices_map = grant_polices_map_opt.unwrap();
+
+        let grant_polices_map = grant_polices_map_opt?;
         //Filter out the caps only that has evaluate at
         let mut final_perms: Vec<FireboltPermission> = app_perms
             .into_iter()

--- a/core/main/src/state/openrpc_state.rs
+++ b/core/main/src/state/openrpc_state.rs
@@ -50,14 +50,15 @@ pub struct OpenRpcState {
 
 impl OpenRpcState {
     pub fn load_additional_rpc(rpc: &mut FireboltOpenRpc, file_contents: &'static str) {
-        let addl_rpc = serde_json::from_str::<OpenRPCParser>(file_contents);
-        if addl_rpc.is_err() {
-            error!("Could not read additional RPC file");
-            return;
-        }
-
-        for m in addl_rpc.unwrap().methods {
-            rpc.methods.push(m);
+        match serde_json::from_str::<OpenRPCParser>(file_contents) {
+            Ok(addl_rpc) => {
+                for m in addl_rpc.methods {
+                    rpc.methods.push(m.clone());
+                }
+            }
+            Err(_) => {
+                error!("Could not read additional RPC file");
+            }
         }
     }
     pub fn new(exclusory: Option<ExclusoryImpl>) -> OpenRpcState {

--- a/core/sdk/src/api/device/device_browser.rs
+++ b/core/sdk/src/api/device/device_browser.rs
@@ -37,10 +37,7 @@ pub struct BrowserProps {
 
 impl BrowserProps {
     pub fn is_local_storage_enabled(&self) -> bool {
-        if self.local_storage_enabled.is_some() {
-            return self.local_storage_enabled.unwrap();
-        }
-        false
+        self.local_storage_enabled.unwrap_or(false)
     }
 }
 
@@ -64,10 +61,11 @@ pub struct BrowserLaunchParams {
 
 impl BrowserLaunchParams {
     pub fn is_local_storage_enabled(&self) -> bool {
-        if self.properties.is_some() {
-            return self.properties.clone().unwrap().is_local_storage_enabled();
+        if let Some(properties) = &self.properties {
+            properties.is_local_storage_enabled()
+        } else {
+            false
         }
-        false
     }
 }
 

--- a/core/sdk/src/api/device/device_user_grants_data.rs
+++ b/core/sdk/src/api/device/device_user_grants_data.rs
@@ -180,8 +180,8 @@ impl GrantPolicies {
     pub fn get_policy(&self, permission: &FireboltPermission) -> Option<GrantPolicy> {
         match permission.role {
             CapabilityRole::Use => {
-                if let Some(value) = &self.use_ {
-                    return Some(value.clone());
+                if let Some(use_) = &self.use_ {
+                    return Some(use_.clone());
                 }
             }
             CapabilityRole::Manage => {

--- a/core/sdk/src/api/firebolt/fb_metrics.rs
+++ b/core/sdk/src/api/firebolt/fb_metrics.rs
@@ -176,15 +176,16 @@ impl Param {
 
 pub fn hashmap_to_param_vec(the_map: Option<HashMap<String, FlatMapValue>>) -> Vec<Param> {
     let mut result = Vec::new();
-    if the_map.is_none() {
-        return vec![];
-    };
 
-    let params_map = the_map.unwrap();
+    let params_map = match the_map {
+        Some(params_map) => params_map,
+        None => return Vec::new(),
+    };
 
     for (key, value) in params_map {
         result.push(Param { name: key, value });
     }
+
     result
 }
 

--- a/core/sdk/src/api/gateway/rpc_gateway_api.rs
+++ b/core/sdk/src/api/gateway/rpc_gateway_api.rs
@@ -237,24 +237,16 @@ impl RpcRequest {
         cid: Option<String>,
         gateway_secure: bool,
     ) -> Result<RpcRequest, RequestParseError> {
-        let parsed_res = serde_json::from_str(&json);
-        if parsed_res.is_err() {
-            return Err(RequestParseError {});
-        }
-        let parsed: serde_json::Value = parsed_res.unwrap();
-        let base_res = serde_json::from_value(parsed.clone());
-        if base_res.is_err() {
-            return Err(RequestParseError {});
-        }
-        let base: ApiBaseRequest = base_res.unwrap();
+        let parsed =
+            serde_json::from_str::<serde_json::Value>(&json).map_err(|_| RequestParseError {})?;
+        let base = serde_json::from_value::<ApiBaseRequest>(parsed.clone())
+            .map_err(|_| RequestParseError {})?;
         if !base.is_jsonrpc() {
             return Err(RequestParseError {});
         }
-        let jsonrpc_req_res = serde_json::from_value(parsed);
-        if jsonrpc_req_res.is_err() {
-            return Err(RequestParseError {});
-        }
-        let jsonrpc_req: JsonRpcApiRequest = jsonrpc_req_res.unwrap();
+        let jsonrpc_req = serde_json::from_value::<JsonRpcApiRequest>(parsed)
+            .map_err(|_| RequestParseError {})?;
+
         let id = jsonrpc_req.id.unwrap_or(0);
         let method = FireboltOpenRpcMethod::name_with_lowercase_module(&jsonrpc_req.method);
         let ctx = CallContext::new(

--- a/core/sdk/src/extn/client/extn_sender.rs
+++ b/core/sdk/src/extn/client/extn_sender.rs
@@ -203,9 +203,9 @@ impl ExtnSender {
         msg: CExtnMessage,
         other_sender: Option<CSender<CExtnMessage>>,
     ) -> RippleResponse {
-        if msg.callback.is_some() {
+        if let Some(callback) = msg.callback.clone() {
             trace!("Sending message on the callback sender");
-            if let Err(e) = msg.clone().callback.unwrap().try_send(msg) {
+            if let Err(e) = callback.try_send(msg) {
                 error!("respond() error for message in callback sender {}", e);
                 return Err(RippleError::SendFailure);
             }

--- a/core/sdk/src/extn/extn_id.rs
+++ b/core/sdk/src/extn/extn_id.rs
@@ -186,39 +186,29 @@ impl TryFrom<String> for ExtnId {
     type Error = RippleError;
 
     fn try_from(cap: String) -> Result<Self, Self::Error> {
-        let c_a = cap.split(':');
-        if c_a.count() > 3 {
-            let c_a: Vec<&str> = cap.split(':').collect();
-            match c_a.first().unwrap().to_lowercase().as_str() {
-                "ripple" => {}
-                _ => return Err(RippleError::ParseError),
-            }
-            let _type = ExtnType::get(c_a.get(1).unwrap());
-            if _type.is_none() {
-                return Err(RippleError::ParseError);
-            }
-            let _type = _type.unwrap();
+        let c_a = cap.split(':').collect::<Vec<_>>();
 
-            let class = ExtnClassId::get(c_a.get(2).unwrap());
-            if class.is_none() {
-                return Err(RippleError::ParseError);
-            }
-            let class = class.unwrap();
-
-            let service = c_a.get(3);
-            if service.is_none() {
-                return Err(RippleError::ParseError);
-            }
-            let service = String::from(*service.unwrap());
-
-            return Ok(ExtnId {
-                _type,
-                class,
-                service,
-            });
+        match c_a
+            .first()
+            .ok_or(RippleError::ParseError)?
+            .to_lowercase()
+            .as_str()
+        {
+            "ripple" => {}
+            _ => return Err(RippleError::ParseError),
         }
 
-        Err(RippleError::ParseError)
+        let _type = ExtnType::get(c_a.get(1).ok_or(RippleError::ParseError)?)
+            .ok_or(RippleError::ParseError)?;
+        let class = ExtnClassId::get(c_a.get(2).ok_or(RippleError::ParseError)?)
+            .ok_or(RippleError::ParseError)?;
+        let service = c_a.get(3).ok_or(RippleError::ParseError)?;
+
+        Ok(ExtnId {
+            _type,
+            class,
+            service: String::from(*service),
+        })
     }
 }
 

--- a/core/sdk/src/framework/bootstrap.rs
+++ b/core/sdk/src/framework/bootstrap.rs
@@ -84,10 +84,11 @@ impl<T> TransientChannel<T> {
 
     pub fn get_receiver(&self) -> Result<Receiver<T>, RippleError> {
         let mut tr = self.tr.write().unwrap();
-        if tr.is_some() {
-            return Ok(tr.take().unwrap());
-        }
 
-        Err(RippleError::InvalidAccess)
+        if let Some(receiver) = tr.take() {
+            Ok(receiver)
+        } else {
+            Err(RippleError::InvalidAccess)
+        }
     }
 }

--- a/device/thunder_ripple_sdk/src/client/thunder_client.rs
+++ b/device/thunder_ripple_sdk/src/client/thunder_client.rs
@@ -279,12 +279,15 @@ impl ThunderClient {
         let subscription_res = client
             .subscribe_to_method::<Value>(subscribe_method.as_str())
             .await;
-        if let Err(e) = subscription_res {
-            error!("Failed to setup subscriber in jsonrpsee client, {}", e);
-            // Maybe this method signature should change to propagate the error up
-            return;
-        }
-        let mut subscription = subscription_res.unwrap();
+
+        let mut subscription = match subscription_res {
+            Ok(subscription) => subscription,
+            Err(e) => {
+                error!("Failed to setup subscriber in jsonrpsee client, {}", e);
+                // Maybe this method signature should change to propagate the error up
+                return;
+            }
+        };
         let params = ThunderRegisterParams {
             event: thunder_message.event_name.clone(),
             id: format!("client.{}.events", thunder_message.module.clone()),

--- a/device/thunder_ripple_sdk/src/client/thunder_client_pool.rs
+++ b/device/thunder_ripple_sdk/src/client/thunder_client_pool.rs
@@ -90,12 +90,14 @@ impl ThunderClientPool {
             while let Some(cmd) = r.recv().await {
                 match cmd {
                     ThunderPoolCommand::ThunderMessage(msg) => {
-                        let c_opt = pool.get_client(&msg);
-                        if c_opt.is_none() {
-                            error!("Thunder pool had no clients!");
-                            return;
-                        }
-                        let c = c_opt.unwrap();
+                        let c = match pool.get_client(&msg) {
+                            Some(client) => client,
+                            None => {
+                                error!("Thunder pool had no clients!");
+                                return;
+                            }
+                        };
+
                         let (resp_tx, resp_rx) = oneshot::channel::<DeviceResponseMessage>();
                         c.in_use.to_owned().store(true, Ordering::Relaxed);
                         let msg_with_intercept = msg.clone(resp_tx);

--- a/device/thunder_ripple_sdk/src/processors/thunder_device_info.rs
+++ b/device/thunder_ripple_sdk/src/processors/thunder_device_info.rs
@@ -446,9 +446,8 @@ impl ThunderDeviceInfoRequestProcessor {
     }
 
     async fn get_serial_number(state: &CachedState) -> String {
-        let response: String;
         match state.get_serial_number() {
-            Some(value) => response = value,
+            Some(value) => value,
             None => {
                 let resp = state
                     .get_thunder_client()
@@ -459,16 +458,16 @@ impl ThunderDeviceInfoRequestProcessor {
                     .await;
                 info!("{}", resp.message);
 
-                let serial_number_option = resp.message["serialNumber"].as_str();
-                if serial_number_option.is_none() {
-                    response = "".to_string();
-                } else {
-                    response = serial_number_option.unwrap().to_string();
-                    state.update_serial_number(response.clone())
-                }
+                resp.message["serialNumber"].as_str().map_or_else(
+                    || "".to_string(),
+                    |serial_number| {
+                        let serial_number = serial_number.to_string();
+                        state.update_serial_number(serial_number.clone());
+                        serial_number
+                    },
+                )
             }
         }
-        response
     }
 
     async fn serial_number(state: CachedState, req: ExtnMessage) -> bool {

--- a/device/thunder_ripple_sdk/src/utils.rs
+++ b/device/thunder_ripple_sdk/src/utils.rs
@@ -33,10 +33,11 @@ pub fn get_audio_profile_from_value(value: Value) -> HashMap<AudioProfile, bool>
     hm.insert(AudioProfile::DolbyDigital7_1Plus, false);
     hm.insert(AudioProfile::DolbyAtmos, false);
 
-    if value.get("supportedAudioFormat").is_none() {
-        return hm;
-    }
-    let supported_profiles = value["supportedAudioFormat"].as_array().unwrap();
+    let supported_profiles = match value.get("supportedAudioFormat") {
+        Some(profiles) => profiles.as_array().unwrap(),
+        None => return hm,
+    };
+
     for profile in supported_profiles {
         let profile_name = profile.as_str().unwrap();
         match profile_name {


### PR DESCRIPTION
CC:  [StefanBossbaly:remove_unwraps](https://github.com/StefanBossbaly/Ripple/tree/remove_unwraps)
## What

Removes ~90 `.unwrap()` calls in favor of other Rust programming paradigms that prove the state of the enum instead of generating a `panic!()` on unexpected case.

Most the the replaced code was written like so, with the conditional check to handle the unwanted variant (`None` in this case) and then the call to `unwrap() `to extract the value.

```
if entry.is_none() {
    error!(
        "on_app_state_change: app_id={} Not found",
        state_change.container_props.name
    );
    return;
}

// safe to unwrap
let app = entry.unwrap();
```
However `unwrap()` under the hood is just a `panic!` when the `None` variant is encountered like so.

```
if entry.is_none() {
    error!(
        "on_app_state_change: app_id={} Not found",
        state_change.container_props.name
    );
    return;
}

// safe to unwrap
let app = match entry {
  Some(value) => value,
  None => panic("called `Option::unwrap()` on a `None` value"),
};
```
You can simplify this code by simply handling the `None` case with a `match` statement. This is remove the panic to ensure that future code changes do not trigger that case like so:

```
let app = match entry {
  Some(value) => value,
  None => {
    error!(
        "on_app_state_change: app_id={} Not found",
        state_change.container_props.name
    );
    return;
  }
};
```


## Why

Calling `.unwrap()` is an anti-pattern in Rust (with limited exceptions). It is better to use pattern matching or other provided functions to handle the cases where the enum is not the expected variant. This also has the added benefit of reducing code size since the `panic!()` macro to handle the unexpected variant will not be generated.

## How

Removes `unwrap()` calls in favor of pattern matching and other monad functions.

## Test

`cargo build --release, cargo test` and inspection to prove that there is no functional difference between the code.

## Checklist

- [x] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
