### PR TITLE
2592: modified the ripple script file for open-rpc.json copying in i…

### DIFF
--- a/core/main/Cargo.toml
+++ b/core/main/Cargo.toml
@@ -33,7 +33,6 @@ local_dev = []
 sysd = ["sd-notify"]
 pre_prod = []
 contract_tests = []
-test = []
 
 [dependencies]
 base64.workspace = true

--- a/core/main/Cargo.toml
+++ b/core/main/Cargo.toml
@@ -33,7 +33,7 @@ local_dev = []
 sysd = ["sd-notify"]
 pre_prod = []
 contract_tests = []
-
+test = []
 
 [dependencies]
 base64.workspace = true

--- a/core/main/Cargo.toml
+++ b/core/main/Cargo.toml
@@ -32,6 +32,8 @@ path = "src/main.rs"
 local_dev = []
 sysd = ["sd-notify"]
 pre_prod = []
+contract_tests = []
+
 
 [dependencies]
 base64.workspace = true

--- a/core/main/src/state/openrpc_state.rs
+++ b/core/main/src/state/openrpc_state.rs
@@ -466,7 +466,7 @@ this is only used once so far, but a bit more maintainable as a const
 /*
 test , local_dev and contract tests load the firebolt open rpc file from either a path or from the openrpc_validator version as compiled in.
 */
-#[cfg(any(feature = "local_dev", feature = "test", feature = "contract_tests"))]
+#[cfg(any(feature = "local_dev", feature = "contract_tests", test))]
 fn load_firebolt_open_rpc_path() -> Result<String, RippleError> {
     if let Ok(path) = std::env::var("FIREBOLT_OPEN_RPC") {
         info!(
@@ -476,18 +476,18 @@ fn load_firebolt_open_rpc_path() -> Result<String, RippleError> {
         load_firebolt_open_rpc_from_file(&path)
     } else {
         let fb_open_rpc_file =
-            include_str!("../../../../openrpc_validator/src/test/firebolt-open-rpc.json");
+            "../../openrpc_validator/src/test/firebolt-open-rpc.json".to_string();
         info!(
             " loading firebolt_open_rpc from openrpc_validator path: {}",
             fb_open_rpc_file
         );
-        load_firebolt_open_rpc_from_file(fb_open_rpc_file)
+        load_firebolt_open_rpc_from_file(&fb_open_rpc_file)
     }
 }
 // /*
 // Production load of the firebolt open rpc file
 // */
-#[cfg(not(any(feature = "local_dev", feature = "test", feature = "contract_tests")))]
+#[cfg(not(any(feature = "local_dev", feature = "contract_tests", test)))]
 fn load_firebolt_open_rpc_path() -> Result<String, RippleError> {
     info!(
         "production: loading firebolt_open_rpc from file {}",

--- a/core/main/src/state/openrpc_state.rs
+++ b/core/main/src/state/openrpc_state.rs
@@ -452,7 +452,7 @@ fn load_firebolt_open_rpc_from_file(fb_open_rpc_file: &str) -> Result<String, Ri
         }
         Err(e) => {
             error!(
-                "can't read firebolt_open_rpc from path :{}, e={:?}",
+                "can't read firebolt_open_rpc from path: {}, e={:?}",
                 &fb_open_rpc_file, e
             );
             Err(RippleError::ProcessorError)
@@ -466,7 +466,7 @@ this is only used once so far, but a bit more maintainable as a const
 /*
 test , local_dev and contract tests load the firebolt open rpc file from either a path or from the openrpc_validator version as compiled in.
 */
-#[cfg(any(feature = "local_dev", feature = "contract_tests"))]
+#[cfg(any(feature = "local_dev", feature = "test", feature = "contract_tests"))]
 fn load_firebolt_open_rpc_path() -> Result<String, RippleError> {
     if let Ok(path) = std::env::var("FIREBOLT_OPEN_RPC") {
         load_firebolt_open_rpc_from_file(&path)
@@ -474,7 +474,7 @@ fn load_firebolt_open_rpc_path() -> Result<String, RippleError> {
         info!(" local_dev or contract_tests: loading firebolt_open_rpc from file openrpc_validator/src/test/firebolt-open-rpc.json");
         let fb_open_rpc_file =
             include_str!("../../../../openrpc_validator/src/test/firebolt-open-rpc.json");
-        Ok(fb_open_rpc_file.to_string())
+        load_firebolt_open_rpc_from_file(&fb_open_rpc_file)
     }
 }
 // /*

--- a/core/main/src/state/openrpc_state.rs
+++ b/core/main/src/state/openrpc_state.rs
@@ -469,18 +469,22 @@ test , local_dev and contract tests load the firebolt open rpc file from either 
 #[cfg(any(feature = "local_dev", feature = "test", feature = "contract_tests"))]
 fn load_firebolt_open_rpc_path() -> Result<String, RippleError> {
     if let Ok(path) = std::env::var("FIREBOLT_OPEN_RPC") {
+        info!(
+            " loading firebolt_open_rpc from FIREBOLT_OPEN_RPC env var: {}",
+            &path
+        );
         load_firebolt_open_rpc_from_file(&path)
     } else {
         info!(" local_dev or contract_tests: loading firebolt_open_rpc from file openrpc_validator/src/test/firebolt-open-rpc.json");
         let fb_open_rpc_file =
             include_str!("../../../../openrpc_validator/src/test/firebolt-open-rpc.json");
-        load_firebolt_open_rpc_from_file(&fb_open_rpc_file)
+        load_firebolt_open_rpc_from_file(fb_open_rpc_file)
     }
 }
 // /*
 // Production load of the firebolt open rpc file
 // */
-#[cfg(not(any(feature = "local_dev", feature = "contract_tests")))]
+#[cfg(not(any(feature = "local_dev", feature = "test", feature = "contract_tests")))]
 fn load_firebolt_open_rpc_path() -> Result<String, RippleError> {
     info!(
         "production: loading firebolt_open_rpc from file {}",

--- a/core/main/src/state/openrpc_state.rs
+++ b/core/main/src/state/openrpc_state.rs
@@ -475,13 +475,10 @@ fn load_firebolt_open_rpc_path() -> Result<String, RippleError> {
         );
         load_firebolt_open_rpc_from_file(&path)
     } else {
+        info!(" local_dev or contract_tests: loading firebolt_open_rpc from file openrpc_validator/src/test/firebolt-open-rpc.json");
         let fb_open_rpc_file =
-            "../../openrpc_validator/src/test/firebolt-open-rpc.json".to_string();
-        info!(
-            " loading firebolt_open_rpc from openrpc_validator path: {}",
-            fb_open_rpc_file
-        );
-        load_firebolt_open_rpc_from_file(&fb_open_rpc_file)
+            include_str!("../../../../openrpc_validator/src/test/firebolt-open-rpc.json");
+        Ok(fb_open_rpc_file.to_string())
     }
 }
 // /*

--- a/core/main/src/state/openrpc_state.rs
+++ b/core/main/src/state/openrpc_state.rs
@@ -15,7 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use ripple_sdk::log::{debug, error};
+use ripple_sdk::log::{debug, error, info};
 use ripple_sdk::{api::firebolt::fb_openrpc::CapabilityPolicy, serde_json};
 use ripple_sdk::{
     api::{
@@ -421,33 +421,49 @@ impl OpenRpcState {
     }
 }
 
-fn load_firebolt_open_rpc_path() -> Option<String> {
-    let mut fb_open_rpc_file = "".to_string();
-    if cfg!(feature = "local_dev") {
-        let key = "FIREBOLT_OPEN_RPC";
-        let env_var = std::env::var(key);
-        if let Ok(path) = env_var {
-            fb_open_rpc_file = path;
-        };
-    } else if cfg!(test) {
-        fb_open_rpc_file = "../../openrpc_validator/src/test/firebolt-open-rpc.json".to_string();
-    } else {
-        fb_open_rpc_file = "/etc/ripple/openrpc/firebolt-open-rpc.json".to_string();
-    }
-
-    match std::fs::read_to_string(&fb_open_rpc_file) {
+fn load_firebolt_open_rpc_from_file(fb_open_rpc_file: &str) -> Result<String, RippleError> {
+    match std::fs::read_to_string(fb_open_rpc_file) {
         Ok(content) => {
             debug!("loading firebolt_open_rpc from {}", &fb_open_rpc_file);
-            Some(content)
+            Ok(content)
         }
         Err(e) => {
             error!(
                 "can't read firebolt_open_rpc from path :{}, e={:?}",
                 &fb_open_rpc_file, e
             );
-            None
+            Err(RippleError::ProcessorError)
         }
     }
+}
+/*
+this is only used once so far, but a bit more maintainable as a const
+*/
+
+/*
+test , local_dev and contract tests load the firebolt open rpc file from either a path or from the openrpc_validator version as compiled in.
+*/
+#[cfg(any(feature = "local_dev", feature = "contract_tests"))]
+fn load_firebolt_open_rpc_path() -> Result<String, RippleError> {
+    if let Ok(path) = std::env::var("FIREBOLT_OPEN_RPC") {
+        load_firebolt_open_rpc_from_file(&path)
+    } else {
+        info!(" local_dev or contract_tests: loading firebolt_open_rpc from file openrpc_validator/src/test/firebolt-open-rpc.json");
+        let fb_open_rpc_file =
+            include_str!("../../../../openrpc_validator/src/test/firebolt-open-rpc.json");
+        Ok(fb_open_rpc_file.to_string())
+    }
+}
+// /*
+// Production load of the firebolt open rpc file
+// */
+#[cfg(not(any(feature = "local_dev", feature = "contract_tests")))]
+fn load_firebolt_open_rpc_path() -> Result<String, RippleError> {
+    info!(
+        "production: loading firebolt_open_rpc from file {}",
+        "/etc/ripple/openrpc/firebolt-open-rpc.json"
+    );
+    load_firebolt_open_rpc_from_file("/etc/ripple/openrpc/firebolt-open-rpc.json")
 }
 
 #[cfg(test)]

--- a/core/main/src/state/openrpc_state.rs
+++ b/core/main/src/state/openrpc_state.rs
@@ -470,14 +470,17 @@ test , local_dev and contract tests load the firebolt open rpc file from either 
 fn load_firebolt_open_rpc_path() -> Result<String, RippleError> {
     if let Ok(path) = std::env::var("FIREBOLT_OPEN_RPC") {
         info!(
-            " loading firebolt_open_rpc from FIREBOLT_OPEN_RPC env var: {}",
+            " loading firebolt_open_rpc from FIREBOLT_OPEN_RPC env var path: {}",
             &path
         );
         load_firebolt_open_rpc_from_file(&path)
     } else {
-        info!(" local_dev or contract_tests: loading firebolt_open_rpc from file openrpc_validator/src/test/firebolt-open-rpc.json");
         let fb_open_rpc_file =
             include_str!("../../../../openrpc_validator/src/test/firebolt-open-rpc.json");
+        info!(
+            " loading firebolt_open_rpc from openrpc_validator path: {}",
+            fb_open_rpc_file
+        );
         load_firebolt_open_rpc_from_file(fb_open_rpc_file)
     }
 }

--- a/ripple
+++ b/ripple
@@ -81,7 +81,6 @@ case ${1} in
         cp ./examples/manifest/app-library-example.json ~/.ripple/firebolt-app-library.json
         cp ./examples/manifest/device-manifest-example.json ~/.ripple/firebolt-device-manifest.json
         cp ./examples/manifest/extn-manifest-example.json ~/.ripple/firebolt-extn-manifest.json
-        cp ./openrpc_validator/src/test/firebolt-open-rpc.json ~/.ripple/firebolt-open-rpc.json
 
         ## Update firebolt-extn-manifest.json
         sed -i "" "s@\"default_path\": \"/usr/lib/rust/\"@\"default_path\": \"$workspace_dir/target/debug/\"@" ~/.ripple/firebolt-extn-manifest.json
@@ -90,7 +89,6 @@ case ${1} in
 
         ## Update firebolt-device-manifest.json
         sed -i "" "s@\"library\": \"/etc/firebolt-app-library.json\"@\"library\": \"$HOME/.ripple/firebolt-app-library.json\"@" ~/.ripple/firebolt-device-manifest.json
-        export FIREBOLT_OPEN_RPC=${workspace_dir}/target/openrpc/firebolt-open-rpc.json
         echo "All Done!"
     ;;
     "run")
@@ -115,7 +113,6 @@ case ${1} in
         sed -i "" "s@\"mock_data_file\": \"mock-device.json\"@\"mock_data_file\": \"$workspace_dir/target/manifests/mock-thunder-device.json\"@" target/manifests/firebolt-extn-manifest.json
         export EXTN_MANIFEST=${workspace_dir}/target/manifests/firebolt-extn-manifest.json
         export DEVICE_MANIFEST=${workspace_dir}/target/manifests/firebolt-device-manifest.json
-        export FIREBOLT_OPEN_RPC=${workspace_dir}/target/openrpc/firebolt-open-rpc.json
         cargo build --features local_dev
         cargo run --features local_dev core/main
     ;;

--- a/ripple
+++ b/ripple
@@ -112,7 +112,7 @@ case ${1} in
         sed -i "" "s@\"library\": \"/etc/firebolt-app-library.json\"@\"library\": \"$workspace_dir/target/manifests/firebolt-app-library.json\"@" target/manifests/firebolt-device-manifest.json
         sed -i "" "s@\"mock_data_file\": \"mock-device.json\"@\"mock_data_file\": \"$workspace_dir/target/manifests/mock-thunder-device.json\"@" target/manifests/firebolt-extn-manifest.json
         export EXTN_MANIFEST=${workspace_dir}/target/manifests/firebolt-extn-manifest.json
-        export DEVICE_MANIFEST=${workspace_dir}/target/manifests/firebolt-device-manifest.json
+        export DEVICE_MANIFEST=${workspace_dir}/target/manifests/firebolt-device-manifest.jsons
         cargo build --features local_dev
         cargo run --features local_dev core/main
     ;;

--- a/ripple
+++ b/ripple
@@ -81,6 +81,7 @@ case ${1} in
         cp ./examples/manifest/app-library-example.json ~/.ripple/firebolt-app-library.json
         cp ./examples/manifest/device-manifest-example.json ~/.ripple/firebolt-device-manifest.json
         cp ./examples/manifest/extn-manifest-example.json ~/.ripple/firebolt-extn-manifest.json
+        cp ./openrpc_validator/src/test/firebolt-open-rpc.json ~/.ripple/firebolt-open-rpc.json
 
         ## Update firebolt-extn-manifest.json
         sed -i "" "s@\"default_path\": \"/usr/lib/rust/\"@\"default_path\": \"$workspace_dir/target/debug/\"@" ~/.ripple/firebolt-extn-manifest.json
@@ -89,7 +90,7 @@ case ${1} in
 
         ## Update firebolt-device-manifest.json
         sed -i "" "s@\"library\": \"/etc/firebolt-app-library.json\"@\"library\": \"$HOME/.ripple/firebolt-app-library.json\"@" ~/.ripple/firebolt-device-manifest.json
-
+        export FIREBOLT_OPEN_RPC=${workspace_dir}/target/openrpc/firebolt-open-rpc.json
         echo "All Done!"
     ;;
     "run")


### PR DESCRIPTION
…nit.

## What

in init case added the firebolt-open-rpc.json file copy and environment variable.

## Why

contract test's are failed to read the firebolt-open-rpc.json file path.

## How

copy the firebolt-open-rpc.json file from openrpc_validator into ripple

## Test

Raise a PR, check for the test result's

## Checklist

- [x] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
