### PR TITLE
fix: Handling for Provider Error for generic

### DIFF
--- a/core/main/src/firebolt/handlers/provider_registrar.rs
+++ b/core/main/src/firebolt/handlers/provider_registrar.rs
@@ -133,13 +133,17 @@ impl ProviderRegistrar {
                 }
             }
             ProviderResponsePayloadType::GenericResponse => {
-                let external_provider_response: Result<ExternalProviderResponse<Value>, CallError> =
-                    params_sequence.next();
+                let external_provider_response: Result<
+                    ExternalProviderResponse<Option<Value>>,
+                    CallError,
+                > = params_sequence.next();
 
                 if let Ok(r) = external_provider_response {
                     return Some(ProviderResponse {
                         correlation_id: r.correlation_id,
-                        result: ProviderResponsePayload::GenericResponse(r.result),
+                        result: ProviderResponsePayload::GenericResponse(
+                            r.result.unwrap_or(Value::Null),
+                        ),
                     });
                 }
             }

--- a/core/main/src/firebolt/handlers/provider_registrar.rs
+++ b/core/main/src/firebolt/handlers/provider_registrar.rs
@@ -845,7 +845,7 @@ mod tests {
     fn test_generic_error() {
         let ctx = CallContext::mock();
         let p = format!(
-            r#"[{},{{"correlationId":"someid","error":{{"code":301,"message":"The Player with 'ipa' id does not exist"}}}}]"#,
+            r#"[{},{{"correlationId":"someid","error":{{"code":-60001,"message":"The Player with 'ipa' id does not exist"}}}}]"#,
             serde_json::to_string(&ctx).unwrap()
         );
         let params = Params::new(Some(&p));
@@ -857,7 +857,7 @@ mod tests {
         .unwrap();
         assert!(result.correlation_id.eq("someid"));
         if let ProviderResponsePayload::GenericError(c) = result.result {
-            assert!(c.code == 301);
+            assert!(c.code == -60001);
             assert!(c.message.eq("The Player with 'ipa' id does not exist"))
         }
     }

--- a/core/main/src/firebolt/handlers/provider_registrar.rs
+++ b/core/main/src/firebolt/handlers/provider_registrar.rs
@@ -119,15 +119,14 @@ impl ProviderRegistrar {
                     });
                 }
             }
-            ProviderResponsePayloadType::ChallengeError
-            | ProviderResponsePayloadType::GenericError => {
+            ProviderResponsePayloadType::GenericError => {
                 let external_provider_error: Result<ExternalProviderError, CallError> =
                     params_sequence.next();
                 match external_provider_error {
                     Ok(r) => {
                         return Some(ProviderResponse {
                             correlation_id: r.correlation_id,
-                            result: ProviderResponsePayload::ChallengeError(r.error),
+                            result: ProviderResponsePayload::GenericError(r.error),
                         });
                     }
                     Err(e) => error!("get provide response Error {:?}", e),
@@ -140,7 +139,7 @@ impl ProviderRegistrar {
                 if let Ok(r) = external_provider_response {
                     return Some(ProviderResponse {
                         correlation_id: r.correlation_id,
-                        result: ProviderResponsePayload::Generic(r.result),
+                        result: ProviderResponsePayload::GenericResponse(r.result),
                     });
                 }
             }
@@ -857,7 +856,7 @@ mod tests {
         )
         .unwrap();
         assert!(result.correlation_id.eq("someid"));
-        if let ProviderResponsePayload::ChallengeError(c) = result.result {
+        if let ProviderResponsePayload::GenericError(c) = result.result {
             assert!(c.code == 301);
             assert!(c.message.eq("The Player with 'ipa' id does not exist"))
         }

--- a/core/main/src/firebolt/handlers/provider_registrar.rs
+++ b/core/main/src/firebolt/handlers/provider_registrar.rs
@@ -119,15 +119,18 @@ impl ProviderRegistrar {
                     });
                 }
             }
-            ProviderResponsePayloadType::ChallengeError => {
+            ProviderResponsePayloadType::ChallengeError
+            | ProviderResponsePayloadType::GenericError => {
                 let external_provider_error: Result<ExternalProviderError, CallError> =
                     params_sequence.next();
-
-                if let Ok(r) = external_provider_error {
-                    return Some(ProviderResponse {
-                        correlation_id: r.correlation_id,
-                        result: ProviderResponsePayload::ChallengeError(r.error),
-                    });
+                match external_provider_error {
+                    Ok(r) => {
+                        return Some(ProviderResponse {
+                            correlation_id: r.correlation_id,
+                            result: ProviderResponsePayload::ChallengeError(r.error),
+                        });
+                    }
+                    Err(e) => error!("get provide response Error {:?}", e),
                 }
             }
             ProviderResponsePayloadType::Generic => {
@@ -319,9 +322,14 @@ impl ProviderRegistrar {
             ) {
                 ProviderBroker::provider_response(&context.platform_state, provider_response).await;
             }
+        } else if let Some(provider_response) = ProviderRegistrar::get_provider_response(
+            ProviderResponsePayloadType::GenericError,
+            params_sequence,
+        ) {
+            ProviderBroker::provider_response(&context.platform_state, provider_response).await;
         } else {
             error!(
-                "callback_error: NO ATTRIBUTES: context.method={}",
+                "callback_error: NO Valid ATTRIBUTES: context.method={}",
                 context.method
             );
             return Err(Error::Custom(String::from("Missing provider attributes")));
@@ -571,7 +579,7 @@ mod tests {
 
     use super::*;
     use jsonrpsee::core::server::rpc_module::Methods;
-    use ripple_sdk::tokio;
+    use ripple_sdk::{tokio, Mockable};
 
     #[tokio::test]
     async fn test_register_methods() {
@@ -832,5 +840,26 @@ mod tests {
         );
 
         assert!(!result);
+    }
+
+    #[test]
+    fn test_generic_error() {
+        let ctx = CallContext::mock();
+        let p = format!(
+            r#"[{},{{"correlationId":"someid","error":{{"code":301,"message":"The Player with 'ipa' id does not exist"}}}}]"#,
+            serde_json::to_string(&ctx).unwrap()
+        );
+        let params = Params::new(Some(&p));
+        let params_sequence = params.sequence();
+        let result = ProviderRegistrar::get_provider_response(
+            ProviderResponsePayloadType::GenericError,
+            params_sequence,
+        )
+        .unwrap();
+        assert!(result.correlation_id.eq("someid"));
+        if let ProviderResponsePayload::ChallengeError(c) = result.result {
+            assert!(c.code == 301);
+            assert!(c.message.eq("The Player with 'ipa' id does not exist"))
+        }
     }
 }

--- a/core/main/src/firebolt/handlers/provider_registrar.rs
+++ b/core/main/src/firebolt/handlers/provider_registrar.rs
@@ -133,7 +133,7 @@ impl ProviderRegistrar {
                     Err(e) => error!("get provide response Error {:?}", e),
                 }
             }
-            ProviderResponsePayloadType::Generic => {
+            ProviderResponsePayloadType::GenericResponse => {
                 let external_provider_response: Result<ExternalProviderResponse<Value>, CallError> =
                     params_sequence.next();
 
@@ -469,7 +469,7 @@ impl ProviderRegistrar {
 
         let response_payload_type = match &context.provider_relation_set.attributes {
             Some(attributes) => attributes.response_payload_type.clone(),
-            None => ProviderResponsePayloadType::Generic,
+            None => ProviderResponsePayloadType::GenericResponse,
         };
 
         if let Some(provider_response) =

--- a/core/sdk/src/api/firebolt/provider.rs
+++ b/core/sdk/src/api/firebolt/provider.rs
@@ -213,7 +213,7 @@ pub struct DataObject {}
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct GenericProviderError {
-    pub code: u32,
+    pub code: i32,
     pub message: String,
     pub data: Option<DataObject>,
 }

--- a/core/sdk/src/api/firebolt/provider.rs
+++ b/core/sdk/src/api/firebolt/provider.rs
@@ -49,6 +49,7 @@ pub enum ProviderResponsePayloadType {
     EntityInfoResponse,
     PurchasedContentResponse,
     Generic,
+    GenericError,
 }
 
 impl ToString for ProviderResponsePayloadType {
@@ -63,6 +64,7 @@ impl ToString for ProviderResponsePayloadType {
                 "PurchasedContentResponse".into()
             }
             ProviderResponsePayloadType::Generic => "GenericResponse".into(),
+            ProviderResponsePayloadType::GenericError => "GenericError".into(),
         }
     }
 }

--- a/core/sdk/src/api/firebolt/provider.rs
+++ b/core/sdk/src/api/firebolt/provider.rs
@@ -48,7 +48,7 @@ pub enum ProviderResponsePayloadType {
     KeyboardResult,
     EntityInfoResponse,
     PurchasedContentResponse,
-    Generic,
+    GenericResponse,
     GenericError,
 }
 
@@ -63,7 +63,7 @@ impl ToString for ProviderResponsePayloadType {
             ProviderResponsePayloadType::PurchasedContentResponse => {
                 "PurchasedContentResponse".into()
             }
-            ProviderResponsePayloadType::Generic => "GenericResponse".into(),
+            ProviderResponsePayloadType::GenericResponse => "GenericResponse".into(),
             ProviderResponsePayloadType::GenericError => "GenericError".into(),
         }
     }


### PR DESCRIPTION
## What

Currently Provider errors are not handled for Providers outside Pin Challenge and Acknowledge Challenge

## Why

Original changes were focused on the Response payloads.

## How

By providing a Generic Error Payload as a default parser for any Provider Responses before throwing errors.

## Test

Using Error Type object for Any API call outside Acknowledge Challenge and Pin Challenge

## Checklist

- [ ] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
