### PR TITLE
feat: Changes for Rule engine and better run script

### DIFF
--- a/core/main/src/broker/http_broker.rs
+++ b/core/main/src/broker/http_broker.rs
@@ -37,7 +37,7 @@ impl EndpointBroker for HttpBroker {
         let (tx, mut tr) = mpsc::channel(10);
         let broker = BrokerSender { sender: tx };
         let is_json_rpc = endpoint.jsonrpc;
-        let uri: Uri = endpoint.url.parse().unwrap();
+        let uri: Uri = endpoint.get_url().parse().unwrap();
         // let mut headers = HeaderMap::new();
         // headers.insert("Content-Type", "application/json".parse().unwrap());
         // if let Some(auth) = &endpoint.authentication {

--- a/core/main/src/broker/thunder_broker.rs
+++ b/core/main/src/broker/thunder_broker.rs
@@ -64,7 +64,8 @@ impl ThunderBroker {
         let callback_for_sender = callback.clone();
         let broker_for_reconnect = broker.clone();
         tokio::spawn(async move {
-            let (mut ws_tx, mut ws_rx) = BrokerUtils::get_ws_broker(&endpoint.url, None).await;
+            let (mut ws_tx, mut ws_rx) =
+                BrokerUtils::get_ws_broker(&endpoint.get_url(), None).await;
 
             // send the first request to the broker. This is the controller statechange subscription request
             let status_request = broker_c

--- a/core/main/src/broker/websocket_broker.rs
+++ b/core/main/src/broker/websocket_broker.rs
@@ -47,7 +47,8 @@ impl WebsocketBroker {
         let broker = BrokerSender { sender: tx };
         tokio::spawn(async move {
             if endpoint.jsonrpc {
-                let (mut ws_tx, mut ws_rx) = BrokerUtils::get_ws_broker(&endpoint.url, None).await;
+                let (mut ws_tx, mut ws_rx) =
+                    BrokerUtils::get_ws_broker(&endpoint.get_url(), None).await;
 
                 tokio::pin! {
                     let read = ws_rx.next();
@@ -103,7 +104,7 @@ impl WebsocketBroker {
                     let cleaner = WSNotificationBroker::start(
                         v.clone(),
                         callback.clone(),
-                        endpoint.url.clone(),
+                        endpoint.get_url().clone(),
                     );
                     {
                         let mut map = map_clone.write().unwrap();

--- a/device/thunder_ripple_sdk/src/bootstrap/get_config_step.rs
+++ b/device/thunder_ripple_sdk/src/bootstrap/get_config_step.rs
@@ -87,7 +87,7 @@ impl ThunderGetConfigStep {
                         GATEWAY_DEFAULT
                     );
                 }
-                if let Ok(host_override) = std::env::var("THUNDER_HOST") {
+                if let Ok(host_override) = std::env::var("DEVICE_HOST") {
                     gateway_url.set_host(Some(&host_override)).ok();
                 }
                 return Ok(ThunderBootstrapStateWithConfig {

--- a/device/thunder_ripple_sdk/src/client/thunder_client.rs
+++ b/device/thunder_ripple_sdk/src/client/thunder_client.rs
@@ -677,9 +677,15 @@ pub struct ThunderRawBoolRequest {
 
 impl ThunderRawBoolRequest {
     async fn send_request(self: Box<Self>) -> Value {
-        let host = match env::var("THUNDER_HOST") {
-            Ok(h) => h,
-            Err(_) => String::from("127.0.0.1"),
+        let host = {
+            if cfg!(feature = "local_dev") {
+                match env::var("DEVICE_HOST") {
+                    Ok(h) => h,
+                    Err(_) => String::from("127.0.0.1"),
+                }
+            } else {
+                String::from("127.0.0.1")
+            }
         };
 
         if let Ok(t) = env::var("THUNDER_TOKEN") {

--- a/ripple
+++ b/ripple
@@ -94,7 +94,7 @@ case ${1} in
     ;;
     "run")
         cargo build --features local_dev
-        THUNDER_HOST=${2} cargo run --features local_dev core/main 
+        DEVICE_HOST=${2} cargo run --features local_dev core/main 
     ;;
     "run-mock")
         workspace_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )


### PR DESCRIPTION
## What

Adds support for reusing run script to run Ripple pointing to a device
Upgrades Rules engine to be case insensitive

## Why

For better developer experience and configuration

## How

Making the key and check case insensitive, and upgrading the scripts and configuration for Device Host.

## Test

Ripple run script is updated to use the DEVICE_HOST variable instead of Thunder Host.
Ripple developers can use any case for the method field.

## Checklist

- [ ] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
