### PR TITLE
RPPL-1565 auto version increment for ripple artifacts (eos-ripple)

### DIFF
--- a/core/main/Cargo.toml
+++ b/core/main/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "main"
-version = "1.1.0"
+version = "2.1.5"
 edition = "2021"
 repository = "https://github.com/rdkcentral/Ripple"
 build = "build.rs"
@@ -62,6 +62,7 @@ openrpc_validator = { path = "../../openrpc_validator" }
 
 [build-dependencies]
 vergen = "1"
+cargo-release = "0.25.10"
 
 [dev-dependencies]
 ripple_tdk = { path = "../tdk" }

--- a/core/main/Cargo.toml
+++ b/core/main/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "main"
-version = "2.1.5"
+version = "1.1.0"
 edition = "2021"
 repository = "https://github.com/rdkcentral/Ripple"
 build = "build.rs"
@@ -59,10 +59,10 @@ jaq-core = "1.5.0"
 jaq-std = { version = "1.5.1", default-features = false }
 
 openrpc_validator = { path = "../../openrpc_validator" }
+cargo-release = "0.25.10"
 
 [build-dependencies]
 vergen = "1"
-cargo-release = "0.25.10"
 
 [dev-dependencies]
 ripple_tdk = { path = "../tdk" }

--- a/core/main/src/main.rs
+++ b/core/main/src/main.rs
@@ -37,7 +37,7 @@ async fn main() {
     // Check for --version flag
     let args: Vec<String> = env::args().collect();
     if args.contains(&"--version".to_string()) {
-        println!("Sakshi ripple {}", env!("CARGO_PKG_VERSION"));
+        println!("Ripple version {}", env!("CARGO_PKG_VERSION"));
         return;
     }
 

--- a/core/main/src/main.rs
+++ b/core/main/src/main.rs
@@ -22,6 +22,7 @@ use ripple_sdk::{
     utils::logger::init_and_configure_logger,
 };
 use state::bootstrap_state::BootstrapState;
+use std::env;
 pub mod bootstrap;
 pub mod broker;
 pub mod firebolt;
@@ -33,12 +34,19 @@ include!(concat!(env!("OUT_DIR"), "/version.rs"));
 
 #[tokio::main(worker_threads = 2)]
 async fn main() {
+    // Check for --version flag
+    let args: Vec<String> = env::args().collect();
+    if args.contains(&"--version".to_string()) {
+        println!("Sakshi ripple {}", env!("CARGO_PKG_VERSION"));
+        return;
+    }
+
     // Init logger
     if let Err(e) = init_and_configure_logger(SEMVER_LIGHTWEIGHT, "gateway".into()) {
         println!("{:?} logger init error", e);
         return;
     }
-    info!("version {}", SEMVER_LIGHTWEIGHT);
+    info!("version {}", env!("CARGO_PKG_VERSION"));
     let bootstate = BootstrapState::build().expect("Failure to init state for bootstrap");
 
     // bootstrap

--- a/openrpc_validator/Cargo.toml
+++ b/openrpc_validator/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 jsonschema = { version = "0.17.1", default-features = false }
 serde_json.workspace = true
 serde.workspace = true
-clap = {version = "=4.0", features = ["std"], default-features = false} # std required during ripple start
+clap = {version = "4.5.13", features = ["std"], default-features = false} # std required during ripple start

--- a/ripple
+++ b/ripple
@@ -117,6 +117,11 @@ case ${1} in
         cargo build --features local_dev
         cargo run --features local_dev core/main
     ;;
+    "--version")
+        # Navigate to an actual package directory within the workspace
+        workspace_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+        echo "Ripple version $(cargo pkgid --manifest-path "${workspace_dir}/core/main/Cargo.toml" | sed 's/.*#//')"
+    ;;
     "-h")
         print_help
     ;;


### PR DESCRIPTION
Acceptance Criteria 2(AC5)
SCENARIO: Provide new ripple functionality to enable ripple to be run and report it's version, in the form of `ripple --version`
GIVEN: Ripple version has been compiled into the binary at build time
WHEN: A user runs `ripple --version`
THEN: Ripple must print the compiled in version to stdout and exit