### PR TITLE
fix: Remove CARGO_PKG_VERSION dependency in device.version

### DIFF
--- a/core/main/src/firebolt/handlers/device_rpc.rs
+++ b/core/main/src/firebolt/handlers/device_rpc.rs
@@ -46,10 +46,7 @@ use ripple_sdk::{
             },
         },
         distributor::distributor_encoder::EncoderRequest,
-        firebolt::{
-            fb_general::{ListenRequest, ListenerResponse},
-            fb_openrpc::FireboltSemanticVersion,
-        },
+        firebolt::fb_general::{ListenRequest, ListenerResponse},
         gateway::rpc_gateway_api::CallContext,
         session::{AccountSessionRequest, ProvisionRequest},
         storage_property::{
@@ -312,15 +309,6 @@ impl DeviceServer for DeviceImpl {
     }
 
     async fn version(&self, ctx: CallContext) -> RpcResult<DeviceVersionResponse> {
-        let mut os = FireboltSemanticVersion::new(
-            env!("CARGO_PKG_VERSION_MAJOR").parse().unwrap(),
-            env!("CARGO_PKG_VERSION_MINOR").parse().unwrap(),
-            env!("CARGO_PKG_VERSION_PATCH").parse().unwrap(),
-            "".to_string(),
-        );
-
-        os.readable = format!("Firebolt OS v{}", env!("CARGO_PKG_VERSION"));
-
         let firmware_info = self.firmware_info(ctx).await?;
         let open_rpc_state = self.state.clone().open_rpc_state;
         let api = open_rpc_state.get_open_rpc().info;
@@ -332,14 +320,11 @@ impl DeviceServer for DeviceImpl {
             api,
             firmware: firmware_info.version,
             os: os_ver,
-            debug: format!(
-                "{} ({})",
-                env!("CARGO_PKG_VERSION"),
-                self.state
-                    .version
-                    .clone()
-                    .unwrap_or(String::from(SEMVER_LIGHTWEIGHT))
-            ),
+            debug: self
+                .state
+                .version
+                .clone()
+                .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string()),
         })
     }
 


### PR DESCRIPTION
## What

Remove CARGO_PKG_VERSION dependency in device.version
CARGO_PKG_VERSION is the value of version in the Cargo.toml file for Ripple.

## Why

Use the version from Platform State by default. Use CARGO_PKG_VERSION as a backup if version is not available in platform state.

## How

How do these changes achieve the goal?

## Test

How has this been tested? How can a reviewer test it?

## Checklist

- [x] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
