### PR TITLE
feat: Configurable Provider Registrations

### DIFF
--- a/core/main/src/firebolt/handlers/provider_registrar.rs
+++ b/core/main/src/firebolt/handlers/provider_registrar.rs
@@ -577,7 +577,7 @@ mod tests {
     async fn test_register_methods() {
         let mut methods = Methods::new();
         let mut runtime = test_utils::MockRuntime::new();
-        runtime.platform_state.open_rpc_state = OpenRpcState::new(None, Vec::new());
+        runtime.platform_state.open_rpc_state = OpenRpcState::new(None, Vec::new(), Vec::new());
 
         let mut provider_relation_map: HashMap<String, ProviderRelationSet> = HashMap::new();
         provider_relation_map.insert("some.method".to_string(), ProviderRelationSet::new());
@@ -597,7 +597,7 @@ mod tests {
     async fn test_register_method_event_provided_by() {
         let mut methods = Methods::new();
         let mut runtime = test_utils::MockRuntime::new();
-        runtime.platform_state.open_rpc_state = OpenRpcState::new(None, Vec::new());
+        runtime.platform_state.open_rpc_state = OpenRpcState::new(None, Vec::new(), Vec::new());
 
         let provider_relation_set = ProviderRelationSet {
             event: true,
@@ -623,7 +623,7 @@ mod tests {
     async fn test_register_method_event_provides() {
         let mut methods = Methods::new();
         let mut runtime = test_utils::MockRuntime::new();
-        runtime.platform_state.open_rpc_state = OpenRpcState::new(None, Vec::new());
+        runtime.platform_state.open_rpc_state = OpenRpcState::new(None, Vec::new(), Vec::new());
 
         let provider_relation_set = ProviderRelationSet {
             event: true,
@@ -649,7 +649,7 @@ mod tests {
     async fn test_register_method_event_provides_to() {
         let mut methods = Methods::new();
         let mut runtime = test_utils::MockRuntime::new();
-        runtime.platform_state.open_rpc_state = OpenRpcState::new(None, Vec::new());
+        runtime.platform_state.open_rpc_state = OpenRpcState::new(None, Vec::new(), Vec::new());
 
         let provider_relation_set = ProviderRelationSet {
             event: true,
@@ -675,7 +675,7 @@ mod tests {
     async fn test_register_method_provides_to() {
         let mut methods = Methods::new();
         let mut runtime = test_utils::MockRuntime::new();
-        runtime.platform_state.open_rpc_state = OpenRpcState::new(None, Vec::new());
+        runtime.platform_state.open_rpc_state = OpenRpcState::new(None, Vec::new(), Vec::new());
 
         let provider_relation_set = ProviderRelationSet {
             event: true,
@@ -701,7 +701,7 @@ mod tests {
     async fn test_register_method_error_for() {
         let mut methods = Methods::new();
         let mut runtime = test_utils::MockRuntime::new();
-        runtime.platform_state.open_rpc_state = OpenRpcState::new(None, Vec::new());
+        runtime.platform_state.open_rpc_state = OpenRpcState::new(None, Vec::new(), Vec::new());
 
         let provider_relation_set = ProviderRelationSet {
             error_for: Some("some.other.method".to_string()),
@@ -726,7 +726,7 @@ mod tests {
     async fn test_register_method_provided_by() {
         let mut methods = Methods::new();
         let mut runtime = test_utils::MockRuntime::new();
-        runtime.platform_state.open_rpc_state = OpenRpcState::new(None, Vec::new());
+        runtime.platform_state.open_rpc_state = OpenRpcState::new(None, Vec::new(), Vec::new());
 
         let provider_relation_set = ProviderRelationSet {
             provided_by: Some("some.other.method".to_string()),
@@ -751,7 +751,7 @@ mod tests {
     async fn test_register_method_allow_focus_for() {
         let mut methods = Methods::new();
         let mut runtime = test_utils::MockRuntime::new();
-        runtime.platform_state.open_rpc_state = OpenRpcState::new(None, Vec::new());
+        runtime.platform_state.open_rpc_state = OpenRpcState::new(None, Vec::new(), Vec::new());
 
         let provider_relation_set = ProviderRelationSet {
             allow_focus_for: Some("some.other.method".to_string()),
@@ -776,7 +776,7 @@ mod tests {
     async fn test_register_method_response_for() {
         let mut methods = Methods::new();
         let mut runtime = test_utils::MockRuntime::new();
-        runtime.platform_state.open_rpc_state = OpenRpcState::new(None, Vec::new());
+        runtime.platform_state.open_rpc_state = OpenRpcState::new(None, Vec::new(), Vec::new());
 
         let provider_relation_set = ProviderRelationSet {
             response_for: Some("some.other.method".to_string()),
@@ -802,7 +802,7 @@ mod tests {
         const METHOD_NAME: &str = "some.method";
 
         let mut runtime = test_utils::MockRuntime::new();
-        runtime.platform_state.open_rpc_state = OpenRpcState::new(None, Vec::new());
+        runtime.platform_state.open_rpc_state = OpenRpcState::new(None, Vec::new(), Vec::new());
 
         let provider_relation_set = ProviderRelationSet {
             response_for: Some("some.other.method".to_string()),

--- a/core/main/src/state/cap/cap_state.rs
+++ b/core/main/src/state/cap/cap_state.rs
@@ -348,7 +348,8 @@ mod tests {
             app_authorization_rules: AppAuthorizationRules { app_ignore_rules },
             method_ignore_rules: Vec::new(),
         };
-        runtime.platform_state.open_rpc_state = OpenRpcState::new(Some(exclusory), Vec::new());
+        runtime.platform_state.open_rpc_state =
+            OpenRpcState::new(Some(exclusory), Vec::new(), Vec::new());
         if let Ok(v) = CapState::get_cap_info(
             &runtime.platform_state,
             MockCallContext::get_from_app_id("some_app"),

--- a/core/main/src/state/openrpc_state.rs
+++ b/core/main/src/state/openrpc_state.rs
@@ -67,7 +67,7 @@ impl ProviderRelationSet {
 fn is_provider_enabled(method: &str, checksets: &Vec<String>) -> bool {
     let method_lower_case = method.to_lowercase();
     for checkset in checksets {
-        if checkset.to_lowercase().eq(&method_lower_case) {
+        if method_lower_case.starts_with(&checkset.to_lowercase()) {
             return true;
         }
     }
@@ -85,6 +85,8 @@ pub fn build_provider_relation_sets(
 
         if !is_provider_enabled(&method.name, checksets) {
             continue;
+        } else {
+            debug!("Provider enabled {:?}", method.name);
         }
 
         if let Some(tags) = &method.tags {
@@ -500,7 +502,7 @@ mod tests {
     #[test]
     fn test_provider_support() {
         assert!(is_provider_enabled(
-            "AcknowledgeChallenge.",
+            "AcknowledgeChallenge.onRequestChalleng",
             &default_providers()
         ));
         assert!(is_provider_enabled("PinChallenge.", &default_providers()));

--- a/core/main/src/state/openrpc_state.rs
+++ b/core/main/src/state/openrpc_state.rs
@@ -64,132 +64,6 @@ impl ProviderRelationSet {
     }
 }
 
-fn is_provider_enabled(method: &str, checksets: &Vec<String>) -> bool {
-    let method_lower_case = method.to_lowercase();
-    for checkset in checksets {
-        if method_lower_case.starts_with(&checkset.to_lowercase()) {
-            return true;
-        }
-    }
-    false
-}
-
-pub fn build_provider_relation_sets(
-    openrpc_methods: &Vec<FireboltOpenRpcMethod>,
-    checksets: &Vec<String>,
-) -> HashMap<String, ProviderRelationSet> {
-    let mut provider_relation_sets = HashMap::default();
-
-    for method in openrpc_methods {
-        let mut has_x_provides = None;
-
-        if !is_provider_enabled(&method.name, checksets) {
-            continue;
-        } else {
-            debug!("Provider enabled {:?}", method.name);
-        }
-
-        if let Some(tags) = &method.tags {
-            let mut has_event = false;
-            let mut x_allow_focus_for = None;
-            let mut x_response_for = None;
-            let mut x_error_for = None;
-            let mut x_provided_by = None;
-            let mut x_provides = None;
-            let mut x_uses = None;
-
-            for tag in tags {
-                if tag.name.eq("event") {
-                    has_event = true;
-                } else if tag.name.eq("capabilities") {
-                    has_x_provides = tag.get_provides();
-                    x_allow_focus_for = tag.allow_focus_for.clone();
-                    x_response_for = tag.response_for.clone();
-                    x_error_for = tag.error_for.clone();
-                    x_provided_by = tag.provided_by.clone();
-                    x_provides = tag.provides.clone();
-                    x_uses = tag.uses.clone();
-                }
-            }
-
-            let mut provider_relation_set = provider_relation_sets
-                .get(&FireboltOpenRpcMethod::name_with_lowercase_module(
-                    &method.name,
-                ))
-                .unwrap_or(&ProviderRelationSet::new())
-                .clone();
-
-            if has_x_provides.is_some() {
-                provider_relation_set.allow_focus_for = x_allow_focus_for;
-                provider_relation_set.response_for = x_response_for;
-                provider_relation_set.error_for = x_error_for;
-                provider_relation_set.capability = x_provides;
-            } else {
-                // x-provided-by can only be set if x-provides isn't.
-                provider_relation_set.provided_by = x_provided_by.clone();
-                if let Some(provided_by) = x_provided_by {
-                    let mut provided_by_set = provider_relation_sets
-                        .get(&provided_by)
-                        .unwrap_or(&ProviderRelationSet::new())
-                        .clone();
-
-                    provided_by_set.provides_to = Some(method.name.clone());
-
-                    provider_relation_sets.insert(
-                        FireboltOpenRpcMethod::name_with_lowercase_module(&provided_by),
-                        provided_by_set.to_owned(),
-                    );
-                }
-            }
-
-            provider_relation_set.uses = x_uses;
-            provider_relation_set.event = has_event;
-
-            // If this is an event, then it provides the capability.
-            if provider_relation_set.event {
-                provider_relation_set.provides = provider_relation_set.capability.clone();
-            }
-
-            let module: Vec<&str> = method.name.split('.').collect();
-            provider_relation_set.attributes = ProviderAttributes::get(module[0]);
-
-            provider_relation_sets.insert(
-                FireboltOpenRpcMethod::name_with_lowercase_module(&method.name),
-                provider_relation_set.to_owned(),
-            );
-        }
-    }
-
-    // Post-process sets to set 'provides' for methods that provide-to other methods.
-
-    let provides_to_array: Vec<(String, String)> = provider_relation_sets
-        .iter()
-        .filter_map(|(method_name, provider_relation_set)| {
-            provider_relation_set
-                .provides_to
-                .as_ref()
-                .map(|provides_to| (method_name.clone(), provides_to.clone()))
-        })
-        .collect();
-
-    for (provider_method, provides_to_method) in provides_to_array {
-        let provided_to_capability =
-            if let Some(provided_to_set) = provider_relation_sets.get(&provides_to_method) {
-                provided_to_set.capability.clone()
-            } else {
-                None
-            };
-
-        if let Some(provider_set) = provider_relation_sets.get_mut(&provider_method) {
-            if provider_set.provides.is_none() {
-                provider_set.provides = provided_to_capability.clone();
-            }
-        }
-    }
-
-    provider_relation_sets
-}
-
 #[derive(Debug, Clone)]
 pub struct OpenRpcState {
     open_rpc: FireboltOpenRpc,
@@ -243,12 +117,7 @@ impl OpenRpcState {
     pub fn add_extension_open_rpc(&self, path: &str) -> Result<(), RippleError> {
         match Self::load_open_rpc(path) {
             Some(open_rpc) => {
-                let provider_relation_sets =
-                    build_provider_relation_sets(&open_rpc.methods, &self.provider_registrations);
-                self.provider_relation_map
-                    .write()
-                    .unwrap()
-                    .extend(provider_relation_sets);
+                self.build_provider_relation_sets(&open_rpc.methods);
                 self.add_open_rpc(open_rpc);
                 Ok(())
             }
@@ -313,13 +182,11 @@ impl OpenRpcState {
             cap_policies: Arc::new(RwLock::new(version_manifest.capabilities)),
             open_rpc: firebolt_open_rpc.clone(),
             extended_rpc: Arc::new(RwLock::new(Vec::new())),
-            provider_relation_map: Arc::new(RwLock::new(build_provider_relation_sets(
-                &firebolt_open_rpc.methods,
-                &provider_registrations.clone(),
-            ))),
+            provider_relation_map: Arc::new(RwLock::new(HashMap::new())),
             openrpc_validator: Arc::new(RwLock::new(openrpc_validator)),
             provider_registrations,
         };
+        v.build_provider_relation_sets(&firebolt_open_rpc.methods);
 
         for path in extn_sdks {
             if v.add_extension_open_rpc(&path).is_err() {
@@ -491,52 +358,122 @@ impl OpenRpcState {
     pub fn get_openrpc_validator(&self) -> FireboltOpenRpcValidator {
         self.openrpc_validator.read().unwrap().clone()
     }
+
+    fn is_provider_enabled(&self, method: &str) -> bool {
+        let method_lower_case = method.to_lowercase();
+        self.provider_registrations
+            .iter()
+            .any(|x| method_lower_case.starts_with(&x.to_lowercase()))
+    }
+
+    pub fn build_provider_relation_sets(&self, openrpc_methods: &Vec<FireboltOpenRpcMethod>) {
+        let mut provider_relation_sets: HashMap<String, ProviderRelationSet> = HashMap::default();
+
+        for method in openrpc_methods {
+            let mut has_x_provides = None;
+
+            if !self.is_provider_enabled(&method.name) {
+                continue;
+            } else {
+                debug!("Provider enabled {:?}", method.name);
+            }
+
+            if let Some(tags) = &method.tags {
+                let mut has_event = false;
+                let mut x_allow_focus_for = None;
+                let mut x_response_for = None;
+                let mut x_error_for = None;
+                let mut x_provided_by = None;
+                let mut x_provides = None;
+                let mut x_uses = None;
+
+                for tag in tags {
+                    if tag.name.eq("event") {
+                        has_event = true;
+                    } else if tag.name.eq("capabilities") {
+                        has_x_provides = tag.get_provides();
+                        x_allow_focus_for = tag.allow_focus_for.clone();
+                        x_response_for = tag.response_for.clone();
+                        x_error_for = tag.error_for.clone();
+                        x_provided_by = tag.provided_by.clone();
+                        x_provides = tag.provides.clone();
+                        x_uses = tag.uses.clone();
+                    }
+                }
+
+                let mut provider_relation_set = provider_relation_sets
+                    .get(&FireboltOpenRpcMethod::name_with_lowercase_module(
+                        &method.name,
+                    ))
+                    .unwrap_or(&ProviderRelationSet::new())
+                    .clone();
+
+                if has_x_provides.is_some() {
+                    provider_relation_set.allow_focus_for = x_allow_focus_for;
+                    provider_relation_set.response_for = x_response_for;
+                    provider_relation_set.error_for = x_error_for;
+                    provider_relation_set.capability = x_provides;
+                } else {
+                    // x-provided-by can only be set if x-provides isn't.
+                    provider_relation_set.provided_by = x_provided_by.clone();
+                    if let Some(provided_by) = x_provided_by {
+                        let mut provided_by_set = provider_relation_sets
+                            .get(&provided_by)
+                            .unwrap_or(&ProviderRelationSet::new())
+                            .clone();
+
+                        provided_by_set.provides_to = Some(method.name.clone());
+
+                        provider_relation_sets.insert(
+                            FireboltOpenRpcMethod::name_with_lowercase_module(&provided_by),
+                            provided_by_set.to_owned(),
+                        );
+                    }
+                }
+
+                provider_relation_set.uses = x_uses;
+                provider_relation_set.event = has_event;
+
+                // If this is an event, then it provides the capability.
+                if provider_relation_set.event {
+                    provider_relation_set.provides = provider_relation_set.capability.clone();
+                }
+
+                let module: Vec<&str> = method.name.split('.').collect();
+                provider_relation_set.attributes = ProviderAttributes::get(module[0]);
+
+                provider_relation_sets.insert(
+                    FireboltOpenRpcMethod::name_with_lowercase_module(&method.name),
+                    provider_relation_set.to_owned(),
+                );
+            }
+        }
+
+        self.provider_relation_map
+            .write()
+            .unwrap()
+            .extend(provider_relation_sets)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use ripple_sdk::api::manifest::extn_manifest::default_providers;
 
-    use super::is_provider_enabled;
+    use crate::state::openrpc_state::OpenRpcState;
 
     #[test]
     fn test_provider_support() {
-        assert!(is_provider_enabled(
-            "AcknowledgeChallenge.onRequestChalleng",
-            &default_providers()
-        ));
-        assert!(is_provider_enabled("PinChallenge.", &default_providers()));
-        assert!(is_provider_enabled(
-            "Discovery.userInterest",
-            &default_providers()
-        ));
-        assert!(is_provider_enabled(
-            "Discovery.onRequestUserInterest",
-            &default_providers()
-        ));
-        assert!(is_provider_enabled(
-            "Discovery.userInterestResponse",
-            &default_providers()
-        ));
-        assert!(is_provider_enabled(
-            "Content.requestUserInterest",
-            &default_providers()
-        ));
-        assert!(is_provider_enabled(
-            "Content.onUserInterest",
-            &default_providers()
-        ));
-        assert!(is_provider_enabled(
-            "IntegratedPlayer.",
-            &default_providers()
-        ));
-        assert!(is_provider_enabled(
-            "integratedPlayer.",
-            &default_providers()
-        ));
-        assert!(is_provider_enabled(
-            "integratedplayer.",
-            &default_providers()
-        ));
+        let state = OpenRpcState::new(None, Vec::new(), default_providers());
+        assert!(state.is_provider_enabled("AcknowledgeChallenge.onRequestChallenge"));
+        assert!(state.is_provider_enabled("PinChallenge."));
+        assert!(state.is_provider_enabled("Discovery.userInterest"));
+        assert!(state.is_provider_enabled("Discovery.onRequestUserInterest"));
+        assert!(state.is_provider_enabled("Discovery.userInterestResponse"));
+        assert!(state.is_provider_enabled("Content.requestUserInterest"));
+        assert!(state.is_provider_enabled("Content.onUserInterest"));
+        assert!(state.is_provider_enabled("IntegratedPlayer."));
+        assert!(state.is_provider_enabled("integratedPlayer."));
+        assert!(state.is_provider_enabled("integratedplayer."));
     }
 }

--- a/core/main/src/state/platform_state.rs
+++ b/core/main/src/state/platform_state.rs
@@ -121,6 +121,7 @@ impl PlatformState {
         let broker_sender = client.get_broker_sender();
         let rule_engine = RuleEngine::build(&extn_manifest);
         let extn_sdks = extn_manifest.extn_sdks.clone();
+        let provider_registations = extn_manifest.provider_registrations.clone();
         Self {
             extn_manifest,
             cap_state: CapState::new(manifest.clone()),
@@ -131,7 +132,7 @@ impl PlatformState {
             app_events_state: AppEventsState::default(),
             provider_broker_state: ProviderBrokerState::default(),
             app_manager_state: AppManagerState::new(&manifest.configuration.saved_dir),
-            open_rpc_state: OpenRpcState::new(Some(exclusory), extn_sdks),
+            open_rpc_state: OpenRpcState::new(Some(exclusory), extn_sdks, provider_registations),
             router_state: RouterState::new(),
             data_governance: DataGovernanceState::default(),
             metrics: MetricsState::default(),

--- a/core/main/src/state/platform_state.rs
+++ b/core/main/src/state/platform_state.rs
@@ -225,6 +225,7 @@ impl PlatformState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ripple_sdk::api::manifest::extn_manifest::default_providers;
     use ripple_tdk::utils::test_utils::Mockable;
 
     impl Mockable for PlatformState {
@@ -236,12 +237,12 @@ mod tests {
                     .to_string(),
             )
             .unwrap();
-            let (_, extn_manifest) = ExtnManifest::load_from_content(
+            let (_, mut extn_manifest) = ExtnManifest::load_from_content(
                 include_str!("../../../../examples/manifest/extn-manifest-example.json")
                     .to_string(),
             )
             .unwrap();
-
+            extn_manifest.provider_registrations = default_providers();
             Self::new(
                 extn_manifest,
                 manifest,

--- a/core/sdk/src/api/manifest/extn_manifest.rs
+++ b/core/sdk/src/api/manifest/extn_manifest.rs
@@ -37,6 +37,22 @@ pub struct ExtnManifest {
     pub rules_path: Vec<String>,
     #[serde(default)]
     pub extn_sdks: Vec<String>,
+    #[serde(default = "default_providers")]
+    pub provider_registrations: Vec<String>,
+}
+
+pub fn default_providers() -> Vec<String> {
+    let value = [
+        "AcknowledgeChallenge.",
+        "PinChallenge.",
+        "Discovery.userInterest",
+        "Discovery.onRequestUserInterest",
+        "Discovery.userInterestResponse",
+        "Content.requestUserInterest",
+        "Content.onUserInterest",
+        "IntegratedPlayer.",
+    ];
+    value.iter().map(|x| x.to_string()).collect()
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -193,6 +209,7 @@ mod tests {
                 timeout: Some(5000),
                 rules_path: Vec::new(),
                 extn_sdks: Vec::new(),
+                provider_registrations: Vec::new(),
             }
         }
     }
@@ -259,6 +276,7 @@ mod tests {
             timeout: None,
             rules_path: Vec::new(),
             extn_sdks: Vec::new(),
+            provider_registrations: Vec::new(),
         };
 
         assert_eq!(

--- a/core/sdk/src/api/manifest/extn_manifest.rs
+++ b/core/sdk/src/api/manifest/extn_manifest.rs
@@ -24,7 +24,7 @@ use crate::{extn::extn_id::ExtnId, utils::error::RippleError};
 
 /// Contains the default path for the manifest
 /// file extension type based on platform
-#[derive(Deserialize, Debug, Clone, Default)]
+#[derive(Deserialize, Debug, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct ExtnManifest {
     pub default_path: String,
@@ -39,6 +39,23 @@ pub struct ExtnManifest {
     pub extn_sdks: Vec<String>,
     #[serde(default = "default_providers")]
     pub provider_registrations: Vec<String>,
+}
+
+/// Some unit tests which use defaults are failing because we need default providers for unit testing
+impl Default for ExtnManifest {
+    fn default() -> Self {
+        Self {
+            default_path: String::default(),
+            default_extension: String::default(),
+            extns: Vec::new(),
+            required_contracts: Vec::new(),
+            rpc_aliases: HashMap::new(),
+            timeout: None,
+            rules_path: Vec::new(),
+            extn_sdks: Vec::new(),
+            provider_registrations: default_providers(),
+        }
+    }
 }
 
 pub fn default_providers() -> Vec<String> {

--- a/core/sdk/src/api/manifest/extn_manifest.rs
+++ b/core/sdk/src/api/manifest/extn_manifest.rs
@@ -284,17 +284,7 @@ mod tests {
             }
         "#;
 
-        let expected_manifest = ExtnManifest {
-            default_path: "".to_string(),
-            default_extension: "".to_string(),
-            extns: vec![],
-            required_contracts: vec![],
-            rpc_aliases: HashMap::new(),
-            timeout: None,
-            rules_path: Vec::new(),
-            extn_sdks: Vec::new(),
-            provider_registrations: Vec::new(),
-        };
+        let expected_manifest = ExtnManifest::default();
 
         assert_eq!(
             ExtnManifest::load_from_content(contents.to_string()),


### PR DESCRIPTION
## What

Provider registrations are hard coded in ripple, making it configurable.

## Why

Hard coded configurations are not scalable for extension sdks.

## How

Having a default set of configurations and allow it to be overridden by manifests

## Test

Test without any manifest changes and make sure all the provider pattern works
Add an entry in provider_registrations for extension manifest and check if other providers fail with method not found.

## Checklist

- [x] I have self-reviewed this PR
- [x] I have added tests that prove the feature works or the fix is effective
