### PR TITLE
feat: Support for resume points using metrics.mediaprogress

### DIFF
--- a/core/main/src/firebolt/handlers/metrics_rpc.rs
+++ b/core/main/src/firebolt/handlers/metrics_rpc.rs
@@ -25,8 +25,10 @@ use std::collections::HashMap;
 
 use ripple_sdk::{
     api::{
+        account_link::{AccountLinkRequest, WatchedRequest},
         firebolt::{
             fb_capabilities::JSON_RPC_STANDARD_ERROR_INVALID_PARAMS,
+            fb_discovery::WatchedInfo,
             fb_metrics::{
                 self, hashmap_to_param_vec, Action, BehavioralMetricContext,
                 BehavioralMetricPayload, CategoryType, ErrorParams, FlatMapValue,
@@ -508,6 +510,35 @@ impl MetricsServer for MetricsImpl {
         media_progress_params: MediaProgressParams,
     ) -> RpcResult<bool> {
         let progress = convert_to_media_position_type(media_progress_params.progress)?;
+
+        if self
+            .state
+            .get_device_manifest()
+            .configuration
+            .default_values
+            .media_progress_as_watched_events
+            && progress != MediaPositionType::None
+        {
+            let request = WatchedRequest {
+                context: ctx.clone(),
+                info: WatchedInfo {
+                    entity_id: media_progress_params.entity_id.clone(),
+                    progress: media_progress_params
+                        .progress
+                        .expect("progress shall not be None at this point"),
+                    completed: None,
+                    watched_on: None,
+                },
+                unit: None,
+            };
+
+            let _ = self
+                .state
+                .get_client()
+                .send_extn_request(AccountLinkRequest::Watched(request))
+                .await;
+        }
+
         let media_progress = BehavioralMetricPayload::MediaProgress(MediaProgress {
             context: ctx.clone().into(),
             entity_id: media_progress_params.entity_id,

--- a/core/sdk/src/api/manifest/device_manifest.rs
+++ b/core/sdk/src/api/manifest/device_manifest.rs
@@ -272,6 +272,8 @@ pub struct DefaultValues {
     pub skip_restriction: String,
     #[serde(default = "default_video_dimensions")]
     pub video_dimensions: Vec<i32>,
+    #[serde(default)]
+    pub media_progress_as_watched_events: bool,
 }
 
 fn additional_info_default() -> HashMap<String, String> {
@@ -372,6 +374,7 @@ impl Default for DefaultValues {
             allow_watch_history: false,
             skip_restriction: "none".to_string(),
             video_dimensions: default_video_dimensions(),
+            media_progress_as_watched_events: false,
         }
     }
 }
@@ -722,6 +725,8 @@ pub(crate) mod tests {
                         allow_watch_history: false,
                         skip_restriction: "none".to_string(),
                         video_dimensions: vec![1920, 1080],
+                        // setting the value to true to simulate manifest override
+                        media_progress_as_watched_events: true,
                     },
                     settings_defaults_per_app: HashMap::new(),
                     model_friendly_names: {
@@ -976,5 +981,24 @@ pub(crate) mod tests {
                 PrivacySettingsStorageType::Local
             ));
         }
+    }
+
+    #[test]
+    fn test_media_progress_as_watched_events() {
+        let manifest = DeviceManifest::mock();
+        assert_eq!(
+            manifest
+                .configuration
+                .default_values
+                .media_progress_as_watched_events,
+            true
+        );
+    }
+
+    #[test]
+    fn test_default_media_progress_as_watched_events() {
+        let default_values = serde_json::from_str::<DefaultValues>("{}").unwrap();
+        // check if the value of media_progress_as_watched_events is false
+        assert_eq!(default_values.media_progress_as_watched_events, false);
     }
 }


### PR DESCRIPTION
## What

Support for resume points using `metrics.mediaprogress` API.
This feature is turned off by default. 

Set the device manifest flag `mediaProgressAsWatchedEvents` to true under `default_values` section to turn on this feature.

## Why

Why are these changes needed?

## How

How do these changes achieve the goal?

## Test

How has this been tested? How can a reviewer test it?

## Checklist

- [x] I have self-reviewed this PR
- [x] I have added tests that prove the feature works or the fix is effective
