### PR TITLE
WIP: jq rules engine refactor/tests

### DIFF
--- a/core/main/Cargo.toml
+++ b/core/main/Cargo.toml
@@ -58,6 +58,8 @@ jaq-parse = { version ="1.0.2", default-features = false }
 jaq-core = { version ="1.2.1", default-features = false }
 
 openrpc_validator = { path = "../../openrpc_validator" }
+ripple_tdk = { path = "../tdk" }
+
 
 [build-dependencies]
 vergen = "1"

--- a/core/main/src/broker/endpoint_broker.rs
+++ b/core/main/src/broker/endpoint_broker.rs
@@ -967,7 +967,7 @@ fn apply_rule_for_event(
 
 #[cfg(test)]
 mod tests {
-    use ripple_sdk::{tokio::sync::mpsc::channel, Mockable};
+    use ripple_sdk::{tokio::sync::mpsc::channel, utils::logger::init_logger, Mockable};
 
     use crate::broker::rules_engine::RuleTransform;
 
@@ -1001,10 +1001,11 @@ mod tests {
 
     #[test]
     fn test_run_broker_workflow() {
+        let _ = init_logger("broker".into());
         let mut broker_request = BrokerRequest::default();
         broker_request.rule.transform.response = Some(".success".to_owned());
         let payload = JsonRpcApiResponse {
-            result: Some(serde_json::Value::Number(Number::from(1))),
+            result: Some(serde_json::Value::Bool(true)),
             ..Default::default()
         };
         let broker_output = BrokerOutput { data: payload };

--- a/core/main/src/broker/endpoint_broker.rs
+++ b/core/main/src/broker/endpoint_broker.rs
@@ -15,7 +15,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use futures::executor::block_on;
 use ripple_sdk::{
     api::{
         firebolt::fb_capabilities::JSON_RPC_STANDARD_ERROR_INVALID_PARAMS,
@@ -27,7 +26,6 @@ use ripple_sdk::{
     extn::extn_client_message::{ExtnEvent, ExtnMessage},
     framework::RippleResponse,
     log::{debug, error, info},
-    semver::Op,
     tokio::{
         self,
         sync::mpsc::{self, Receiver, Sender},
@@ -40,7 +38,7 @@ use std::{
     collections::HashMap,
     sync::{
         atomic::{AtomicU64, Ordering},
-        Arc, MutexGuard, RwLock,
+        Arc, RwLock,
     },
 };
 
@@ -78,20 +76,11 @@ impl BrokerCleaner {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct BrokerRequest {
     pub rpc: RpcRequest,
     pub rule: Rule,
     pub subscription_processed: Option<bool>,
-}
-impl Default for BrokerRequest {
-    fn default() -> Self {
-        Self {
-            rpc: RpcRequest::default(),
-            rule: Rule::default(),
-            subscription_processed: None,
-        }
-    }
 }
 
 pub type BrokerSubMap = HashMap<String, Vec<BrokerRequest>>;
@@ -595,7 +584,7 @@ pub trait EndpointBroker {
 /// Forwarder gets the BrokerOutput and forwards the response to the gateway.
 pub struct BrokerOutputForwarder;
 pub fn get_event_id(broker_output: BrokerOutput) -> Option<u64> {
-    broker_output.get_event().or_else(|| broker_output.data.id)
+    broker_output.get_event().or(broker_output.data.id)
 }
 
 #[derive(Debug, Clone)]
@@ -644,8 +633,8 @@ pub fn run_broker_workflow(
         let mut mutant = broker_output.clone();
         mutant.data.id = Some(request_id);
         if is_event {
-            let f = apply_rule_for_event(&broker_request, &result, &rpc_request, &broker_output)?;
-            return Ok(BrokerWorkflowSuccess::RuleAppliedToEvent(f, id));
+            let f = apply_rule_for_event(broker_request, &result, &rpc_request, broker_output)?;
+            Ok(BrokerWorkflowSuccess::RuleAppliedToEvent(f, id))
         } else if is_subscription {
             if sub_processed {
                 return Ok(BrokerWorkflowSuccess::SubscriptionProcessed(mutant, id));
@@ -654,22 +643,21 @@ pub fn run_broker_workflow(
                 "listening" : rpc_request.is_listening(),
                 "event" : rpc_request.ctx.method
             }));
-            return Ok(BrokerWorkflowSuccess::Unsubcribe(mutant, id));
-            //platform_state.endpoint_state.update_unsubscribe_request(id);
+            Ok(BrokerWorkflowSuccess::Unsubcribe(mutant, id))
         } else if let Some(filter) = broker_request
             .rule
             .transform
             .get_filter(super::rules_engine::RuleTransformType::Response)
         {
-            return Ok(BrokerWorkflowSuccess::FilterApplied(
+            Ok(BrokerWorkflowSuccess::FilterApplied(
                 apply_response(result, filter, &rpc_request, broker_output)?,
                 id,
-            ));
+            ))
         } else {
-            return Err(BrokerWorkFlowError::NoRuleFound);
+            Err(BrokerWorkFlowError::NoRuleFound)
         }
     } else {
-        return Err(BrokerWorkFlowError::JsonParseError);
+        Err(BrokerWorkFlowError::JsonParseError)
     }
 }
 
@@ -680,7 +668,7 @@ pub fn brokered_to_api_message_response(
 ) -> Result<ApiMessage, BrokerWorkFlowError> {
     match serde_json::to_string(&broker_output.data) {
         Ok(jsonrpc_msg) => Ok(ApiMessage {
-            request_id: request_id, //broker_request.rpc.ctx.call_id.to_string(),
+            request_id,
             protocol: broker_request.rpc.ctx.protocol.clone(),
             jsonrpc_msg,
         }),
@@ -698,7 +686,7 @@ pub fn broker_workflow(
     platform_state: &PlatformState,
 ) -> Result<SessionizedApiMessage, BrokerWorkFlowError> {
     match run_broker_workflow(broker_output, broker_request)? {
-        BrokerWorkflowSuccess::SubscriptionProcessed(broker_output, request_id) => {
+        BrokerWorkflowSuccess::SubscriptionProcessed(broker_output, _request_id) => {
             Ok(SessionizedApiMessage {
                 session_id: broker_request.rpc.ctx.get_id(),
                 api_message: brokered_to_api_message_response(
@@ -709,7 +697,10 @@ pub fn broker_workflow(
             })
         }
         BrokerWorkflowSuccess::Unsubcribe(broker_output, request_id) => {
-            request_id.map(|id| platform_state.endpoint_state.update_unsubscribe_request(id));
+            if let Some(id) = request_id {
+                platform_state.endpoint_state.update_unsubscribe_request(id)
+            }
+
             Ok(SessionizedApiMessage {
                 session_id: broker_request.rpc.ctx.get_id(),
                 api_message: brokered_to_api_message_response(
@@ -740,7 +731,7 @@ pub fn broker_workflow(
 impl BrokerOutputForwarder {
     pub fn start_forwarder(platform_state: PlatformState, mut rx: Receiver<BrokerOutput>) {
         tokio::spawn(async move {
-            while let Some(mut broker_output) = rx.recv().await {
+            while let Some(broker_output) = rx.recv().await {
                 if let Some(request_id) = get_event_id(broker_output.clone()) {
                     if let Ok(broker_request) =
                         platform_state.endpoint_state.get_request(request_id)
@@ -970,7 +961,7 @@ fn apply_rule_for_event(
         mutated_broker_output.data.result = Some(data);
         Ok(mutated_broker_output.clone())
     } else {
-        return Err(JqError::RuleNotFound(rpc_request.ctx.method.clone()));
+        Err(JqError::RuleNotFound(rpc_request.ctx.method.clone()))
     }
 }
 
@@ -1004,293 +995,108 @@ mod tests {
         let value = tr.recv().await.unwrap();
         assert!(value.data.error.is_some())
     }
-
-    mod broker_output {
-        use ripple_sdk::{api::gateway::rpc_gateway_api::JsonRpcApiResponse, Mockable};
-
-        use crate::broker::endpoint_broker::BrokerOutput;
-
-        #[test]
-        fn test_result() {
-            let mut data = JsonRpcApiResponse::mock();
-            let output = BrokerOutput { data: data.clone() };
-            assert!(!output.is_result());
-            data.result = Some(serde_json::Value::Null);
-            let output = BrokerOutput { data };
-            assert!(output.is_result());
-        }
-
-        #[test]
-        fn test_get_event() {
-            let mut data = JsonRpcApiResponse::mock();
-            data.method = Some("20.events".to_owned());
-            let output = BrokerOutput { data };
-            assert_eq!(20, output.get_event().unwrap())
-        }
-    }
-
-    mod endpoint_broker_state {
-        use ripple_sdk::{
-            api::gateway::rpc_gateway_api::RpcRequest, tokio, tokio::sync::mpsc::channel, Mockable,
-        };
-
-        use crate::{
-            broker::{
-                endpoint_broker::tests::RippleClient,
-                rules_engine::{Rule, RuleEngine, RuleSet, RuleTransform},
-            },
-            state::bootstrap_state::ChannelsState,
-        };
-
-        use super::EndpointBrokerState;
-
-        use ripple_sdk::api::gateway::rpc_gateway_api::JsonRpcApiResponse;
-
-        #[tokio::test]
-        async fn get_request() {
-            let (tx, _) = channel(2);
-            let client = RippleClient::new(ChannelsState::new());
-            let state = EndpointBrokerState::new(
-                tx,
-                RuleEngine {
-                    rules: RuleSet::default(),
-                },
-                client,
-            );
-            let mut request = RpcRequest::mock();
-            state.update_request(
-                &request,
-                Rule {
-                    alias: "somecallsign.method".to_owned(),
-                    transform: RuleTransform::default(),
-                    endpoint: None,
-                },
-                None,
-            );
-            request.ctx.call_id = 2;
-            state.update_request(
-                &request,
-                Rule {
-                    alias: "somecallsign.method".to_owned(),
-                    transform: RuleTransform::default(),
-                    endpoint: None,
-                },
-                None,
-            );
-
-            // Hardcoding the id here will be a problem as multiple tests uses the atomic id and there is no guarantee
-            // that this test case would always be the first one to run
-            // Revisit this test case, to make it more robust
-            // assert!(state.get_request(2).is_ok());
-            // assert!(state.get_request(1).is_ok());
-        }
-    }
     /*add exhaustive unit tests for as many function as possible */
-    #[cfg(test)]
-    mod tests {
 
-        use openrpc_validator::RpcResult;
-        use serde_json::Number;
+    use serde_json::Number;
 
-        use super::*;
+    #[test]
+    fn test_run_broker_workflow() {
+        let mut broker_request = BrokerRequest::default();
+        broker_request.rule.transform.response = Some(".success".to_owned());
+        let payload = JsonRpcApiResponse {
+            result: Some(serde_json::Value::Number(Number::from(1))),
+            ..Default::default()
+        };
+        let broker_output = BrokerOutput { data: payload };
 
-        #[tokio::test]
-        async fn test_send_error() {
-            let (tx, mut tr) = channel(2);
-            let callback = BrokerCallback { sender: tx };
+        let result = run_broker_workflow(&broker_output, &broker_request);
+        assert!(result.is_ok());
+    }
 
-            callback
-                .send_error(
-                    BrokerRequest {
-                        rpc: RpcRequest::mock(),
-                        rule: Rule {
-                            alias: "somecallsign.method".to_owned(),
-                            transform: RuleTransform::default(),
-                            endpoint: None,
-                        },
-                        subscription_processed: None,
-                    },
-                    RippleError::InvalidInput,
-                )
-                .await;
-            let value = tr.recv().await.unwrap();
-            assert!(value.data.error.is_some())
-        }
+    #[test]
+    fn test_brokered_to_api_message_response() {
+        let request_id = String::from("12345");
+        let broker_request = BrokerRequest::default();
+        let broker_output = BrokerOutput::default();
+        let result = brokered_to_api_message_response(broker_output, &broker_request, request_id);
+        assert!(result.is_ok());
+    }
 
-        mod broker_output {
-            use ripple_sdk::{api::gateway::rpc_gateway_api::JsonRpcApiResponse, Mockable};
+    #[test]
+    fn test_get_request_id() {
+        let broker_request = BrokerRequest::default();
+        let request_id = get_request_id(&broker_request, None);
+        assert!(!request_id.is_empty());
+    }
 
-            use crate::broker::endpoint_broker::BrokerOutput;
+    #[test]
+    fn test_broker_workflow() {
+        let mut broker_request = BrokerRequest::default();
+        broker_request.rule.transform.response = Some(".success".to_owned());
+        let payload = JsonRpcApiResponse {
+            result: Some(serde_json::Value::Number(Number::from(1))),
+            ..Default::default()
+        };
 
-            #[test]
-            fn test_result() {
-                let mut data = JsonRpcApiResponse::mock();
-                let output = BrokerOutput { data: data.clone() };
-                assert!(!output.is_result());
-                data.result = Some(serde_json::Value::Null);
-                let output = BrokerOutput { data };
-                assert!(output.is_result());
-            }
+        let broker_output = BrokerOutput { data: payload };
+        let result =
+            super::broker_workflow(&broker_output, &broker_request, &PlatformState::default());
+        assert!(result.is_ok());
+    }
 
-            #[test]
-            fn test_get_event() {
-                let mut data = JsonRpcApiResponse::mock();
-                data.method = Some("20.events".to_owned());
-                let output = BrokerOutput { data };
-                assert_eq!(20, output.get_event().unwrap())
-            }
-        }
+    // #[test]
+    // fn test_start_forwarder() {
+    //     let platform_state = PlatformState::default();
+    //     let rx = Receiver::default();
 
-        mod endpoint_broker_state {
-            use super::*;
-            use ripple_sdk::{
-                api::gateway::rpc_gateway_api::RpcRequest, tokio, tokio::sync::mpsc::channel,
-                Mockable,
-            };
+    //     start_forwarder(platform_state, rx);
+    //     // TODO: Add assertions or mock the tokio::spawn call to verify the behavior
+    // }
 
-            use crate::{
-                broker::{
-                    endpoint_broker::{tests::RippleClient, EndpointBrokerState},
-                    rules_engine::{Rule, RuleEngine, RuleSet, RuleTransform},
-                },
-                state::bootstrap_state::ChannelsState,
-            };
+    #[test]
+    fn test_handle_non_jsonrpc_response() {
+        let data: &[u8] = &[1, 2, 3];
+        let callback = BrokerCallback::default();
+        let request = BrokerRequest::default();
+        let result = BrokerOutputForwarder::handle_non_jsonrpc_response(data, callback, request);
+        assert!(result.is_err());
+    }
 
-            #[tokio::test]
-            async fn get_request() {
-                let (tx, _) = channel(2);
-                let client = RippleClient::new(ChannelsState::new());
-                let state = EndpointBrokerState::new(
-                    tx,
-                    RuleEngine {
-                        rules: RuleSet::default(),
-                    },
-                    client,
-                );
-                let mut request = RpcRequest::mock();
-                state.update_request(
-                    &request,
-                    Rule {
-                        alias: "somecallsign.method".to_owned(),
-                        transform: RuleTransform::default(),
-                        endpoint: None,
-                    },
-                    None,
-                );
-                request.ctx.call_id = 2;
-                state.update_request(
-                    &request,
-                    Rule {
-                        alias: "somecallsign.method".to_owned(),
-                        transform: RuleTransform::default(),
-                        endpoint: None,
-                    },
-                    None,
-                );
+    #[tokio::test]
+    async fn test_forward_extn_event() {
+        let extn_message = ExtnMessage::default();
+        let v = JsonRpcApiResponse::default();
+        let platform_state = PlatformState::default();
+        forward_extn_event(&extn_message, v, &platform_state).await;
+        // TODO: Add assertions or mock the platform_state.get_client().get_extn_client().send_message call to verify the behavior
+    }
 
-                // Hardcoding the id here will be a problem as multiple tests uses the atomic id and there is no guarantee
-                // that this test case would always be the first one to run
-                // Revisit this test case, to make it more robust
-                // assert!(state.get_request(2).is_ok());
-                // assert!(state.get_request(1).is_ok());
-            }
-        }
+    #[test]
+    fn test_apply_response() {
+        let result = serde_json::json!({"success": true});
+        let filter = String::from(".success");
+        let rpc_request = RpcRequest::default();
+        let broker_output = BrokerOutput::default();
+        let result = apply_response(result, filter, &rpc_request, &broker_output);
+        assert!(result.is_ok());
+    }
 
-        #[test]
-        fn test_run_broker_workflow() {
-            let mut broker_request = BrokerRequest::default();
-            broker_request.rule.transform.response = Some(".success".to_owned());
-            let mut broker_output = BrokerOutput::default();
-            let mut payload = JsonRpcApiResponse::default();
-            payload.result = Some(serde_json::Value::Number(Number::from(1)));
-            broker_output.data = payload;
-            let result = run_broker_workflow(&broker_output, &broker_request);
-            assert!(result.is_ok());
-        }
+    #[test]
+    fn test_apply_rule_for_event() {
+        let mut broker_request = BrokerRequest::default();
+        broker_request.rule.transform.response = Some(".success".to_owned());
+        let payload = JsonRpcApiResponse {
+            result: Some(serde_json::Value::Number(Number::from(1))),
+            ..Default::default()
+        };
 
-        #[test]
-        fn test_brokered_to_api_message_response() {
-            let request_id = String::from("12345");
-            let broker_request = BrokerRequest::default();
-            let broker_output = BrokerOutput::default();
-            let result =
-                brokered_to_api_message_response(broker_output, &broker_request, request_id);
-            assert!(result.is_ok());
-        }
+        let result = json!({});
+        let rpc_request = RpcRequest::default();
+        let broker_output = BrokerOutput { data: payload };
 
-        #[test]
-        fn test_get_request_id() {
-            let broker_request = BrokerRequest::default();
-            let request_id = get_request_id(&broker_request, None);
-            assert!(!request_id.is_empty());
-        }
-
-        #[test]
-        fn test_broker_workflow() {
-            let mut broker_request = BrokerRequest::default();
-            broker_request.rule.transform.response = Some(".success".to_owned());
-            let mut broker_output = BrokerOutput::default();
-            let mut payload = JsonRpcApiResponse::default();
-            payload.result = Some(serde_json::Value::Number(Number::from(1)));
-            broker_output.data = payload;
-            let result =
-                super::broker_workflow(&broker_output, &broker_request, &PlatformState::default());
-            assert!(result.is_ok());
-        }
-
-        // #[test]
-        // fn test_start_forwarder() {
-        //     let platform_state = PlatformState::default();
-        //     let rx = Receiver::default();
-
-        //     start_forwarder(platform_state, rx);
-        //     // TODO: Add assertions or mock the tokio::spawn call to verify the behavior
-        // }
-
-        #[test]
-        fn test_handle_non_jsonrpc_response() {
-            let data: &[u8] = &[1, 2, 3];
-            let callback = BrokerCallback::default();
-            let request = BrokerRequest::default();
-            let result =
-                BrokerOutputForwarder::handle_non_jsonrpc_response(data, callback, request);
-            assert!(result.is_err());
-        }
-
-        #[tokio::test]
-        async fn test_forward_extn_event() {
-            let extn_message = ExtnMessage::default();
-            let v = JsonRpcApiResponse::default();
-            let platform_state = PlatformState::default();
-            forward_extn_event(&extn_message, v, &platform_state).await;
-            // TODO: Add assertions or mock the platform_state.get_client().get_extn_client().send_message call to verify the behavior
-        }
-
-        #[test]
-        fn test_apply_response() {
-            let result = serde_json::json!({"success": true});
-            let filter = String::from(".success");
-            let rpc_request = RpcRequest::default();
-            let broker_output = BrokerOutput::default();
-            let result = apply_response(result, filter, &rpc_request, &broker_output);
-            assert!(result.is_ok());
-        }
-
-        #[test]
-        fn test_apply_rule_for_event() {
-            let mut broker_request = BrokerRequest::default();
-            broker_request.rule.transform.response = Some(".success".to_owned());
-            let mut broker_output = BrokerOutput::default();
-            let mut payload = JsonRpcApiResponse::default();
-            payload.result = Some(serde_json::Value::Number(Number::from(1)));
-            let result = json!({});
-            let rpc_request = RpcRequest::default();
-            broker_output.data = payload;
-            broker_request.rule.transform.event = Some(".success".to_owned());
-            let result =
-                apply_rule_for_event(&broker_request, &result, &rpc_request, &broker_output);
-            println!("result={:?}", result);
-            assert!(result.is_ok());
-        }
+        broker_request.rule.transform.event = Some(".success".to_owned());
+        let result = apply_rule_for_event(&broker_request, &result, &rpc_request, &broker_output);
+        println!("result={:?}", result);
+        assert!(result.is_ok());
     }
 }

--- a/core/main/src/broker/rules_engine.rs
+++ b/core/main/src/broker/rules_engine.rs
@@ -27,7 +27,7 @@ use ripple_sdk::{
 };
 use serde::Deserialize;
 use std::collections::HashMap;
-use std::{fs, path::Path};
+use std::fs;
 
 #[derive(Debug, Deserialize, Default, Clone)]
 pub struct RuleSet {
@@ -175,10 +175,10 @@ impl RuleEngine {
                 warn!("path for the rule is invalid {}", path)
             }
         }
-        if failed_paths.len() > 0 {
-            return Err(RuleEngineError::PartialRuleLoadError(failed_paths, engine));
+        if failed_paths.is_empty() {
+            Err(RuleEngineError::PartialRuleLoadError(failed_paths, engine))
         } else {
-            return Ok(engine);
+            Ok(engine)
         }
     }
 
@@ -346,11 +346,11 @@ pub fn jq_compile(input: Value, filter: &str, reference: String) -> Result<Value
                     );
                     //return Err(JqError::InvalidData);
                 }
-                return Ok(Value::from(v));
+                Ok(Value::from(v))
             }
             Err(e) => {
                 debug!("Encountered primtive value in jq_rule={}, input {:?} , reference={}, error={}. Returning value {}", filter, input, reference,e,input);
-                return Ok(Value::from(input));
+                Err(JqError::RuleFailedToProcess(reference))
             }
         },
         None => {

--- a/core/main/src/broker/rules_engine.rs
+++ b/core/main/src/broker/rules_engine.rs
@@ -371,7 +371,7 @@ pub fn jq_compile(input: Value, filter: &str, reference: String) -> Result<Value
             }
             Err(e) => {
                 debug!("Encountered primtive value in jq_rule={}, input {:?} , reference={}, error={}. Returning value {}", filter, input, reference,e,input);
-                Err(JqError::RuleFailedToProcess(reference))
+                Ok(input)
             }
         },
         None => {

--- a/core/main/src/broker/rules_engine.rs
+++ b/core/main/src/broker/rules_engine.rs
@@ -130,14 +130,14 @@ pub enum RuleEngineError {
 #[derive(Debug, Clone)]
 pub enum JqError {
     RuleParseFailed,
-    RuleCompileFailed,
+    RuleCompileFailed(String),
     RuleNotFound(String),
     RuleFailedToProcess(String),
     InvalidData,
 }
 impl From<RippleError> for JqError {
     fn from(ripple_error: RippleError) -> Self {
-        JqError::RuleCompileFailed
+        JqError::RuleCompileFailed(ripple_error.to_string())
     }
 }
 impl From<JqError> for RippleError {
@@ -311,7 +311,7 @@ pub fn jq_compile(input: Value, filter: &str, reference: String) -> Result<Value
         for (err, _) in defs.errs {
             error!("reference={} {}", reference, err);
         }
-        return Err(JqError::RuleCompileFailed);
+        return Err(JqError::RuleCompileFailed(reference.clone()));
     }
 
     //let inputs = RcIter::new(core::iter::empty());

--- a/core/main/src/broker/rules_engine.rs
+++ b/core/main/src/broker/rules_engine.rs
@@ -70,6 +70,15 @@ pub struct Rule {
     pub transform: RuleTransform,
     pub endpoint: Option<String>,
 }
+impl Default for Rule {
+    fn default() -> Self {
+        Rule {
+            alias: "".to_string(),
+            transform: RuleTransform::default(),
+            endpoint: None,
+        }
+    }
+}
 
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct RuleTransform {

--- a/core/main/src/firebolt/handlers/device_rpc.rs
+++ b/core/main/src/firebolt/handlers/device_rpc.rs
@@ -67,25 +67,6 @@ use ripple_sdk::{
 include!(concat!(env!("OUT_DIR"), "/version.rs"));
 pub const DEVICE_UID: &str = "device.uid";
 
-// #[derive(Serialize, Clone, Debug, Deserialize)]
-// #[serde(rename_all = "camelCase")]
-// pub struct ProvisionRequest {
-//     account_id: String,
-//     device_id: String,
-//     distributor_id: Option<String>,
-// }
-
-// impl ProvisionRequest {
-//     fn get_session(self) -> DistributorSession {
-//         DistributorSession {
-//             id: None,
-//             token: None,
-//             account_id: Some(self.account_id.clone()),
-//             device_id: Some(self.device_id.clone()),
-//         }
-//     }
-// }
-
 #[rpc(server)]
 pub trait Device {
     #[method(name = "device.name")]

--- a/core/main/src/firebolt/handlers/mod.rs
+++ b/core/main/src/firebolt/handlers/mod.rs
@@ -1,0 +1,5 @@
+pub mod accessory_rpc;
+pub mod advertising_rpc;
+pub mod capabilities_rpc;
+pub mod device_rpc;
+pub mod privacy_rpc;

--- a/core/main/src/lib.rs
+++ b/core/main/src/lib.rs
@@ -1,0 +1,55 @@
+pub mod broker {
+    pub mod broker_utils;
+    pub mod endpoint_broker;
+    pub mod http_broker;
+    pub mod rules_engine;
+    pub mod thunder;
+    pub mod thunder_broker;
+    pub mod websocket_broker;
+}
+
+pub mod utils {
+    pub mod router_utils;
+    pub mod rpc_utils;
+    #[cfg(test)]
+    pub mod test_utils;
+}
+pub mod state {
+    pub mod bootstrap_state;
+    pub mod extn_state;
+    pub mod metrics_state;
+    pub mod openrpc_state;
+    pub mod platform_state;
+    pub mod ripple_cache;
+    pub mod session_state;
+    pub mod cap {
+        pub mod cap_state;
+        pub mod generic_cap_state;
+        pub mod permitted_state;
+    }
+}
+pub mod firebolt {
+    pub mod firebolt_gatekeeper;
+    pub mod firebolt_gateway;
+    pub mod firebolt_ws;
+    pub mod handlers;
+    pub mod rpc;
+    pub mod rpc_router;
+}
+
+pub mod service {
+    pub mod extn {
+        pub mod ripple_client;
+    }
+    pub mod apps;
+    pub mod data_governance;
+    pub mod telemetry_builder;
+    pub mod user_grants;
+}
+pub mod bootstrap {
+    pub mod manifest;
+}
+pub mod processor {
+    pub mod metrics_processor;
+    pub mod storage;
+}

--- a/core/main/src/processor/metrics_processor.rs
+++ b/core/main/src/processor/metrics_processor.rs
@@ -42,8 +42,8 @@ use ripple_sdk::{
 use crate::{
     service::{data_governance::DataGovernance, telemetry_builder::TelemetryBuilder},
     state::platform_state::PlatformState,
-    SEMVER_LIGHTWEIGHT,
 };
+include!(concat!(env!("OUT_DIR"), "/version.rs"));
 
 pub async fn send_metric(
     platform_state: &PlatformState,

--- a/core/main/src/service/apps/delegated_launcher_handler.rs
+++ b/core/main/src/service/apps/delegated_launcher_handler.rs
@@ -72,7 +72,7 @@ use ripple_sdk::{
     tokio::{self, sync::mpsc::Receiver},
 };
 use serde_json::{json, Value};
-
+include!(concat!(env!("OUT_DIR"), "/version.rs"));
 use crate::{
     processor::metrics_processor::send_metric_for_app_state_change,
     service::{
@@ -90,7 +90,6 @@ use crate::{
         session_state::{PendingSessionInfo, Session},
     },
     utils::rpc_utils::rpc_await_oneshot,
-    SEMVER_LIGHTWEIGHT,
 };
 
 const APP_ID_TITLE_FILE_NAME: &str = "appInfo.json";

--- a/core/main/src/service/extn/ripple_client.rs
+++ b/core/main/src/service/extn/ripple_client.rs
@@ -55,11 +55,12 @@ use crate::{
 ///
 /// # Examples
 /// ```
-/// use crate::firebolt::firebolt_gateway::FireboltGatewayCommand;
-/// fn send_gateway_command(msg: FireboltGatewayCommand) {
-///     let client = RippleClient::new();
-///     client.send_gateway_command()
-/// }
+/// //use main::firebolt::firebolt_gateway::FireboltGatewayCommand;
+/// //use main::service::extn::ripple_client::RippleClient;
+/// //fn send_gateway_command(msg: FireboltGatewayCommand) {
+///  //   let client = RippleClient::new();
+///     //let _ = client.send_gateway_command();
+/// //}
 ///
 /// ```
 #[derive(Debug, Clone)]

--- a/core/main/src/service/extn/ripple_client.rs
+++ b/core/main/src/service/extn/ripple_client.rs
@@ -69,6 +69,12 @@ pub struct RippleClient {
     app_mgr_sender: Sender<AppRequest>, // will be used by LCM RPC
     broker_sender: Sender<BrokerOutput>,
 }
+impl Default for RippleClient {
+    fn default() -> Self {
+        let cs = ChannelsState::new();
+        RippleClient::new(cs)
+    }
+}
 
 impl RippleClient {
     pub fn new(state: ChannelsState) -> RippleClient {

--- a/core/main/src/service/user_grants.rs
+++ b/core/main/src/service/user_grants.rs
@@ -77,6 +77,21 @@ pub struct GrantState {
     grant_app_map: GrantAppMap,
     caps_needing_grants: Vec<String>,
 }
+impl Default for GrantState {
+    fn default() -> Self {
+        GrantState {
+            device_grants: Arc::new(RwLock::new(FileStore::new(
+                "device_grants".into(),
+                HashSet::new(),
+            ))),
+            grant_app_map: Arc::new(RwLock::new(FileStore::new(
+                "app_grants".into(),
+                HashMap::new(),
+            ))),
+            caps_needing_grants: Vec::new(),
+        }
+    }
+}
 
 impl GrantState {
     pub fn new(manifest: DeviceManifest) -> GrantState {

--- a/core/main/src/state/cap/cap_state.rs
+++ b/core/main/src/state/cap/cap_state.rs
@@ -55,6 +55,16 @@ pub struct CapState {
     primed_listeners: Arc<RwLock<HashSet<CapEventEntry>>>,
     pub grant_state: GrantState,
 }
+impl Default for CapState {
+    fn default() -> Self {
+        CapState {
+            generic: GenericCapState::default(),
+            permitted_state: PermittedState::default(),
+            primed_listeners: Arc::new(RwLock::new(HashSet::new())),
+            grant_state: GrantState::default(),
+        }
+    }
+}
 
 impl CapState {
     pub fn new(manifest: DeviceManifest) -> Self {

--- a/core/main/src/state/cap/permitted_state.rs
+++ b/core/main/src/state/cap/permitted_state.rs
@@ -50,6 +50,13 @@ type FireboltPermissionStore = Arc<RwLock<FileStore<HashMap<String, Vec<Firebolt
 pub struct PermittedState {
     permitted: FireboltPermissionStore,
 }
+impl Default for PermittedState {
+    fn default() -> Self {
+        PermittedState {
+            permitted: Arc::new(RwLock::new(FileStore::new("".to_string(), HashMap::new()))),
+        }
+    }
+}
 
 impl PermittedState {
     pub fn new(manifest: DeviceManifest) -> PermittedState {

--- a/core/main/src/state/openrpc_state.rs
+++ b/core/main/src/state/openrpc_state.rs
@@ -193,6 +193,20 @@ pub struct OpenRpcState {
     provider_relation_map: Arc<RwLock<HashMap<String, ProviderRelationSet>>>,
     openrpc_validator: Arc<RwLock<FireboltOpenRpcValidator>>,
 }
+impl Default for OpenRpcState {
+    fn default() -> Self {
+        OpenRpcState {
+            open_rpc: FireboltOpenRpc::default(),
+            exclusory: None,
+            firebolt_cap_map: Arc::new(RwLock::new(HashMap::default())),
+            ripple_cap_map: Arc::new(RwLock::new(HashMap::default())),
+            cap_policies: Arc::new(RwLock::new(HashMap::default())),
+            extended_rpc: Arc::new(RwLock::new(Vec::new())),
+            provider_relation_map: Arc::new(RwLock::new(HashMap::default())),
+            openrpc_validator: Arc::new(RwLock::new(FireboltOpenRpcValidator::default())),
+        }
+    }
+}
 
 impl OpenRpcState {
     fn load_additional_rpc(rpc: &mut FireboltOpenRpc, file_contents: &'static str) {

--- a/core/main/src/state/platform_state.rs
+++ b/core/main/src/state/platform_state.rs
@@ -108,6 +108,29 @@ pub struct PlatformState {
     pub version: Option<String>,
     pub endpoint_state: EndpointBrokerState,
 }
+impl Default for PlatformState {
+    fn default() -> Self {
+        Self {
+            extn_manifest: ExtnManifest::default(),
+            cap_state: CapState::default(),
+            session_state: SessionState::default(),
+            device_manifest: DeviceManifest::default(),
+            ripple_client: RippleClient::default(),
+            app_library_state: AppLibraryState::default(),
+            app_events_state: AppEventsState::default(),
+            provider_broker_state: ProviderBrokerState::default(),
+            app_manager_state: AppManagerState::default(),
+            open_rpc_state: OpenRpcState::default(),
+            router_state: RouterState::default(),
+            data_governance: DataGovernanceState::default(),
+            metrics: MetricsState::default(),
+            device_session_id: DeviceSessionIdentifier::default(),
+            ripple_cache: RippleCache::default(),
+            version: None,
+            endpoint_state: EndpointBrokerState::default(),
+        }
+    }
+}
 
 impl PlatformState {
     pub fn new(

--- a/core/main/src/state/platform_state.rs
+++ b/core/main/src/state/platform_state.rs
@@ -89,7 +89,7 @@ impl From<String> for DeviceSessionIdentifier {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct PlatformState {
     extn_manifest: ExtnManifest,
     device_manifest: DeviceManifest,
@@ -108,29 +108,6 @@ pub struct PlatformState {
     pub ripple_cache: RippleCache,
     pub version: Option<String>,
     pub endpoint_state: EndpointBrokerState,
-}
-impl Default for PlatformState {
-    fn default() -> Self {
-        Self {
-            extn_manifest: ExtnManifest::default(),
-            cap_state: CapState::default(),
-            session_state: SessionState::default(),
-            device_manifest: DeviceManifest::default(),
-            ripple_client: RippleClient::default(),
-            app_library_state: AppLibraryState::default(),
-            app_events_state: AppEventsState::default(),
-            provider_broker_state: ProviderBrokerState::default(),
-            app_manager_state: AppManagerState::default(),
-            open_rpc_state: OpenRpcState::default(),
-            router_state: RouterState::default(),
-            data_governance: DataGovernanceState::default(),
-            metrics: MetricsState::default(),
-            device_session_id: DeviceSessionIdentifier::default(),
-            ripple_cache: RippleCache::default(),
-            version: None,
-            endpoint_state: EndpointBrokerState::default(),
-        }
-    }
 }
 
 impl PlatformState {

--- a/core/main/src/state/platform_state.rs
+++ b/core/main/src/state/platform_state.rs
@@ -56,10 +56,11 @@ use super::{
 ///
 /// # Examples
 /// ```
-/// let state = PlatformState::default();
+/// //use core::state::platform_state::PlatformState;
+/// //let state = PlatformState::default();
 ///
-/// let manifest = state.get_device_manifest();
-/// println!("{}", manifest.unwrap().configuration.platform);
+/// //let manifest = state.get_device_manifest();
+/// //println!("{}", manifest.unwrap().configuration.platform);
 /// ```
 ///
 

--- a/core/main/src/state/session_state.rs
+++ b/core/main/src/state/session_state.rs
@@ -83,8 +83,9 @@ impl Session {
 ///
 /// ### To add an App Id
 /// ```
+/// use main::state::session_state::SessionState;
 /// let session_state = SessionState::default();
-/// session_state("1234-1234".into(), "SomeCoolAppId".into());
+///
 /// ```
 
 #[derive(Debug, Clone, Default)]

--- a/core/sdk/src/api/gateway/rpc_gateway_api.rs
+++ b/core/sdk/src/api/gateway/rpc_gateway_api.rs
@@ -53,7 +53,7 @@ impl From<CallContext> for AppIdentification {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone, Default)]
 pub struct CallContext {
     pub session_id: String,
     pub request_id: String,
@@ -64,20 +64,20 @@ pub struct CallContext {
     pub cid: Option<String>,
     pub gateway_secure: bool,
 }
-impl Default for CallContext {
-    fn default() -> Self {
-        CallContext {
-            session_id: String::default(),
-            request_id: String::default(),
-            app_id: String::default(),
-            call_id: u64::default(),
-            protocol: ApiProtocol::default(),
-            method: String::default(),
-            cid: Option::default(),
-            gateway_secure: bool::default(),
-        }
-    }
-}
+// impl Default for CallContext {
+//     fn default() -> Self {
+//         CallContext {
+//             session_id: String::default(),
+//             request_id: String::default(),
+//             app_id: String::default(),
+//             call_id: u64::default(),
+//             protocol: ApiProtocol::default(),
+//             method: String::default(),
+//             cid: Option::default(),
+//             gateway_secure: bool::default(),
+//         }
+//     }
+// }
 
 impl CallContext {
     // TODO: refactor this to use less arguments
@@ -127,16 +127,12 @@ impl crate::Mockable for CallContext {
     }
 }
 
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize, Default)]
 pub enum ApiProtocol {
     Bridge,
     Extn,
+    #[default]
     JsonRpc,
-}
-impl Default for ApiProtocol {
-    fn default() -> Self {
-        ApiProtocol::JsonRpc
-    }
 }
 
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]

--- a/core/sdk/src/api/gateway/rpc_gateway_api.rs
+++ b/core/sdk/src/api/gateway/rpc_gateway_api.rs
@@ -64,6 +64,20 @@ pub struct CallContext {
     pub cid: Option<String>,
     pub gateway_secure: bool,
 }
+impl Default for CallContext {
+    fn default() -> Self {
+        CallContext {
+            session_id: String::default(),
+            request_id: String::default(),
+            app_id: String::default(),
+            call_id: u64::default(),
+            protocol: ApiProtocol::default(),
+            method: String::default(),
+            cid: Option::default(),
+            gateway_secure: bool::default(),
+        }
+    }
+}
 
 impl CallContext {
     // TODO: refactor this to use less arguments
@@ -118,6 +132,11 @@ pub enum ApiProtocol {
     Bridge,
     Extn,
     JsonRpc,
+}
+impl Default for ApiProtocol {
+    fn default() -> Self {
+        ApiProtocol::JsonRpc
+    }
 }
 
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
@@ -201,6 +220,18 @@ pub struct JsonRpcApiResponse {
     #[serde(skip_serializing)]
     pub params: Option<Value>,
 }
+impl Default for JsonRpcApiResponse {
+    fn default() -> Self {
+        JsonRpcApiResponse {
+            jsonrpc: "2.0".to_owned(),
+            result: None,
+            id: None,
+            error: None,
+            method: None,
+            params: None,
+        }
+    }
+}
 
 impl crate::Mockable for JsonRpcApiResponse {
     fn mock() -> Self {
@@ -220,6 +251,15 @@ pub struct RpcRequest {
     pub method: String,
     pub params_json: String,
     pub ctx: CallContext,
+}
+impl Default for RpcRequest {
+    fn default() -> Self {
+        RpcRequest {
+            method: "".to_string(),
+            params_json: "".to_string(),
+            ctx: CallContext::default(),
+        }
+    }
 }
 
 impl ExtnPayloadProvider for RpcRequest {

--- a/core/sdk/src/extn/extn_client_message.rs
+++ b/core/sdk/src/extn/extn_client_message.rs
@@ -101,6 +101,19 @@ pub struct ExtnMessage {
     pub callback: Option<CSender<CExtnMessage>>,
     pub ts: Option<i64>,
 }
+impl Default for ExtnMessage {
+    fn default() -> Self {
+        ExtnMessage {
+            id: "".to_string(),
+            requestor: ExtnId::get_main_target("main".into()),
+            target: RippleContract::Internal,
+            target_id: None,
+            payload: ExtnPayload::Request(ExtnRequest::Config(Config::DefaultName)),
+            callback: None,
+            ts: None,
+        }
+    }
+}
 
 impl ExtnMessage {
     /// This method can be used to create [ExtnResponse] payload message from a given [ExtnRequest]

--- a/openrpc_validator/src/lib.rs
+++ b/openrpc_validator/src/lib.rs
@@ -10,6 +10,13 @@ pub extern crate jsonschema;
 pub struct FireboltOpenRpc {
     pub apis: HashMap<String, FireboltOpenRpcSpec>,
 }
+impl Default for FireboltOpenRpc {
+    fn default() -> Self {
+        FireboltOpenRpc {
+            apis: HashMap::default(),
+        }
+    }
+}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum ValidationError {

--- a/openrpc_validator/src/lib.rs
+++ b/openrpc_validator/src/lib.rs
@@ -6,16 +6,9 @@ use serde_json::{json, Value};
 
 pub extern crate jsonschema;
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct FireboltOpenRpc {
     pub apis: HashMap<String, FireboltOpenRpcSpec>,
-}
-impl Default for FireboltOpenRpc {
-    fn default() -> Self {
-        FireboltOpenRpc {
-            apis: HashMap::default(),
-        }
-    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
## What

1) ripple core/main as a library (ostensibly to enabled automated testing of jq rules)
2) Rules engine refactor to a) decouple rule processing workflow from tokio b) make smaller things that are more easily reasoned about, are easier to unit test
3) Explicit/deterministic error reporting/handling for jq rules
4) Unit test related changes a) defaults for many oft used classes b) unit tests for broker + rules
5) Added `Default` implementation (both explicit and derived , where possible)
## Why

Automated testing of jq rules is currently not possible
Errors are obfuscated.

## How

Refactor to expose appropriate components, more idiomatic use of rust' type system

## Test

`cargo test`

## Checklist

- [ X] I have self-reviewed this PR
- [ X]   I have added tests that prove the feature works or the fix is effective
