### PR TITLE
RPPL-2445: fix: get_hdcp_status() will update the correct HDCP status

### DIFF
--- a/device/thunder_ripple_sdk/src/processors/thunder_device_info.rs
+++ b/device/thunder_ripple_sdk/src/processors/thunder_device_info.rs
@@ -148,7 +148,6 @@ pub struct CachedDeviceInfo {
     model: Option<String>,
     make: Option<String>,
     hdcp_support: Option<HashMap<HdcpProfile, bool>>,
-    hdcp_status: Option<HDCPStatus>,
     hdr_profile: Option<HashMap<HdrProfile, bool>>,
     version: Option<FireboltSemanticVersion>,
 }
@@ -182,15 +181,6 @@ impl CachedState {
     fn update_hdcp_support(&self, value: HashMap<HdcpProfile, bool>) {
         let mut hdcp = self.cached.write().unwrap();
         let _ = hdcp.hdcp_support.insert(value);
-    }
-
-    fn get_hdcp_status(&self) -> Option<HDCPStatus> {
-        self.cached.read().unwrap().hdcp_status.clone()
-    }
-
-    fn update_hdcp_status(&self, value: HDCPStatus) {
-        let mut hdcp = self.cached.write().unwrap();
-        let _ = hdcp.hdcp_status.insert(value);
     }
 
     fn get_hdr(&self) -> Option<HashMap<HdrProfile, bool>> {
@@ -721,22 +711,16 @@ impl ThunderDeviceInfoRequestProcessor {
 
     async fn get_hdcp_status(state: &CachedState) -> HDCPStatus {
         let mut response: HDCPStatus = HDCPStatus::default();
-        match state.get_hdcp_status() {
-            Some(status) => response = status,
-            None => {
-                let resp = state
-                    .get_thunder_client()
-                    .call(DeviceCallRequest {
-                        method: ThunderPlugin::Hdcp.method("getHDCPStatus"),
-                        params: None,
-                    })
-                    .await;
-                info!("{}", resp.message);
-                if let Ok(thdcp) = serde_json::from_value::<ThunderHDCPStatus>(resp.message) {
-                    response = thdcp.hdcp_status;
-                    state.update_hdcp_status(response.clone());
-                }
-            }
+        let resp = state
+            .get_thunder_client()
+            .call(DeviceCallRequest {
+                method: ThunderPlugin::Hdcp.method("getHDCPStatus"),
+                params: None,
+            })
+            .await;
+        info!("{}", resp.message);
+        if let Ok(thdcp) = serde_json::from_value::<ThunderHDCPStatus>(resp.message) {
+            response = thdcp.hdcp_status;
         }
         response
     }


### PR DESCRIPTION
## What

modify the get_hdcp_status() handling slightly

## Why

hdcp status is not properly updating

## How

invoking thunder each time to get the correct hdcp status

## Test

after changes connect/disconnect hdmi cable then status will update accordingly.

## Checklist

- [+] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
