### PR TITLE
RPPL-2407: fix:ad_opt_out for Advertising.config.

### DIFF
--- a/core/main/src/firebolt/handlers/advertising_rpc.rs
+++ b/core/main/src/firebolt/handlers/advertising_rpc.rs
@@ -351,7 +351,7 @@ impl AdvertisingServer for AdvertisingImpl {
             .await
             .unwrap_or(false);
 
-        let ad_opt_out = PrivacyImpl::get_allow_app_content_ad_targeting(&self.state).await;
+        let ad_opt_out = !PrivacyImpl::get_allow_app_content_ad_targeting(&self.state).await;
 
         let mut privacy_data = privacy_rpc::get_allow_app_content_ad_targeting_settings(
             &self.state,


### PR DESCRIPTION

## What

inverse the value updated by get_allow_app_content_ad_targeting().

## Why

get_allow_app_content_ad_targeting() inversion value should be update to  ad_opt_out.

## How

inversing the value updated by get_allow_app_content_ad_targeting()

## Test

https://ccp.sys.comcast.net/browse/RPPL-2407  refer this task for some test input's

## Checklist

- [+] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
