### PR TITLE
set default value for audioDescriptionEnabled

### DIFF
--- a/core/main/src/processor/storage/default_storage_properties.rs
+++ b/core/main/src/processor/storage/default_storage_properties.rs
@@ -22,12 +22,13 @@ use ripple_sdk::{
         KEY_ALLOW_PRIMARY_BROWSE_AD_TARGETING, KEY_ALLOW_PRIMARY_CONTENT_AD_TARGETING,
         KEY_ALLOW_PRODUCT_ANALYTICS, KEY_ALLOW_REMOTE_DIAGNOSTICS, KEY_ALLOW_RESUME_POINTS,
         KEY_ALLOW_UNENTITLED_PERSONALIZATION, KEY_ALLOW_UNENTITLED_RESUME_POINTS,
-        KEY_ALLOW_WATCH_HISTORY, KEY_BACKGROUND_COLOR, KEY_BACKGROUND_OPACITY, KEY_COUNTRY_CODE,
-        KEY_ENABLED, KEY_FONT_COLOR, KEY_FONT_EDGE, KEY_FONT_EDGE_COLOR, KEY_FONT_FAMILY,
-        KEY_FONT_OPACITY, KEY_FONT_SIZE, KEY_LANGUAGE, KEY_LOCALE, KEY_NAME, KEY_SKIP_RESTRICTION,
-        KEY_TEXT_ALIGN, KEY_TEXT_ALIGN_VERTICAL, KEY_WINDOW_COLOR, KEY_WINDOW_OPACITY,
-        NAMESPACE_ADVERTISING, NAMESPACE_CLOSED_CAPTIONS, NAMESPACE_DEVICE_NAME,
-        NAMESPACE_LOCALIZATION, NAMESPACE_PRIVACY,
+        KEY_ALLOW_WATCH_HISTORY, KEY_AUDIO_DESCRIPTION_ENABLED, KEY_BACKGROUND_COLOR,
+        KEY_BACKGROUND_OPACITY, KEY_COUNTRY_CODE, KEY_ENABLED, KEY_FONT_COLOR, KEY_FONT_EDGE,
+        KEY_FONT_EDGE_COLOR, KEY_FONT_FAMILY, KEY_FONT_OPACITY, KEY_FONT_SIZE, KEY_LANGUAGE,
+        KEY_LOCALE, KEY_NAME, KEY_SKIP_RESTRICTION, KEY_TEXT_ALIGN, KEY_TEXT_ALIGN_VERTICAL,
+        KEY_WINDOW_COLOR, KEY_WINDOW_OPACITY, NAMESPACE_ADVERTISING, NAMESPACE_AUDIO_DESCRIPTION,
+        NAMESPACE_CLOSED_CAPTIONS, NAMESPACE_DEVICE_NAME, NAMESPACE_LOCALIZATION,
+        NAMESPACE_PRIVACY,
     },
     log::debug,
 };
@@ -130,6 +131,17 @@ impl DefaultStorageProperties {
                     .configuration
                     .default_values
                     .allow_watch_history),
+                _ => Err(DefaultStoragePropertiesError::UnreconizedKey(
+                    key.to_owned(),
+                )),
+            }
+        } else if namespace.eq(NAMESPACE_AUDIO_DESCRIPTION) {
+            match key {
+                KEY_AUDIO_DESCRIPTION_ENABLED => Ok(state
+                    .get_device_manifest()
+                    .configuration
+                    .default_values
+                    .accessibility_audio_description_settings),
                 _ => Err(DefaultStoragePropertiesError::UnreconizedKey(
                     key.to_owned(),
                 )),

--- a/core/main/src/processor/storage/storage_manager.rs
+++ b/core/main/src/processor/storage/storage_manager.rs
@@ -76,12 +76,14 @@ pub struct StorageManager;
 
 impl StorageManager {
     pub async fn get_bool(state: &PlatformState, property: StorageProperty) -> RpcResult<bool> {
+        println!("^^^^ get bool 1");
         if let Some(val) = state
             .ripple_cache
             .get_cached_bool_storage_property(&property)
         {
             return Ok(val);
         }
+        println!("^^^^ get bool 2");
         let data = property.as_data();
         match StorageManager::get_bool_from_namespace(state, data.namespace.to_string(), data.key)
             .await

--- a/core/main/src/processor/storage/storage_manager.rs
+++ b/core/main/src/processor/storage/storage_manager.rs
@@ -76,14 +76,12 @@ pub struct StorageManager;
 
 impl StorageManager {
     pub async fn get_bool(state: &PlatformState, property: StorageProperty) -> RpcResult<bool> {
-        println!("^^^^ get bool 1");
         if let Some(val) = state
             .ripple_cache
             .get_cached_bool_storage_property(&property)
         {
             return Ok(val);
         }
-        println!("^^^^ get bool 2");
         let data = property.as_data();
         match StorageManager::get_bool_from_namespace(state, data.namespace.to_string(), data.key)
             .await

--- a/core/sdk/src/api/manifest/device_manifest.rs
+++ b/core/sdk/src/api/manifest/device_manifest.rs
@@ -375,6 +375,8 @@ impl Default for DefaultValues {
             video_dimensions: default_video_dimensions(),
             media_progress_as_watched_events: false,
             accessibility_audio_description_settings: false,
+            accessibility_audio_description_settings:
+                default_accessibility_audio_description_settings(),
         }
     }
 }

--- a/core/sdk/src/api/manifest/device_manifest.rs
+++ b/core/sdk/src/api/manifest/device_manifest.rs
@@ -1012,12 +1012,11 @@ pub(crate) mod tests {
     #[test]
     fn test_accessibility_audio_desc_settings_default_value() {
         let manifest = DeviceManifest::mock();
-        assert_eq!(
-            manifest
+        assert!(
+            !manifest
                 .configuration
                 .default_values
-                .accessibility_audio_description_settings,
-            false
+                .accessibility_audio_description_settings
         );
     }
 }

--- a/core/sdk/src/api/manifest/device_manifest.rs
+++ b/core/sdk/src/api/manifest/device_manifest.rs
@@ -268,6 +268,8 @@ pub struct DefaultValues {
     pub video_dimensions: Vec<i32>,
     #[serde(default, rename = "mediaProgressAsWatchedEvents")]
     pub media_progress_as_watched_events: bool,
+    #[serde(default = "default_accessibility_audio_description_settings")]
+    pub accessibility_audio_description_settings: bool,
 }
 
 fn additional_info_default() -> HashMap<String, String> {
@@ -286,6 +288,9 @@ pub fn default_video_dimensions() -> Vec<i32> {
     vec![1920, 1080]
 }
 
+pub fn default_accessibility_audio_description_settings() -> bool {
+    false
+}
 #[derive(Deserialize, Debug, Clone, Default)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct SettingsDefaults {
@@ -369,6 +374,7 @@ impl Default for DefaultValues {
             skip_restriction: "none".to_string(),
             video_dimensions: default_video_dimensions(),
             media_progress_as_watched_events: false,
+            accessibility_audio_description_settings: false,
         }
     }
 }
@@ -709,6 +715,7 @@ pub(crate) mod tests {
                         video_dimensions: vec![1920, 1080],
                         // setting the value to true to simulate manifest override
                         media_progress_as_watched_events: true,
+                        accessibility_audio_description_settings: false,
                     },
                     settings_defaults_per_app: HashMap::new(),
                     model_friendly_names: {

--- a/core/sdk/src/api/manifest/device_manifest.rs
+++ b/core/sdk/src/api/manifest/device_manifest.rs
@@ -268,7 +268,7 @@ pub struct DefaultValues {
     pub video_dimensions: Vec<i32>,
     #[serde(default, rename = "mediaProgressAsWatchedEvents")]
     pub media_progress_as_watched_events: bool,
-    #[serde(default = "default_accessibility_audio_description_settings")]
+    #[serde(default)]
     pub accessibility_audio_description_settings: bool,
 }
 
@@ -288,9 +288,6 @@ pub fn default_video_dimensions() -> Vec<i32> {
     vec![1920, 1080]
 }
 
-pub fn default_accessibility_audio_description_settings() -> bool {
-    false
-}
 #[derive(Deserialize, Debug, Clone, Default)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct SettingsDefaults {
@@ -374,9 +371,7 @@ impl Default for DefaultValues {
             skip_restriction: "none".to_string(),
             video_dimensions: default_video_dimensions(),
             media_progress_as_watched_events: false,
-            accessibility_audio_description_settings: false,
-            accessibility_audio_description_settings:
-                default_accessibility_audio_description_settings(),
+            accessibility_audio_description_settings: false
         }
     }
 }
@@ -1012,5 +1007,17 @@ pub(crate) mod tests {
         )
         .unwrap();
         assert!(default_values.media_progress_as_watched_events);
+    }
+
+    #[test]
+    fn test_accessibility_audio_desc_settings_default_value() {
+        let manifest = DeviceManifest::mock();
+        assert_eq!(
+            manifest
+                .configuration
+                .default_values
+                .accessibility_audio_description_settings,
+            false
+        );
     }
 }

--- a/core/sdk/src/api/manifest/device_manifest.rs
+++ b/core/sdk/src/api/manifest/device_manifest.rs
@@ -371,7 +371,7 @@ impl Default for DefaultValues {
             skip_restriction: "none".to_string(),
             video_dimensions: default_video_dimensions(),
             media_progress_as_watched_events: false,
-            accessibility_audio_description_settings: false
+            accessibility_audio_description_settings: false,
         }
     }
 }


### PR DESCRIPTION
## What

Set a default value for accessibility.audioDescriptionSettings firebolt API

## Why

Ripple StorageManager to return a default value for audioDescriptionEnabled when the corresponding entry is not available in Thunder Persistent Storage.

## How

How do these changes achieve the goal?

## Test

How has this been tested? How can a reviewer test it?

## Checklist

- [ ] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
