### PR TITLE
RPPL-2654 Merge RPPL-2593 changes to 1.13

### DIFF
--- a/core/main/src/firebolt/handlers/account_rpc.rs
+++ b/core/main/src/firebolt/handlers/account_rpc.rs
@@ -22,11 +22,9 @@ use jsonrpsee::{
 };
 use ripple_sdk::{
     api::{
-        distributor::distributor_encoder::EncoderRequest,
         gateway::rpc_gateway_api::CallContext,
         session::{AccountSessionRequest, AccountSessionTokenRequest},
     },
-    extn::extn_client_message::ExtnResponse,
     log::error,
 };
 
@@ -35,14 +33,16 @@ use crate::{
     utils::rpc_utils::rpc_err,
 };
 
+const KEY_FIREBOLT_ACCOUNT_UID: &str = "fireboltAccountUid";
+
 #[rpc(server)]
 pub trait Account {
     #[method(name = "account.session")]
     async fn session(&self, ctx: CallContext, a_t_r: AccountSessionTokenRequest) -> RpcResult<()>;
     #[method(name = "account.id")]
-    async fn id_rpc(&self, ctx: CallContext) -> RpcResult<String>;
+    async fn id(&self, ctx: CallContext) -> RpcResult<String>;
     #[method(name = "account.uid")]
-    async fn uid_rpc(&self, ctx: CallContext) -> RpcResult<String>;
+    async fn uid(&self, ctx: CallContext) -> RpcResult<String>;
 }
 
 #[derive(Debug, Clone)]
@@ -68,31 +68,13 @@ impl AccountServer for AccountImpl {
         Ok(())
     }
 
-    async fn id_rpc(&self, _ctx: CallContext) -> RpcResult<String> {
+    async fn id(&self, _ctx: CallContext) -> RpcResult<String> {
         self.id().await
     }
 
-    async fn uid_rpc(&self, ctx: CallContext) -> RpcResult<String> {
-        if let Ok(id) = self.id().await {
-            if self.platform_state.supports_encoding() {
-                if let Ok(resp) = self
-                    .platform_state
-                    .get_client()
-                    .send_extn_request(EncoderRequest {
-                        reference: id.clone(),
-                        scope: ctx.app_id.clone(),
-                    })
-                    .await
-                {
-                    if let Some(ExtnResponse::String(s)) = resp.payload.extract() {
-                        return Ok(s);
-                    }
-                }
-            }
-            return Ok(id);
-        }
-
-        Err(rpc_err("Account.uid: some failure"))
+    async fn uid(&self, ctx: CallContext) -> RpcResult<String> {
+        crate::utils::common::get_uid(&self.platform_state, ctx.app_id, KEY_FIREBOLT_ACCOUNT_UID)
+            .await
     }
 }
 impl AccountImpl {

--- a/core/main/src/firebolt/rpc_router.rs
+++ b/core/main/src/firebolt/rpc_router.rs
@@ -133,15 +133,19 @@ async fn resolve_route(
 impl RpcRouter {
     pub async fn route(
         state: PlatformState,
-        req: RpcRequest,
+        mut req: RpcRequest,
         session: Session,
         timer: Option<Timer>,
     ) {
         let methods = state.router_state.get_methods();
         let resources = state.router_state.resources.clone();
 
+        let method = req.method.clone();
+        if let Some(overridden_method) = state.get_manifest().has_rpc_override_method(&req.method) {
+            req.method = overridden_method;
+        }
+
         tokio::spawn(async move {
-            let method = req.method.clone();
             let app_id = req.ctx.app_id.clone();
             let start = Utc::now().timestamp_millis();
             let resp = resolve_route(methods, resources, req.clone()).await;

--- a/core/main/src/utils/common.rs
+++ b/core/main/src/utils/common.rs
@@ -1,0 +1,30 @@
+use crate::processor::storage::storage_manager::StorageManager;
+use crate::state::platform_state::PlatformState;
+use jsonrpsee::core::RpcResult;
+use ripple_sdk::{api::storage_property::StoragePropertyData, uuid::Uuid};
+
+const UID_SCOPE: &str = "device";
+
+pub async fn get_uid(
+    state: &PlatformState,
+    app_id: String,
+    key: &'static str,
+) -> RpcResult<String> {
+    let uid: String;
+    let mut data = StoragePropertyData {
+        scope: Some(UID_SCOPE.to_string()),
+        key,
+        namespace: app_id.clone(),
+        value: String::new(),
+    };
+
+    if let Ok(id) = StorageManager::get_string_for_scope(state, &data).await {
+        uid = id;
+    } else {
+        // Using app_id as namespace will result in different uid for each app
+        data.value = Uuid::new_v4().to_string();
+        StorageManager::set_string_for_scope(state, &data, None).await?;
+        uid = data.value;
+    }
+    Ok(uid)
+}

--- a/core/main/src/utils/mod.rs
+++ b/core/main/src/utils/mod.rs
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+pub mod common;
 pub mod router_utils;
 pub mod rpc_utils;
 pub mod serde_utils;

--- a/core/sdk/src/api/manifest/extn_manifest.rs
+++ b/core/sdk/src/api/manifest/extn_manifest.rs
@@ -32,6 +32,8 @@ pub struct ExtnManifest {
     pub extns: Vec<ExtnManifestEntry>,
     pub required_contracts: Vec<String>,
     pub rpc_aliases: HashMap<String, Vec<String>>,
+    #[serde(default)]
+    pub rpc_overrides: HashMap<String, String>,
     pub timeout: Option<u64>,
     #[serde(default)]
     pub rules_path: Vec<String>,
@@ -50,6 +52,7 @@ impl Default for ExtnManifest {
             extns: Vec::new(),
             required_contracts: Vec::new(),
             rpc_aliases: HashMap::new(),
+            rpc_overrides: HashMap::new(),
             timeout: None,
             rules_path: Vec::new(),
             extn_sdks: Vec::new(),
@@ -202,6 +205,10 @@ impl ExtnManifest {
     pub fn get_timeout(&self) -> u64 {
         self.timeout.unwrap_or(10000)
     }
+
+    pub fn has_rpc_override_method(&self, method: &str) -> Option<String> {
+        self.rpc_overrides.get(method).cloned()
+    }
 }
 #[cfg(test)]
 mod tests {
@@ -223,6 +230,7 @@ mod tests {
                 extns: vec![],
                 required_contracts: vec![],
                 rpc_aliases: HashMap::new(),
+                rpc_overrides: HashMap::new(),
                 timeout: Some(5000),
                 rules_path: Vec::new(),
                 extn_sdks: Vec::new(),
@@ -284,7 +292,18 @@ mod tests {
             }
         "#;
 
-        let expected_manifest = ExtnManifest::default();
+        let expected_manifest = ExtnManifest {
+            default_path: "".to_string(),
+            default_extension: "".to_string(),
+            extns: vec![],
+            required_contracts: vec![],
+            rpc_aliases: HashMap::new(),
+            rpc_overrides: HashMap::new(),
+            timeout: None,
+            rules_path: Vec::new(),
+            extn_sdks: Vec::new(),
+            provider_registrations: default_providers(),
+        };
 
         assert_eq!(
             ExtnManifest::load_from_content(contents.to_string()),

--- a/core/sdk/src/api/storage_property.rs
+++ b/core/sdk/src/api/storage_property.rs
@@ -73,9 +73,6 @@ pub const KEY_PARTNER_EXCLUSIONS: &str = "partnerExclusions";
 pub const KEY_SKIP_RESTRICTION: &str = "skipRestriction";
 pub const KEY_AUDIO_DESCRIPTION_ENABLED: &str = "audioDescriptionEnabled";
 pub const KEY_PREFERRED_AUDIO_LANGUAGES: &str = "preferredAudioLanguages";
-pub const KEY_FIREBOLT_DEVICE_UID: &str = "fireboltDeviceUid";
-
-pub const SCOPE_DEVICE: &str = "device";
 
 pub const EVENT_CLOSED_CAPTIONS_SETTINGS_CHANGED: &str =
     "accessibility.onClosedCaptionsSettingsChanged";


### PR DESCRIPTION
…… (#660)

RPPL-2593 Device.uid is returning a value that contains dash (#633) (… (#657)

RPPL-2593 Device.uid is returning a value that contains dash (#633) (#656)

* fix: implement rpc_overriddes

* build: cleanup

* build: cleanup

* fix: remove algorithm

* build: cleanup

* fix: cleanup device.uid after implementing legacy.device.uid in badger

* fix: clippy errors

* build: cleanup

## What

What does this PR add or remove?

## Why

Why are these changes needed?

## How

How do these changes achieve the goal?

## Test

How has this been tested? How can a reviewer test it?

## Checklist

- [ ] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
