### PR TITLE
refactor: Filtering logs

### DIFF
--- a/core/sdk/src/utils/logger.rs
+++ b/core/sdk/src/utils/logger.rs
@@ -44,6 +44,13 @@ pub fn init_logger(name: String) -> Result<(), fern::InitError> {
             ));
         })
         .level(filter)
+        .level_for("h2", log::LevelFilter::Off)
+        .level_for("hyper", log::LevelFilter::Off)
+        .level_for("rustls", log::LevelFilter::Off)
+        .level_for("tower", log::LevelFilter::Off)
+        .level_for("tower_http", log::LevelFilter::Off)
+        .level_for("jsonrpsee_client_transport", log::LevelFilter::Off)
+        .level_for("jsonrpsee_core", log::LevelFilter::Off)
         .chain(std::io::stdout())
         .apply()?;
     Ok(())
@@ -101,6 +108,13 @@ pub fn init_and_configure_logger(version: &str, name: String) -> Result<(), fern
             }
         })
         .level(filter)
+        .level_for("h2", log::LevelFilter::Off)
+        .level_for("hyper", log::LevelFilter::Off)
+        .level_for("rustls", log::LevelFilter::Off)
+        .level_for("tower", log::LevelFilter::Off)
+        .level_for("tower_http", log::LevelFilter::Off)
+        .level_for("jsonrpsee_client_transport", log::LevelFilter::Off)
+        .level_for("jsonrpsee_core", log::LevelFilter::Off)
         .chain(std::io::stdout())
         .apply()?;
     Ok(())

--- a/core/sdk/src/utils/logger.rs
+++ b/core/sdk/src/utils/logger.rs
@@ -44,7 +44,7 @@ pub fn init_logger(name: String) -> Result<(), fern::InitError> {
             ));
         })
         .level(filter)
-	//log filter applied here, making the log level to OFF for the below mentioned crates
+        //log filter applied here, making the log level to OFF for the below mentioned crates
         .level_for("h2", log::LevelFilter::Off)
         .level_for("hyper", log::LevelFilter::Off)
         .level_for("rustls", log::LevelFilter::Off)
@@ -109,7 +109,7 @@ pub fn init_and_configure_logger(version: &str, name: String) -> Result<(), fern
             }
         })
         .level(filter)
-	//log filter applied here, making the log level to OFF for the below mentioned crates
+        //log filter applied here, making the log level to OFF for the below mentioned crates
         .level_for("h2", log::LevelFilter::Off)
         .level_for("hyper", log::LevelFilter::Off)
         .level_for("rustls", log::LevelFilter::Off)

--- a/core/sdk/src/utils/logger.rs
+++ b/core/sdk/src/utils/logger.rs
@@ -44,6 +44,7 @@ pub fn init_logger(name: String) -> Result<(), fern::InitError> {
             ));
         })
         .level(filter)
+	//log filter applied here, making the log level to OFF for the below mentioned crates
         .level_for("h2", log::LevelFilter::Off)
         .level_for("hyper", log::LevelFilter::Off)
         .level_for("rustls", log::LevelFilter::Off)
@@ -108,6 +109,7 @@ pub fn init_and_configure_logger(version: &str, name: String) -> Result<(), fern
             }
         })
         .level(filter)
+	//log filter applied here, making the log level to OFF for the below mentioned crates
         .level_for("h2", log::LevelFilter::Off)
         .level_for("hyper", log::LevelFilter::Off)
         .level_for("rustls", log::LevelFilter::Off)


### PR DESCRIPTION
## What

added the log filter based on crate names like h2, hyper, tower, tower_http, rustls, jsonrpsee_client_transport, jsonrpsee_core with the log level as OFF

## Why

to cutdown the unnecessary log capturing in the production build

## How

apply log level filter using the crate names and mention log level as OFF 

## Test

run the bootup sequence and checked the logs before and after these changes.

## Checklist

- [x] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
