### PR TITLE
LifecycleManagement.setState - Added state transition validation 

### DIFF
--- a/core/main/src/firebolt/handlers/discovery_rpc.rs
+++ b/core/main/src/firebolt/handlers/discovery_rpc.rs
@@ -202,7 +202,7 @@ pub async fn get_content_partner_id(
         app_resp_tx,
     );
     if let Err(e) = platform_state.get_client().send_app_request(app_request) {
-        error!("Send error for set_state {:?}", e);
+        error!("Send error for AppMethod::GetAppContentCatalog {:?}", e);
         return Err(rpc_err("Unable send app request"));
     }
     let resp = rpc_await_oneshot(app_resp_rx).await?;

--- a/core/main/src/processor/account_link_processor.rs
+++ b/core/main/src/processor/account_link_processor.rs
@@ -240,7 +240,7 @@ impl AccountLinkProcessor {
             app_resp_tx,
         );
         if let Err(e) = platform_state.get_client().send_app_request(app_request) {
-            error!("Send error for set_state {:?}", e);
+            error!("Send error for AppMethod::GetAppContentCatalog {:?}", e);
             return Err(RippleError::ProcessorError);
         }
         let resp = rpc_await_oneshot(app_resp_rx).await;

--- a/core/main/src/service/apps/delegated_launcher_handler.rs
+++ b/core/main/src/service/apps/delegated_launcher_handler.rs
@@ -1310,17 +1310,192 @@ impl DelegatedLauncherHandler {
     }
 
     fn is_valid_lifecycle_transition(from: LifecycleState, to: LifecycleState) -> bool {
-        match to {
-            LifecycleState::Suspended | LifecycleState::Unloading => {
+        // Early exit, Not do the state transition when from and to States are the same
+        if from == to {
+            return false;
+        }
+
+        match (from, to) {
+            // An app MUST NOT be transitioned to Suspended, or Unloaded (i.e. not running anymore)
+            // from any state other than Inactive
+            (_, LifecycleState::Suspended | LifecycleState::Unloading) => {
                 from == LifecycleState::Inactive
             }
-            LifecycleState::Foreground => {
+            // An app MUST NOT be transitioned (or immediate set to) Foreground
+            // without going through either Inactive or Background
+            (_, LifecycleState::Foreground) => {
                 from == LifecycleState::Inactive || from == LifecycleState::Background
             }
-            // Not do the state transition when from and to are the same
-            _ if from == to => false,
-            // Allowing all other transitions
+            // Transition from Suspended to only Inactive is allowed
+            (LifecycleState::Suspended, LifecycleState::Inactive) => true,
+            (LifecycleState::Suspended, _) => false,
+            // Do not allow transition to initializing from any other state.
+            (_, LifecycleState::Initializing) => false,
+            // No more state transitions are allowed from Unloading
+            (LifecycleState::Unloading, _) => false,
+            // Allow any other state transition
             _ => true,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_same_state_transition() {
+        assert!(!DelegatedLauncherHandler::is_valid_lifecycle_transition(
+            LifecycleState::Inactive,
+            LifecycleState::Inactive
+        ),);
+        assert!(!DelegatedLauncherHandler::is_valid_lifecycle_transition(
+            LifecycleState::Foreground,
+            LifecycleState::Foreground
+        ),);
+    }
+
+    #[test]
+    fn test_transition_from_inactive() {
+        // Inactive to Background
+        assert!(DelegatedLauncherHandler::is_valid_lifecycle_transition(
+            LifecycleState::Inactive,
+            LifecycleState::Background
+        ),);
+        // Inactive to Foreground
+        assert!(DelegatedLauncherHandler::is_valid_lifecycle_transition(
+            LifecycleState::Inactive,
+            LifecycleState::Foreground
+        ),);
+        // Inactive to Suspended
+        assert!(DelegatedLauncherHandler::is_valid_lifecycle_transition(
+            LifecycleState::Inactive,
+            LifecycleState::Suspended
+        ),);
+        // Inactive to Unloading
+        assert!(DelegatedLauncherHandler::is_valid_lifecycle_transition(
+            LifecycleState::Inactive,
+            LifecycleState::Unloading
+        ),);
+        // Inactive to Initializing
+        assert!(!DelegatedLauncherHandler::is_valid_lifecycle_transition(
+            LifecycleState::Inactive,
+            LifecycleState::Initializing
+        ),);
+    }
+
+    #[test]
+    fn test_transition_from_foreground() {
+        // Foreground to Background
+        assert!(DelegatedLauncherHandler::is_valid_lifecycle_transition(
+            LifecycleState::Foreground,
+            LifecycleState::Background
+        ),);
+        // Foreground to Inactive
+        assert!(DelegatedLauncherHandler::is_valid_lifecycle_transition(
+            LifecycleState::Foreground,
+            LifecycleState::Inactive
+        ),);
+        // Foreground to Suspended
+        assert!(!DelegatedLauncherHandler::is_valid_lifecycle_transition(
+            LifecycleState::Foreground,
+            LifecycleState::Suspended
+        ),);
+        // Foreground to Unloading
+        assert!(!DelegatedLauncherHandler::is_valid_lifecycle_transition(
+            LifecycleState::Foreground,
+            LifecycleState::Unloading
+        ),);
+        // Foreground to Initializing
+        assert!(!DelegatedLauncherHandler::is_valid_lifecycle_transition(
+            LifecycleState::Foreground,
+            LifecycleState::Initializing
+        ),);
+    }
+
+    #[test]
+    fn test_transition_from_background() {
+        // Background to Foreground
+        assert!(DelegatedLauncherHandler::is_valid_lifecycle_transition(
+            LifecycleState::Background,
+            LifecycleState::Foreground
+        ),);
+        // Background to Inactive
+        assert!(DelegatedLauncherHandler::is_valid_lifecycle_transition(
+            LifecycleState::Background,
+            LifecycleState::Inactive
+        ),);
+        // Background to Suspended
+        assert!(!DelegatedLauncherHandler::is_valid_lifecycle_transition(
+            LifecycleState::Background,
+            LifecycleState::Suspended
+        ),);
+        // Background to Unloading
+        assert!(!DelegatedLauncherHandler::is_valid_lifecycle_transition(
+            LifecycleState::Background,
+            LifecycleState::Unloading
+        ),);
+        // Background to Initializing
+        assert!(!DelegatedLauncherHandler::is_valid_lifecycle_transition(
+            LifecycleState::Background,
+            LifecycleState::Initializing
+        ),);
+    }
+
+    #[test]
+    fn test_transition_from_suspended() {
+        // Suspended to Inactive
+        assert!(DelegatedLauncherHandler::is_valid_lifecycle_transition(
+            LifecycleState::Suspended,
+            LifecycleState::Inactive
+        ),);
+        // Suspended to Foreground
+        assert!(!DelegatedLauncherHandler::is_valid_lifecycle_transition(
+            LifecycleState::Suspended,
+            LifecycleState::Foreground
+        ),);
+        // Suspended to Background
+        assert!(!DelegatedLauncherHandler::is_valid_lifecycle_transition(
+            LifecycleState::Suspended,
+            LifecycleState::Background
+        ),);
+        // Suspended to Unloading
+        assert!(!DelegatedLauncherHandler::is_valid_lifecycle_transition(
+            LifecycleState::Suspended,
+            LifecycleState::Unloading
+        ),);
+        // Suspended to Initializing
+        assert!(!DelegatedLauncherHandler::is_valid_lifecycle_transition(
+            LifecycleState::Suspended,
+            LifecycleState::Initializing
+        ),);
+    }
+    #[test]
+    fn test_transition_from_unloading() {
+        // Unloading to Inactive
+        assert!(!DelegatedLauncherHandler::is_valid_lifecycle_transition(
+            LifecycleState::Unloading,
+            LifecycleState::Inactive
+        ),);
+        // Unloading to Foreground
+        assert!(!DelegatedLauncherHandler::is_valid_lifecycle_transition(
+            LifecycleState::Unloading,
+            LifecycleState::Foreground
+        ),);
+        // Unloading to Background
+        assert!(!DelegatedLauncherHandler::is_valid_lifecycle_transition(
+            LifecycleState::Unloading,
+            LifecycleState::Background
+        ),);
+        // Unloading to Suspended
+        assert!(!DelegatedLauncherHandler::is_valid_lifecycle_transition(
+            LifecycleState::Unloading,
+            LifecycleState::Suspended
+        ),);
+        // Unloading to Initializing
+        assert!(!DelegatedLauncherHandler::is_valid_lifecycle_transition(
+            LifecycleState::Unloading,
+            LifecycleState::Initializing
+        ),);
     }
 }

--- a/core/main/src/service/apps/delegated_launcher_handler.rs
+++ b/core/main/src/service/apps/delegated_launcher_handler.rs
@@ -1376,6 +1376,8 @@ impl DelegatedLauncherHandler {
         }
 
         match (from, to) {
+            // Allow transitioning from initializing to only Inactive
+            (LifecycleState::Initializing, _) => to == LifecycleState::Inactive,
             // An app MUST NOT be transitioned to Suspended, or Unloaded (i.e. not running anymore)
             // from any state other than Inactive
             (_, LifecycleState::Suspended | LifecycleState::Unloading) => {
@@ -1412,6 +1414,35 @@ mod tests {
         assert!(!DelegatedLauncherHandler::is_valid_lifecycle_transition(
             LifecycleState::Foreground,
             LifecycleState::Foreground
+        ),);
+    }
+
+    #[test]
+    fn test_transition_from_initializing() {
+        // Initializing to Inactive
+        assert!(DelegatedLauncherHandler::is_valid_lifecycle_transition(
+            LifecycleState::Initializing,
+            LifecycleState::Inactive
+        ),);
+        // Initializing to Foreground
+        assert!(!DelegatedLauncherHandler::is_valid_lifecycle_transition(
+            LifecycleState::Initializing,
+            LifecycleState::Foreground
+        ),);
+        // Initializing to Background
+        assert!(!DelegatedLauncherHandler::is_valid_lifecycle_transition(
+            LifecycleState::Initializing,
+            LifecycleState::Background
+        ),);
+        // Initializing to Suspended
+        assert!(!DelegatedLauncherHandler::is_valid_lifecycle_transition(
+            LifecycleState::Initializing,
+            LifecycleState::Suspended
+        ),);
+        // Initializing to Unloading
+        assert!(!DelegatedLauncherHandler::is_valid_lifecycle_transition(
+            LifecycleState::Initializing,
+            LifecycleState::Unloading
         ),);
     }
 

--- a/core/sdk/src/api/manifest/device_manifest.rs
+++ b/core/sdk/src/api/manifest/device_manifest.rs
@@ -272,6 +272,8 @@ pub struct DefaultValues {
     pub skip_restriction: String,
     #[serde(default = "default_video_dimensions")]
     pub video_dimensions: Vec<i32>,
+    #[serde(default)]
+    pub lifecycle_transition_validate: bool,
 }
 
 fn additional_info_default() -> HashMap<String, String> {
@@ -372,6 +374,7 @@ impl Default for DefaultValues {
             allow_watch_history: false,
             skip_restriction: "none".to_string(),
             video_dimensions: default_video_dimensions(),
+            lifecycle_transition_validate: false,
         }
     }
 }
@@ -722,6 +725,7 @@ pub(crate) mod tests {
                         allow_watch_history: false,
                         skip_restriction: "none".to_string(),
                         video_dimensions: vec![1920, 1080],
+                        lifecycle_transition_validate: true,
                     },
                     settings_defaults_per_app: HashMap::new(),
                     model_friendly_names: {
@@ -976,5 +980,47 @@ pub(crate) mod tests {
                 PrivacySettingsStorageType::Local
             ));
         }
+    }
+
+    #[test]
+    fn test_lifecycle_transition_validate() {
+        let manifest = DeviceManifest::mock();
+        assert!(
+            manifest
+                .configuration
+                .default_values
+                .lifecycle_transition_validate
+        );
+    }
+
+    #[test]
+    fn test_default_lifecycle_transition_validate() {
+        // create DefaultValues object by providing only the required fields
+        let default_values = serde_json::from_str::<DefaultValues>(
+            r#"{
+            "country_code": "US",
+            "language": "en",
+            "locale": "en-US",
+            "name": "Living Room"
+        }"#,
+        )
+        .unwrap();
+        assert!(!default_values.lifecycle_transition_validate);
+    }
+
+    #[test]
+    fn test_lifecycle_transition_validate_override() {
+        // create DefaultValues object by providing the required fields and lifecycle_transition_validate
+        let default_values = serde_json::from_str::<DefaultValues>(
+            r#"{
+            "country_code": "US",
+            "language": "en",
+            "locale": "en-US",
+            "name": "Living Room",
+            "lifecycle_transition_validate": true
+        }"#,
+        )
+        .unwrap();
+        assert!(default_values.lifecycle_transition_validate);
     }
 }


### PR DESCRIPTION
## What

Added app lifecycle state transition validation.

## Why

Current implementation allows state transition to `suspended` or `unloading` directly from `foreground`/`background`.
This has been fixed by including a state transition validation function

## How

Added the function `fn is_valid_lifecycle_transition(from: LifecycleState, to: LifecycleState) -> bool` to validate the app lifecycle state transition.

This validation check is disabled by default.  Set the feature flag `"lifecycle_transition_validate":true`  in device manifest to enable this check. 

## Test

How has this been tested? How can a reviewer test it?

## Checklist

- [x] I have self-reviewed this PR
- [x] I have added tests that prove the feature works or the fix is effective
