### PR TITLE
fix: Removed startmode from Plugin State Status structure

### DIFF
--- a/core/main/src/broker/thunder/thunder_plugins_status_mgr.rs
+++ b/core/main/src/broker/thunder/thunder_plugins_status_mgr.rs
@@ -45,7 +45,6 @@ const STATE_CHANGE_EVENT_METHOD: &str = "client.Controller.1.events.statechange"
 pub struct Status {
     pub callsign: String,
     pub state: String,
-    pub startmode: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -568,9 +567,7 @@ mod tests {
         let data = JsonRpcApiResponse {
             id: Some(1),
             jsonrpc: "2.0".to_string(),
-            result: Some(
-                serde_json::json!([{"callsign":"TestPlugin","state":"activated","startmode":"auto"}]),
-            ),
+            result: Some(serde_json::json!([{"callsign":"TestPlugin","state":"activated"}])),
             error: None,
             method: None,
             params: None,


### PR DESCRIPTION
## What

Removed unused `startmode` filed from PluginStatus response.

## Why

It's an optional field and currently not used in Ripple. This was causing a deserialization error in parsing Status response from Controller as not all plugin status response includes startmode in the response message

## How

Removed this field from Status structure.

## Test

How has this been tested? How can a reviewer test it?

## Checklist

- [x] I have self-reviewed this PR
- [x] I have added tests that prove the feature works or the fix is effective
