### PR TITLE
fix: Multiple instances of Thunder Broker created during Ripple bootstrap

### DIFF
--- a/core/main/src/broker/endpoint_broker.rs
+++ b/core/main/src/broker/endpoint_broker.rs
@@ -458,6 +458,10 @@ impl EndpointBrokerState {
 
     pub fn build_other_endpoints(&mut self, session: Option<AccountSession>) {
         for (key, endpoint) in self.rule_engine.rules.endpoints.clone() {
+            // skip thunder endpoint as it is already built using build_thunder_endpoint
+            if key == "thunder" {
+                continue;
+            }
             let request = BrokerConnectRequest::new_with_sesssion(
                 key,
                 endpoint.clone(),

--- a/core/main/src/broker/endpoint_broker.rs
+++ b/core/main/src/broker/endpoint_broker.rs
@@ -459,7 +459,7 @@ impl EndpointBrokerState {
     pub fn build_other_endpoints(&mut self, session: Option<AccountSession>) {
         for (key, endpoint) in self.rule_engine.rules.endpoints.clone() {
             // skip thunder endpoint as it is already built using build_thunder_endpoint
-            if key == "thunder" {
+            if let RuleEndpointProtocol::Thunder = endpoint.protocol {
                 continue;
             }
             let request = BrokerConnectRequest::new_with_sesssion(


### PR DESCRIPTION

## What

 Skipped Thunder Endpoint creation when setting up OtherBrokers.

## Why

ThunderBroker instances are created at multiple places. 

## How

How do these changes achieve the goal?

## Test

How has this been tested? How can a reviewer test it?

## Checklist

- [ ] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
