### PR TITLE
feat: Upgrade Telemetry and better logging levels

### DIFF
--- a/core/main/src/bootstrap/start_fbgateway_step.rs
+++ b/core/main/src/bootstrap/start_fbgateway_step.rs
@@ -15,6 +15,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use std::time::Instant;
+
 use crate::{
     firebolt::{
         firebolt_gateway::FireboltGateway,
@@ -40,7 +42,7 @@ use crate::{
     state::{bootstrap_state::BootstrapState, platform_state::PlatformState},
 };
 use jsonrpsee::core::{async_trait, server::rpc_module::Methods};
-use ripple_sdk::log::debug;
+use ripple_sdk::log::{debug, info};
 use ripple_sdk::{framework::bootstrap::Bootstep, utils::error::RippleError};
 pub struct FireboltGatewayStep;
 
@@ -108,6 +110,10 @@ impl Bootstep<BootstrapState> for FireboltGatewayStep {
             return Err(RippleError::BootstrapError);
         }
         TelemetryBuilder::send_ripple_telemetry(&state.platform_state);
+        info!(
+            "Ripple Total Bootstrap time: {}",
+            Instant::now().duration_since(state.start_time).as_millis()
+        );
         gateway.start().await;
 
         Err(RippleError::ServiceError)

--- a/core/main/src/broker/event_management_utility.rs
+++ b/core/main/src/broker/event_management_utility.rs
@@ -19,7 +19,7 @@ use std::{collections::HashMap, pin::Pin};
 
 use futures::Future;
 use ripple_sdk::{
-    api::gateway::rpc_gateway_api::{ApiProtocol, CallContext, RpcRequest},
+    api::gateway::rpc_gateway_api::{ApiProtocol, CallContext, RpcRequest, RpcStats},
     extn::extn_client_message::ExtnResponse,
     log::info,
     utils::error::RippleError,
@@ -85,6 +85,7 @@ impl EventManagementUtility {
         let rpc_request = RpcRequest {
             ctx: new_ctx.clone(),
             method: "advertising.policy".into(),
+            stats: RpcStats::default(),
             params_json: RpcRequest::prepend_ctx(None, &new_ctx),
         };
 

--- a/core/main/src/broker/rules_engine.rs
+++ b/core/main/src/broker/rules_engine.rs
@@ -18,9 +18,10 @@ use jaq_interpret::{Ctx, FilterT, ParseCtx, RcIter, Val};
 use ripple_sdk::api::{
     gateway::rpc_gateway_api::RpcRequest, manifest::extn_manifest::ExtnManifest,
 };
+use ripple_sdk::log::trace;
 use ripple_sdk::{
     chrono::Utc,
-    log::{debug, error, info, warn},
+    log::{error, info, warn},
     serde_json::Value,
     utils::error::RippleError,
 };
@@ -41,7 +42,7 @@ impl RuleSet {
             .rules
             .into_iter()
             .map(|(k, v)| {
-                debug!("Loading JQ Rule for {}", k.to_lowercase());
+                trace!("Loading JQ Rule for {}", k.to_lowercase());
                 (k.to_lowercase(), v)
             })
             .collect();
@@ -104,11 +105,11 @@ pub struct RuleTransform {
 impl RuleTransform {
     pub fn apply_context(&mut self, rpc_request: &RpcRequest) {
         if let Some(value) = self.request.take() {
-            debug!("Check if value contains {}", value);
+            trace!("Check if value contains {}", value);
             if value.contains("$context.appId") {
-                debug!("has context");
+                trace!("has context");
                 let new_value = value.replace("$context.appId", &rpc_request.ctx.app_id);
-                debug!("changed value {}", new_value);
+                trace!("changed value {}", new_value);
                 let _ = self.request.insert(new_value);
             } else {
                 let _ = self.request.insert(value);
@@ -146,14 +147,14 @@ impl RuleEngine {
     }
 
     pub fn build(extn_manifest: &ExtnManifest) -> Self {
-        debug!("building rules engine {:?}", extn_manifest.rules_path);
+        trace!("building rules engine {:?}", extn_manifest.rules_path);
         let mut engine = RuleEngine::default();
         for path in extn_manifest.rules_path.iter() {
             let path_for_rule = Self::build_path(path, &extn_manifest.default_path);
-            debug!("loading rule {}", path_for_rule);
+            info!("loading rule {}", path_for_rule);
             if let Some(p) = Path::new(&path_for_rule).to_str() {
                 if let Ok(contents) = fs::read_to_string(p) {
-                    debug!("Rule content {}", contents);
+                    info!("Rule content {}", contents);
                     if let Ok((_, rule_set)) = Self::load_from_content(contents) {
                         engine.rules.append(rule_set)
                     } else {
@@ -195,7 +196,7 @@ impl RuleEngine {
             rule.transform.apply_context(rpc_request);
             return Some(rule);
         } else {
-            info!(
+            trace!(
                 "Rule not available for {}, hence falling back to extension handler",
                 rpc_request.method
             );
@@ -205,7 +206,7 @@ impl RuleEngine {
 }
 
 pub fn jq_compile(input: Value, filter: &str, reference: String) -> Result<Value, RippleError> {
-    debug!("Jq rule {}  input {:?}", filter, input);
+    info!("Jq rule {}  input {:?}", filter, input);
     let start = Utc::now().timestamp_millis();
     // start out only from core filters,
     // which do not include filters in the standard library

--- a/core/main/src/firebolt/firebolt_gateway.rs
+++ b/core/main/src/firebolt/firebolt_gateway.rs
@@ -25,16 +25,15 @@ use ripple_sdk::{
         },
         gateway::{
             rpc_error::RpcError,
-            rpc_gateway_api::{ApiMessage, ApiProtocol, RpcRequest},
+            rpc_gateway_api::{ApiMessage, ApiProtocol, ApiStats, RpcRequest},
         },
     },
-    chrono::Utc,
     extn::extn_client_message::ExtnMessage,
-    log::{debug, error, info, warn},
+    log::{debug, error, info, trace, warn},
     serde_json::{self, Value},
     tokio,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     firebolt::firebolt_gatekeeper::FireboltGatekeeper,
@@ -46,6 +45,7 @@ use crate::{
         bootstrap_state::BootstrapState, openrpc_state::OpenRpcState,
         platform_state::PlatformState, session_state::Session,
     },
+    utils::router_utils::{capture_stage, get_rpc_header_with_status},
 };
 
 use super::rpc_router::RpcRouter;
@@ -53,7 +53,7 @@ pub struct FireboltGateway {
     state: BootstrapState,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct JsonRpcMessage {
     pub jsonrpc: TwoPointZero,
     pub id: u64,
@@ -61,7 +61,7 @@ pub struct JsonRpcMessage {
     pub error: Option<JsonRpcError>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct JsonRpcError {
     pub code: i32,
     pub message: String,
@@ -98,7 +98,7 @@ impl FireboltGateway {
     }
 
     pub async fn start(&self) {
-        info!("Starting Gateway Listener");
+        trace!("Starting Gateway Listener");
         let mut firebolt_gateway_rx = self
             .state
             .channels_state
@@ -145,9 +145,11 @@ impl FireboltGateway {
     }
 
     pub async fn handle(&self, request: RpcRequest, extn_msg: Option<ExtnMessage>) {
-        info!(
+        trace!(
             "firebolt_gateway Received Firebolt request {} {} {}",
-            request.ctx.request_id, request.method, request.params_json
+            request.ctx.request_id,
+            request.method,
+            request.params_json
         );
         let mut extn_request = false;
         // First check sender if no sender no need to process
@@ -186,7 +188,6 @@ impl FireboltGateway {
          */
         let mut request_c = request.clone();
         request_c.method = FireboltOpenRpcMethod::name_with_lowercase_module(&request.method);
-
         let metrics_timer = TelemetryBuilder::start_firebolt_metrics_timer(
             &platform_state.get_client().get_extn_client(),
             request_c.method.clone(),
@@ -196,19 +197,9 @@ impl FireboltGateway {
         let open_rpc_state = self.state.platform_state.open_rpc_state.clone();
 
         tokio::spawn(async move {
-            let start = Utc::now().timestamp_millis();
-
+            capture_stage(&mut request_c, "context_ready");
             // Validate incoming request parameters.
-            if let Err(error_string) = validate_request(open_rpc_state, &request_c) {
-                let now = Utc::now().timestamp_millis();
-
-                RpcRouter::log_rdk_telemetry_message(
-                    &request.ctx.app_id,
-                    &request.method,
-                    JSON_RPC_STANDARD_ERROR_INVALID_PARAMS,
-                    now - start,
-                );
-
+            if let Err(error_string) = validate_request(open_rpc_state, &mut request_c) {
                 TelemetryBuilder::stop_and_send_firebolt_metrics_timer(
                     &platform_state.clone(),
                     metrics_timer,
@@ -225,6 +216,7 @@ impl FireboltGateway {
                 send_json_rpc_error(&platform_state, &request, json_rpc_error).await;
                 return;
             }
+            capture_stage(&mut request_c, "openrpc_val");
 
             let result = if extn_request {
                 // extn protocol means its an internal Ripple request skip permissions.
@@ -232,6 +224,7 @@ impl FireboltGateway {
             } else {
                 FireboltGatekeeper::gate(platform_state.clone(), request_c.clone()).await
             };
+            capture_stage(&mut request_c, "permission");
 
             match result {
                 Ok(_) => {
@@ -277,15 +270,6 @@ impl FireboltGateway {
                 Err(e) => {
                     let deny_reason = e.reason;
                     // log firebolt response message in RDKTelemetry 1.0 friendly format
-                    let now = Utc::now().timestamp_millis();
-
-                    RpcRouter::log_rdk_telemetry_message(
-                        &request.ctx.app_id,
-                        &request.method,
-                        deny_reason.get_rpc_error_code(),
-                        now - start,
-                    );
-
                     TelemetryBuilder::stop_and_send_firebolt_metrics_timer(
                         &platform_state.clone(),
                         metrics_timer,
@@ -312,33 +296,55 @@ impl FireboltGateway {
     }
 }
 
-fn validate_request(open_rpc_state: OpenRpcState, request: &RpcRequest) -> Result<(), String> {
-    let major_version = open_rpc_state.get_version().major.to_string();
-    let openrpc_validator = open_rpc_state.get_openrpc_validator();
-
-    if let Some(rpc_method) = openrpc_validator.get_method_by_name(&request.method) {
-        let validator = openrpc_validator
-            .params_validator(major_version, &rpc_method.name)
-            .unwrap();
-
-        if let Ok(params) = serde_json::from_str::<Vec<serde_json::Value>>(&request.params_json) {
-            if params.len() > 1 {
-                if let Err(errors) = validator.validate(&params[1]) {
-                    let mut error_string = String::new();
-                    for error in errors {
-                        error_string.push_str(&format!("{} ", error));
-                    }
-                    return Err(error_string);
-                }
-            }
+fn validate_request(open_rpc_state: OpenRpcState, request: &mut RpcRequest) -> Result<(), String> {
+    // Params should be valid given we get the request from Firebolt WS Call context is decorated
+    // in index 0
+    if let Ok(params) = serde_json::from_str::<Vec<serde_json::Value>>(&request.params_json) {
+        // Check if there are params
+        let param = params.get(1);
+        if param.is_none() {
+            // if params are necessary then handler or jq rule will fail
+            // This method can unblock other calls.
+            return Ok(());
         }
-    } else {
-        // TODO: Currently LifecycleManagement and other APIs are not in the schema. Let these pass through to their
-        // respective handlers for now.
-        debug!(
-            "validate_request: Method not found in schema: {}",
-            request.method
-        );
+        let param = param.unwrap();
+        let method_name = request.method.to_lowercase();
+
+        // Check if the cache is already created using add_json_schema_cache below
+        let v = open_rpc_state.validate_schema(&method_name, param);
+        if v.is_ok() {
+            // Params are valid
+            return Ok(());
+        } else if let Err(Some(s)) = v {
+            // Params are not valid
+            return Err(s);
+        }
+        let major_version = open_rpc_state.get_version().major.to_string();
+        let openrpc_validator = open_rpc_state.get_openrpc_validator();
+        // Get Method from the validator
+        if let Some(rpc_method) = openrpc_validator.get_method_by_name(&method_name) {
+            // Get schema validator
+            let validator = openrpc_validator
+                .params_validator(major_version, &rpc_method.name)
+                .unwrap();
+            // validate
+            if let Err(errors) = validator.validate(param) {
+                let mut error_string = String::new();
+                for error in errors {
+                    error_string.push_str(&format!("{} ", error));
+                }
+                return Err(error_string);
+            }
+            // store validator in runtime for future validations of the same api
+            open_rpc_state.add_json_schema_cache(method_name, validator);
+        } else {
+            // TODO: Currently LifecycleManagement and other APIs are not in the schema. Let these pass through to their
+            // respective handlers for now.
+            debug!(
+                "validate_request: Method not found in schema: {}",
+                request.method
+            );
+        }
     }
 
     Ok(())
@@ -354,6 +360,7 @@ async fn send_json_rpc_error(
         .session_state
         .get_session(&request.ctx)
     {
+        let status_code = json_rpc_error.code;
         let error_message = JsonRpcMessage {
             jsonrpc: TwoPointZero {},
             id: request.ctx.call_id,
@@ -361,11 +368,16 @@ async fn send_json_rpc_error(
         };
 
         if let Ok(error_message) = serde_json::to_string(&error_message) {
-            let api_message = ApiMessage::new(
+            let mut api_message = ApiMessage::new(
                 request.clone().ctx.protocol,
                 error_message,
                 request.clone().ctx.request_id,
             );
+
+            api_message.stats = Some(ApiStats {
+                stats_ref: get_rpc_header_with_status(request, status_code),
+                stats: request.stats.clone(),
+            });
 
             match session.get_transport() {
                 EffectiveTransport::Websocket => {

--- a/core/main/src/firebolt/handlers/privacy_rpc.rs
+++ b/core/main/src/firebolt/handlers/privacy_rpc.rs
@@ -27,6 +27,7 @@ use jsonrpsee::{
     types::error::CallError,
     RpcModule,
 };
+use ripple_sdk::api::gateway::rpc_gateway_api::RpcStats;
 use ripple_sdk::{
     api::{
         device::device_peristence::SetBoolProperty,
@@ -92,6 +93,7 @@ impl AllowAppContentAdTargetingSettings {
             ctx: new_ctx.clone(),
             method: "localization.countryCode".into(),
             params_json: RpcRequest::prepend_ctx(None, &new_ctx),
+            stats: RpcStats::default(),
         };
 
         let resp = platform_state

--- a/core/main/src/processor/storage/default_storage_properties.rs
+++ b/core/main/src/processor/storage/default_storage_properties.rs
@@ -30,7 +30,7 @@ use ripple_sdk::{
         NAMESPACE_AUDIO_DESCRIPTION, NAMESPACE_CLOSED_CAPTIONS, NAMESPACE_DEVICE_NAME,
         NAMESPACE_LOCALIZATION, NAMESPACE_PRIVACY,
     },
-    log::debug,
+    log::trace,
 };
 
 use crate::state::platform_state::PlatformState;
@@ -51,7 +51,7 @@ impl DefaultStorageProperties {
         namespace: &String,
         key: &'static str,
     ) -> Result<bool, DefaultStoragePropertiesError> {
-        debug!("get_bool: namespace={}, key={}", namespace, key);
+        trace!("get_bool: namespace={}, key={}", namespace, key);
         if namespace.eq(NAMESPACE_CLOSED_CAPTIONS) {
             match key {
                 KEY_ENABLED => Ok(state
@@ -158,7 +158,7 @@ impl DefaultStorageProperties {
         namespace: &String,
         key: &'static str,
     ) -> Result<String, DefaultStoragePropertiesError> {
-        debug!("get_string: namespace={}, key={}", namespace, key);
+        trace!("get_string: namespace={}, key={}", namespace, key);
         if namespace.eq(NAMESPACE_CLOSED_CAPTIONS) {
             let captions = state
                 .get_device_manifest()
@@ -272,7 +272,7 @@ impl DefaultStorageProperties {
         namespace: &String,
         key: &'static str,
     ) -> Result<u32, DefaultStoragePropertiesError> {
-        debug!("get_number_as_u32: namespace={}, key={}", namespace, key);
+        trace!("get_number_as_u32: namespace={}, key={}", namespace, key);
         if namespace.eq(NAMESPACE_CLOSED_CAPTIONS) {
             let captions = state
                 .get_device_manifest()
@@ -309,7 +309,7 @@ impl DefaultStorageProperties {
         namespace: &String,
         key: &'static str,
     ) -> Result<f32, DefaultStoragePropertiesError> {
-        debug!("get_number_as_f32: namespace={}, key={}", namespace, key);
+        trace!("get_number_as_f32: namespace={}, key={}", namespace, key);
         if namespace.eq(NAMESPACE_CLOSED_CAPTIONS) {
             let captions = state
                 .get_device_manifest()

--- a/core/main/src/processor/storage/storage_manager.rs
+++ b/core/main/src/processor/storage/storage_manager.rs
@@ -26,7 +26,7 @@ use ripple_sdk::{
         storage_property::{StorageProperty, StoragePropertyData},
     },
     extn::extn_client_message::ExtnResponse,
-    log::debug,
+    log::trace,
     serde_json::{json, Value},
     tokio,
     utils::error::RippleError,
@@ -104,7 +104,7 @@ impl StorageManager {
         context: Option<Value>,
     ) -> RpcResult<()> {
         let data = property.as_data();
-        debug!("Storage property: {:?} as data: {:?}", property, data);
+        trace!("Storage property: {:?} as data: {:?}", property, data);
         if let Some(val) = state
             .ripple_cache
             .get_cached_bool_storage_property(&property)
@@ -387,7 +387,7 @@ impl StorageManager {
         namespace: String,
         key: &'static str,
     ) -> Result<StorageManagerResponse<bool>, StorageManagerError> {
-        debug!("get_bool: namespace={}, key={}", namespace, key);
+        trace!("get_bool: namespace={}, key={}", namespace, key);
         let resp = StorageManager::get(state, &namespace, &key.to_string(), None).await;
         match storage_to_bool_rpc_result(resp) {
             Ok(value) => Ok(StorageManagerResponse::Ok(value)),
@@ -453,7 +453,7 @@ impl StorageManager {
         key: &'static str,
         scope: Option<String>,
     ) -> Result<StorageManagerResponse<String>, StorageManagerError> {
-        debug!("get_string: namespace={}, key={}", namespace, key);
+        trace!("get_string: namespace={}, key={}", namespace, key);
         let resp = StorageManager::get(state, &namespace, &key.to_string(), scope).await;
         match storage_to_string_rpc_result(resp) {
             Ok(value) => Ok(StorageManagerResponse::Ok(value)),
@@ -474,7 +474,7 @@ impl StorageManager {
         namespace: String,
         key: &'static str,
     ) -> Result<StorageManagerResponse<u32>, StorageManagerError> {
-        debug!("get_string: namespace={}, key={}", namespace, key);
+        trace!("get_string: namespace={}, key={}", namespace, key);
         let resp = StorageManager::get(state, &namespace, &key.to_string(), None).await;
         match storage_to_u32_rpc_result(resp) {
             Ok(value) => Ok(StorageManagerResponse::Ok(value)),
@@ -497,9 +497,10 @@ impl StorageManager {
         namespace: String,
         key: &'static str,
     ) -> Result<StorageManagerResponse<f32>, StorageManagerError> {
-        debug!(
+        trace!(
             "get_number_as_f32_from_namespace: namespace={}, key={}",
-            namespace, key
+            namespace,
+            key
         );
         let resp = StorageManager::get(state, &namespace, &key.to_string(), None).await;
 
@@ -551,7 +552,7 @@ impl StorageManager {
         key: &String,
         scope: Option<String>,
     ) -> Result<ExtnResponse, RippleError> {
-        debug!("get: namespace={}, key={}", namespace, key);
+        trace!("get: namespace={}, key={}", namespace, key);
         let data = GetStorageProperty {
             namespace: namespace.clone(),
             key: key.clone(),
@@ -580,7 +581,7 @@ impl StorageManager {
         key: &String,
         scope: Option<String>,
     ) -> Result<ExtnResponse, RippleError> {
-        debug!("delete: namespace={}, key={}", namespace, key);
+        trace!("delete: namespace={}, key={}", namespace, key);
         let data = DeleteStorageProperty {
             namespace: namespace.clone(),
             key: key.clone(),
@@ -676,7 +677,7 @@ impl StorageManager {
                 let ctx = context.clone();
                 let evt = String::from(*event);
                 tokio::spawn(async move {
-                    debug!("notify: Sending event {:?} ctx {:?}", evt, ctx);
+                    trace!("notify: Sending event {:?} ctx {:?}", evt, ctx);
                     AppEvents::emit_with_context(&state_for_event, &evt, &result, ctx).await;
                 });
             }

--- a/core/main/src/service/apps/app_events.rs
+++ b/core/main/src/service/apps/app_events.rs
@@ -269,6 +269,8 @@ impl AppEvents {
             result: data,
             id: Id::Number(listener.call_ctx.call_id),
         };
+
+        // Events are pass through no stats
         let api_message = ApiMessage::new(
             protocol,
             json!(event).to_string(),

--- a/core/main/src/service/telemetry_builder.rs
+++ b/core/main/src/service/telemetry_builder.rs
@@ -33,7 +33,7 @@ use ripple_sdk::{
     chrono::{DateTime, Utc},
     extn::client::extn_client::ExtnClient,
     framework::RippleResponse,
-    log::{debug, error},
+    log::{error, trace},
 };
 use serde_json::Value;
 
@@ -226,7 +226,7 @@ impl TelemetryBuilder {
     ) -> Option<Timer> {
         let metrics_tags = get_metrics_tags(extn_client, InteractionType::Firebolt, Some(app_id))?;
 
-        debug!("start_firebolt_metrics_timer: {}: {:?}", name, metrics_tags);
+        trace!("start_firebolt_metrics_timer: {}: {:?}", name, metrics_tags);
 
         Some(Timer::start(
             name,

--- a/core/main/src/service/user_grants.rs
+++ b/core/main/src/service/user_grants.rs
@@ -53,7 +53,7 @@ use ripple_sdk::{
         usergrant_entry::UserGrantInfo,
     },
     framework::file_store::FileStore,
-    log::{debug, error, warn},
+    log::{debug, error, trace, warn},
     serde_json::Value,
     tokio::sync::oneshot,
     utils::error::RippleError,
@@ -568,7 +568,7 @@ impl GrantState {
             .await;
 
             if caps_needing_grant_in_request.is_empty() {
-                debug!("check_with_roles: caps_needing_grant_in_request list is empty() after applying grant_exclusion_filters");
+                trace!("check_with_roles: caps_needing_grant_in_request list is empty() after applying grant_exclusion_filters");
                 return Ok(());
             }
         }

--- a/core/main/src/state/bootstrap_state.rs
+++ b/core/main/src/state/bootstrap_state.rs
@@ -15,6 +15,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use std::time::Instant;
+
 use ripple_sdk::{
     api::apps::AppRequest,
     async_channel::{unbounded, Receiver as CReceiver, Sender as CSender},
@@ -107,6 +109,7 @@ impl Default for ChannelsState {
 
 #[derive(Debug, Clone)]
 pub struct BootstrapState {
+    pub start_time: Instant,
     pub platform_state: PlatformState,
     pub channels_state: ChannelsState,
     pub extn_state: ExtnState,
@@ -160,6 +163,7 @@ impl BootstrapState {
             None
         }
         Ok(BootstrapState {
+            start_time: Instant::now(),
             platform_state,
             channels_state,
             extn_state,

--- a/core/main/src/state/cap/generic_cap_state.rs
+++ b/core/main/src/state/cap/generic_cap_state.rs
@@ -27,7 +27,7 @@ use ripple_sdk::{
         },
         manifest::device_manifest::DeviceManifest,
     },
-    log::debug,
+    log::{error, info, trace},
 };
 use serde::Deserialize;
 use serde_json::json;
@@ -75,7 +75,7 @@ impl GenericCapState {
                 not_available.insert(cap.as_str());
             }
         }
-        debug!("Caps that are not available: {:?}", not_available);
+        info!("Caps that are not available: {:?}", not_available);
     }
 
     pub fn check_for_processor(&self, request: Vec<String>) -> HashMap<String, bool> {
@@ -139,11 +139,14 @@ impl GenericCapState {
                 result.push(fb_perm.cap.clone())
             }
         }
-        debug!(
+        trace!(
             "checking availability of caps request={:?}, not_available={:?}, result: {:?}",
-            request, not_available, result
+            request,
+            not_available,
+            result
         );
         if !result.is_empty() {
+            error!("Availability Error for {:?}", result);
             return Err(DenyReasonWithCap::new(DenyReason::Unavailable, result));
         }
         Ok(())

--- a/core/main/src/state/openrpc_state.rs
+++ b/core/main/src/state/openrpc_state.rs
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use openrpc_validator::jsonschema::JSONSchema;
 use ripple_sdk::log::{debug, error, info};
 use ripple_sdk::{api::firebolt::fb_openrpc::CapabilityPolicy, serde_json};
 use ripple_sdk::{
@@ -31,6 +32,7 @@ use ripple_sdk::{
     },
     utils::error::RippleError,
 };
+use serde_json::Value;
 use std::{
     collections::HashMap,
     sync::{Arc, RwLock},
@@ -75,6 +77,7 @@ pub struct OpenRpcState {
     provider_relation_map: Arc<RwLock<HashMap<String, ProviderRelationSet>>>,
     openrpc_validator: Arc<RwLock<FireboltOpenRpcValidator>>,
     provider_registrations: Vec<String>,
+    json_schema_cache: Arc<RwLock<HashMap<String, JSONSchema>>>,
 }
 
 impl OpenRpcState {
@@ -149,6 +152,7 @@ impl OpenRpcState {
             provider_relation_map: Arc::new(RwLock::new(HashMap::new())),
             openrpc_validator: Arc::new(RwLock::new(openrpc_validator)),
             provider_registrations,
+            json_schema_cache: Arc::new(RwLock::new(HashMap::new())),
         };
         v.build_provider_relation_sets(&firebolt_open_rpc.methods);
 
@@ -441,6 +445,28 @@ impl OpenRpcState {
             .write()
             .unwrap()
             .extend(provider_relation_sets)
+    }
+
+    pub fn add_json_schema_cache(&self, method: String, schema: JSONSchema) {
+        let mut json_cache = self.json_schema_cache.write().unwrap();
+        let _ = json_cache.insert(method, schema);
+    }
+
+    pub fn validate_schema(&self, method: &str, value: &Value) -> Result<(), Option<String>> {
+        let json_cache = self.json_schema_cache.read().unwrap();
+        if let Some(schema) = json_cache.get(method) {
+            if let Err(e) = schema.validate(value) {
+                let mut error_string = String::new();
+                for error in e {
+                    error_string.push_str(&format!("{} ", error));
+                }
+                Err(Some(error_string))
+            } else {
+                Ok(())
+            }
+        } else {
+            Err(None)
+        }
     }
 }
 

--- a/core/main/src/utils/router_utils.rs
+++ b/core/main/src/utils/router_utils.rs
@@ -17,10 +17,10 @@
 use ripple_sdk::{
     api::{
         apps::EffectiveTransport,
-        gateway::rpc_gateway_api::{ApiMessage, JsonRpcApiResponse},
+        gateway::rpc_gateway_api::{ApiMessage, JsonRpcApiResponse, RpcRequest},
     },
     extn::extn_client_message::{ExtnMessage, ExtnResponse},
-    log::error,
+    log::{error, trace},
     serde_json::{self, Result as SResult},
     utils::error::RippleError,
 };
@@ -75,4 +75,30 @@ pub fn return_extn_response(msg: ApiMessage, extn_msg: ExtnMessage) {
             error!("Not a Request object {:?}", extn_msg);
         }
     }
+}
+
+pub fn get_rpc_header_with_status(request: &RpcRequest, status_code: i32) -> String {
+    format!(
+        "{},{},{}",
+        request.ctx.app_id, request.ctx.method, status_code
+    )
+}
+
+pub fn get_rpc_header(request: &RpcRequest) -> String {
+    format!("{},{}", request.ctx.app_id, request.ctx.method)
+}
+
+pub fn add_telemetry_status_code(original_ref: &str, status_code: &str) -> String {
+    format!("{},{}", original_ref, status_code)
+}
+
+pub fn capture_stage(request: &mut RpcRequest, stage: &str) {
+    let duration = request.stats.update_stage(stage);
+    trace!(
+        "Firebolt processing stage: {},{},{},{}",
+        request.ctx.app_id,
+        request.ctx.method,
+        stage,
+        duration
+    )
 }

--- a/core/sdk/src/extn/client/extn_client.rs
+++ b/core/sdk/src/extn/client/extn_client.rs
@@ -254,7 +254,7 @@ impl ExtnClient {
                     continue;
                 }
             };
-            debug!("** receiving message latency={} msg={:?}", latency, message);
+            trace!("** receiving message latency={} msg={:?}", latency, message);
             if message.payload.is_response() {
                 Self::handle_single(message, self.response_processors.clone());
             } else if message.payload.is_event() {
@@ -268,9 +268,9 @@ impl ExtnClient {
                         &message.target_id.as_ref().unwrap().to_string(),
                     ) {
                         let send_response = self.sender.respond(message.into(), Some(sender));
-                        debug!("fwding event result: {:?}", send_response);
+                        trace!("fwding event result: {:?}", send_response);
                     } else {
-                        debug!("unable to get sender for target: {:?}", message.target_id);
+                        error!("unable to get sender for target: {:?}", message.target_id);
                         self.handle_no_processor_error(message);
                     }
                 } else {
@@ -378,7 +378,7 @@ impl ExtnClient {
         let new_context = { self.ripple_context.read().unwrap().clone() };
         let message = new_context.get_event_message();
         if propagate {
-            debug!("Formed Context update event: {:?}", message);
+            trace!("Formed Context update event: {:?}", message);
             let c_message: CExtnMessage = message.clone().into();
             {
                 let senders = self.get_other_senders();
@@ -388,7 +388,7 @@ impl ExtnClient {
                 }
             }
         } else {
-            debug!("Context information is already updated. Hence not propagating");
+            trace!("Context information is already updated. Hence not propagating");
         }
         Self::handle_vec_stream(message, self.event_processors.clone());
     }
@@ -697,7 +697,7 @@ impl ExtnClient {
             .send_request(id, payload, other_sender, Some(tx))?;
         match tokio::time::timeout(Duration::from_millis(timeout_in_msecs), tr.recv()).await {
             Ok(Ok(cmessage)) => {
-                debug!("** receiving message msg={:?}", cmessage);
+                trace!("** receiving message msg={:?}", cmessage);
                 let message: Result<ExtnMessage, RippleError> = cmessage.try_into();
 
                 if let Ok(message) = message {
@@ -777,7 +777,7 @@ impl ExtnClient {
         if let Some(sender) = self.get_extn_sender_with_extn_id(id) {
             self.sender.send_event(event, Some(sender))
         } else {
-            debug!("current client has so sender information so call forward event");
+            trace!("current client has so sender information so call forward event");
             self.sender.forward_event(id, event)
         }
     }
@@ -849,7 +849,7 @@ pub mod tests {
                 device_info_request::DeviceInfoRequest,
                 device_request::{AccountToken, DeviceRequest},
             },
-            gateway::rpc_gateway_api::{ApiProtocol, CallContext, RpcRequest},
+            gateway::rpc_gateway_api::{ApiProtocol, CallContext, RpcRequest, RpcStats},
             session::SessionAdjective,
         },
         extn::{
@@ -1260,6 +1260,7 @@ pub mod tests {
             ctx: new_ctx.clone(),
             method: "some.method".into(),
             params_json: RpcRequest::prepend_ctx(None, &new_ctx),
+            stats: RpcStats::default(),
         };
 
         tokio::spawn(async move {

--- a/core/sdk/src/framework/bootstrap.rs
+++ b/core/sdk/src/framework/bootstrap.rs
@@ -18,7 +18,7 @@
 use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
-use log::debug;
+use log::info;
 use tokio::sync::mpsc::{Receiver, Sender};
 
 use crate::utils::error::RippleError;
@@ -35,10 +35,10 @@ impl<S: Clone> Bootstrap<S> {
     }
 
     pub async fn step(&self, s: impl Bootstep<S>) -> Result<&Self, RippleError> {
-        debug!(">>>Starting Bootstep {}<<<", s.get_name());
+        info!(">>>Starting Bootstep {}<<<", s.get_name());
         s.setup(self.state.clone()).await?;
 
-        debug!("---Successful Bootstep {}---", s.get_name());
+        info!("---Successful Bootstep {}---", s.get_name());
         Ok(self)
     }
 }

--- a/examples/rpc_extn/src/rpc/legacy_jsonrpsee_extn.rs
+++ b/examples/rpc_extn/src/rpc/legacy_jsonrpsee_extn.rs
@@ -17,10 +17,9 @@
 
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use ripple_sdk::{
-    api::gateway::rpc_gateway_api::{ApiProtocol, CallContext, RpcRequest},
+    api::gateway::rpc_gateway_api::{ApiProtocol, CallContext, RpcRequest, RpcStats},
     async_trait::async_trait,
-    extn::client::extn_client::ExtnClient,
-    extn::extn_client_message::ExtnResponse,
+    extn::{client::extn_client::ExtnClient, extn_client_message::ExtnResponse},
     tokio::runtime::Runtime,
     utils::extn_utils::ExtnUtils,
 };
@@ -58,6 +57,7 @@ impl LegacyServer for LegacyImpl {
         let rpc_request = RpcRequest {
             ctx: new_ctx.clone(),
             method: "device.make".into(),
+            stats: RpcStats::default(),
             params_json: RpcRequest::prepend_ctx(Some(serde_json::Value::Null), &new_ctx),
         };
         if let Ok(Ok(ExtnResponse::Value(v))) = self
@@ -80,6 +80,7 @@ impl LegacyServer for LegacyImpl {
         let rpc_request = RpcRequest {
             ctx: new_ctx.clone(),
             method: "device.model".into(),
+            stats: RpcStats::default(),
             params_json: RpcRequest::prepend_ctx(Some(serde_json::Value::Null), &new_ctx),
         };
         if let Ok(msg) = client.request(rpc_request).await {


### PR DESCRIPTION
## What

Adds better logging to help triage and measure telemetry

## Why

Telemetry currently offered in Ripple is very limiting, there is a need for measuring the time taken in each stage for every request.
Some of the Ripple logging have been too verbose for triaging and some production logs are lacking to help investigate issues faster.

## How

By addition of RpcStats object to RPCRequest during request processing and API message for Response dispatching
## Test

Tested by making calls to multiple Firebolt APIs and validating the logs

## Checklist

- [ ] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
