### PR TITLE
fix: Bug fix in on_status_response() function

### DIFF
--- a/core/main/src/broker/thunder/thunder_plugins_status_mgr.rs
+++ b/core/main/src/broker/thunder/thunder_plugins_status_mgr.rs
@@ -22,7 +22,7 @@ use std::{
 use ripple_sdk::{
     api::gateway::rpc_gateway_api::JsonRpcApiResponse,
     chrono::{DateTime, Duration, Utc},
-    log::{info, warn, error},
+    log::{error, info, warn},
     utils::error::RippleError,
 };
 use serde::{Deserialize, Serialize};

--- a/core/main/src/broker/thunder/thunder_plugins_status_mgr.rs
+++ b/core/main/src/broker/thunder/thunder_plugins_status_mgr.rs
@@ -416,19 +416,17 @@ impl StatusManager {
             }
             self.update_status(callsign.to_string(), status.to_state());
 
-            if status.to_state().is_activated() {
-                let (pending_requests, expired) =
-                    self.retrive_pending_broker_requests(callsign.to_string());
+            let (pending_requests, expired) =
+                self.retrive_pending_broker_requests(callsign.to_string());
 
-                for pending_request in pending_requests {
-                    if expired {
-                        info!("Expired request: {:?}", pending_request);
-                        callback
-                            .send_error(pending_request, RippleError::ServiceError)
-                            .await;
-                    } else {
-                        let _ = sender.send(pending_request).await;
-                    }
+            for pending_request in pending_requests {
+                if expired {
+                    info!("Expired request: {:?}", pending_request);
+                    callback
+                        .send_error(pending_request, RippleError::ServiceError)
+                        .await;
+                } else {
+                    let _ = sender.send(pending_request).await;
                 }
             }
         }

--- a/core/main/src/broker/thunder/thunder_plugins_status_mgr.rs
+++ b/core/main/src/broker/thunder/thunder_plugins_status_mgr.rs
@@ -22,7 +22,7 @@ use std::{
 use ripple_sdk::{
     api::gateway::rpc_gateway_api::JsonRpcApiResponse,
     chrono::{DateTime, Duration, Utc},
-    log::{info, warn},
+    log::{info, warn, error},
     utils::error::RippleError,
 };
 use serde::{Deserialize, Serialize};
@@ -319,7 +319,7 @@ impl StatusManager {
                     if !pending_requests.is_empty() {
                         for pending_request in pending_requests {
                             if expired {
-                                info!("Expired request: {:?}", pending_request);
+                                error!("Expired request: {:?}", pending_request);
                                 callback
                                     .send_error(pending_request, RippleError::ServiceError)
                                     .await;
@@ -367,7 +367,7 @@ impl StatusManager {
 
             for pending_request in pending_requests {
                 if expired {
-                    info!("Expired request: {:?}", pending_request);
+                    error!("Expired request: {:?}", pending_request);
                     callback
                         .send_error(pending_request, RippleError::ServiceError)
                         .await;
@@ -421,7 +421,7 @@ impl StatusManager {
 
             for pending_request in pending_requests {
                 if expired {
-                    info!("Expired request: {:?}", pending_request);
+                    error!("Expired request: {:?}", pending_request);
                     callback
                         .send_error(pending_request, RippleError::ServiceError)
                         .await;
@@ -443,7 +443,7 @@ impl StatusManager {
             None => return,
         };
 
-        info!(
+        error!(
             "Error Received from Thunder on getting the status of the plugin: {:?}",
             error
         );


### PR DESCRIPTION
## What

Bug fix 

## Why

This fix is required to process all pending broker requests upon receiving response of plugin status command, irrespective of the activation status

## How

How do these changes achieve the goal?

## Test

How has this been tested? How can a reviewer test it?

## Checklist

- [x] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
