### PR TITLE
fix: Provider Error method should trigger

### DIFF
--- a/core/main/src/firebolt/handlers/provider_registrar.rs
+++ b/core/main/src/firebolt/handlers/provider_registrar.rs
@@ -402,7 +402,15 @@ impl ProviderRegistrar {
                     {
                         Ok(result) => match result {
                             Ok(provider_response_payload) => {
-                                return Ok(provider_response_payload.as_value());
+                                return if let Some(e) = provider_response_payload.is_error() {
+                                    Err(Error::Call(CallError::Custom {
+                                        code: e.code,
+                                        message: e.message,
+                                        data: None,
+                                    }))
+                                } else {
+                                    Ok(provider_response_payload.as_value())
+                                };
                             }
                             Err(_) => {
                                 return Err(Error::Custom(String::from(

--- a/core/sdk/src/api/firebolt/provider.rs
+++ b/core/sdk/src/api/firebolt/provider.rs
@@ -136,6 +136,14 @@ impl ProviderResponsePayload {
             ProviderResponsePayload::GenericResponse(res) => res.clone(),
         }
     }
+
+    pub fn is_error(&self) -> Option<GenericProviderError> {
+        if let ProviderResponsePayload::GenericError(e) = self {
+            Some(e.clone())
+        } else {
+            None
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize)]
@@ -371,5 +379,18 @@ mod tests {
                 entries: vec![],
             })
         );
+    }
+
+    #[test]
+    fn test_error_payload() {
+        let error = ProviderResponsePayload::GenericError(GenericProviderError {
+            code: -32121,
+            message: "some error message".into(),
+            data: None,
+        });
+        let er = error.is_error().unwrap();
+        assert!(er.code.eq(&-32121));
+        assert!(er.message.eq("some error message"));
+        assert!(er.data.is_none());
     }
 }


### PR DESCRIPTION
## What

Provider Error methods add the json rpc error on the result field 

## Why

The handling of a Generic Error enumeration is identical to that of a standard response.
## How

Separating the error handling compared to response handling.

## Test

Calling AcknowledgeError, PinChallengeError and expect the error to be encapsulated in an error object
## Checklist

- [x] I have self-reviewed this PR
- [x] I have added tests that prove the feature works or the fix is effective
