### PR TITLE
feat: Create an RDK contract test framework using generic client.

### DIFF
--- a/device/thunder_ripple_sdk/Cargo.toml
+++ b/device/thunder_ripple_sdk/Cargo.toml
@@ -33,7 +33,9 @@ contract_tests = [
     "test-log",
     "home",
     "tree_magic_mini",
-    "rstest"
+    "rstest",
+    "futures-util"
+
 ]
 local_dev=[]
 
@@ -61,6 +63,7 @@ csv = "1.1"  # Allowing minor updates
 home = { version = "=0.5.5", optional = true }
 tree_magic_mini = { version = "=3.0.3", optional = true }
 rstest = { version = "0.18.2", optional = true, default-features = false }
+futures-util = { version = "0.3.28", features = ["sink", "std"], default-features = false, optional = true}
 
 [dev-dependencies]
 

--- a/device/thunder_ripple_sdk/src/tests/contracts/thunder_controller_pacts.rs
+++ b/device/thunder_ripple_sdk/src/tests/contracts/thunder_controller_pacts.rs
@@ -34,15 +34,19 @@ async fn test_register_state_change_event() {
         })
     );
 
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 0,
-        "method": "Controller.1.register",
-        "params": json!({
-            "event": "statechange", "id": "client.Controller.1.events"
+    send_thunder_call_message!(
+        server_url.to_string(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "Controller.1.register",
+            "params": {
+                "event": "statechange",
+                "id": "client.Controller.1.events"
+            }
         })
-    });
-    send_thunder_call_message!(server_url.to_string(), request).await;
+    )
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -80,13 +84,16 @@ async fn test_device_info_plugin_status() {
         })
     );
 
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 1,
-        "method": "Controller.1.status@DeviceInfo",
-        "params": json!({})
-    });
-    send_thunder_call_message!(server_url.to_string(), request).await;
+    send_thunder_call_message!(
+        server_url.to_string(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "Controller.1.status@DeviceInfo",
+            "params": json!({})
+        })
+    )
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -111,15 +118,18 @@ async fn test_device_info_plugin_state() {
         })
     );
 
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 2,
-        "method": "Controller.1.activate",
-        "params": json!({
-            "callsign": "DeviceInfo",
+    send_thunder_call_message!(
+        server_url.to_string(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "Controller.1.activate",
+            "params": json!({
+                "callsign": "DeviceInfo",
+            })
         })
-    });
-    send_thunder_call_message!(server_url.to_string(), request).await;
+    )
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -157,12 +167,15 @@ async fn test_display_settings_plugin_status() {
         })
     );
 
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 3,
-        "method": "Controller.1.status@org.rdk.DisplaySettings",
-    });
-    send_thunder_call_message!(server_url.to_string(), request).await;
+    send_thunder_call_message!(
+        server_url.to_string(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "Controller.1.status@org.rdk.DisplaySettings",
+        })
+    )
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -187,15 +200,18 @@ async fn test_activate_display_settings_plugin() {
         })
     );
 
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 4,
-        "method": "Controller.1.activate",
-        "params": json!({
-            "callsign": "org.rdk.DisplaySettings",
+    send_thunder_call_message!(
+        server_url.to_string(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "Controller.1.activate",
+            "params": json!({
+                "callsign": "org.rdk.DisplaySettings",
+            })
         })
-    });
-    send_thunder_call_message!(server_url.to_string(), request).await;
+    )
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -233,12 +249,15 @@ async fn test_status_org_rdk_system() {
         })
     );
 
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 5,
-        "method": "Controller.1.status@org.rdk.System",
-    });
-    send_thunder_call_message!(server_url.to_string(), request).await;
+    send_thunder_call_message!(
+        server_url.to_string(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "Controller.1.status@org.rdk.System",
+        })
+    )
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -263,15 +282,18 @@ async fn test_activate_org_rdk_system() {
         })
     );
 
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 6,
-        "method": "Controller.1.activate",
-        "params": json!({
-            "callsign": "org.rdk.System",
+    send_thunder_call_message!(
+        server_url.to_string(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 6,
+            "method": "Controller.1.activate",
+            "params": json!({
+                "callsign": "org.rdk.System",
+            })
         })
-    });
-    send_thunder_call_message!(server_url.to_string(), request).await;
+    )
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -309,12 +331,15 @@ async fn test_status_org_rdk_hdcp_profile() {
         })
     );
 
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 7,
-        "method": "Controller.1.status@org.rdk.HdcpProfile",
-    });
-    send_thunder_call_message!(server_url.to_string(), request).await;
+    send_thunder_call_message!(
+        server_url.to_string(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "Controller.1.status@org.rdk.HdcpProfile",
+        })
+    )
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -339,15 +364,18 @@ async fn test_activate_org_rdk_hdcp_profile() {
         })
     );
 
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 8,
-        "method": "Controller.1.activate",
-        "params": json!({
-            "callsign": "org.rdk.HdcpProfile",
+    send_thunder_call_message!(
+        server_url.to_string(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 8,
+            "method": "Controller.1.activate",
+            "params": json!({
+                "callsign": "org.rdk.HdcpProfile",
+            })
         })
-    });
-    send_thunder_call_message!(server_url.to_string(), request).await;
+    )
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -386,12 +414,15 @@ async fn test_status_org_rdk_telemetry() {
         })
     );
 
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 9,
-        "method": "Controller.1.status@org.rdk.Telemetry",
-    });
-    send_thunder_call_message!(server_url.to_string(), request).await;
+    send_thunder_call_message!(
+        server_url.to_string(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 9,
+            "method": "Controller.1.status@org.rdk.Telemetry",
+        })
+    )
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -416,13 +447,16 @@ async fn test_activate_org_rdk_telemetry() {
         })
     );
 
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 10,
-        "method": "Controller.1.activate",
-        "params": json!({
-            "callsign": "org.rdk.Telemetry",
+    send_thunder_call_message!(
+        server_url.to_string(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 10,
+            "method": "Controller.1.activate",
+            "params": json!({
+                "callsign": "org.rdk.Telemetry",
+            })
         })
-    });
-    send_thunder_call_message!(server_url.to_string(), request).await;
+    )
+    .await;
 }

--- a/device/thunder_ripple_sdk/src/tests/contracts/thunder_device_info_pacts.rs
+++ b/device/thunder_ripple_sdk/src/tests/contracts/thunder_device_info_pacts.rs
@@ -68,16 +68,20 @@ async fn test_device_get_info_mac_address() {
         .start_mock_server_async(Some("websockets/transport/websockets"))
         .await;
 
-    let server_url = url::Url::parse(mock_server.path("/jsonrpc").as_str()).unwrap();
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 0,
-        "method": "org.rdk.System.1.getDeviceInfo",
-        "params": json!({
-            "params": ["estb_mac"]
+    send_thunder_call_message!(
+        url::Url::parse(mock_server.path("/jsonrpc").as_str())
+            .unwrap()
+            .to_string(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "org.rdk.System.1.getDeviceInfo",
+            "params": {
+                "params": ["estb_mac"]
+            }
         })
-    });
-    send_thunder_call_message!(server_url.to_string(), request).await;
+    )
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -122,13 +126,17 @@ async fn test_device_get_model() {
         .start_mock_server_async(Some("websockets/transport/websockets"))
         .await;
 
-    let server_url = url::Url::parse(mock_server.path("/jsonrpc").as_str()).unwrap();
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 0,
-        "method": "org.rdk.System.1.getSystemVersions"
-    });
-    send_thunder_call_message!(server_url.to_string(), request).await;
+    send_thunder_call_message!(
+        url::Url::parse(mock_server.path("/jsonrpc").as_str())
+            .unwrap()
+            .to_string(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "org.rdk.System.1.getSystemVersions"
+        })
+    )
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -175,13 +183,17 @@ async fn test_device_get_interfaces_wifi() {
         .start_mock_server_async(Some("websockets/transport/websockets"))
         .await;
 
-    let server_url = url::Url::parse(mock_server.path("/jsonrpc").as_str()).unwrap();
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 0,
-        "method": "org.rdk.Network.1.getInterfaces"
-    });
-    send_thunder_call_message!(server_url.to_string(), request).await;
+    send_thunder_call_message!(
+        url::Url::parse(mock_server.path("/jsonrpc").as_str())
+            .unwrap()
+            .to_string(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "org.rdk.Network.1.getInterfaces"
+        })
+    )
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -228,13 +240,17 @@ async fn test_device_get_interfaces_ethernet() {
         .start_mock_server_async(Some("websockets/transport/websockets"))
         .await;
 
-    let server_url = url::Url::parse(mock_server.path("/jsonrpc").as_str()).unwrap();
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 0,
-        "method": "org.rdk.Network.1.getInterfaces"
-    });
-    send_thunder_call_message!(server_url.to_string(), request).await;
+    send_thunder_call_message!(
+        url::Url::parse(mock_server.path("/jsonrpc").as_str())
+            .unwrap()
+            .to_string(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "org.rdk.Network.1.getInterfaces"
+        })
+    )
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -270,13 +286,17 @@ async fn test_device_get_audio() {
         .start_mock_server_async(Some("websockets/transport/websockets"))
         .await;
 
-    let server_url = url::Url::parse(mock_server.path("/jsonrpc").as_str()).unwrap();
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 0,
-        "method": "org.rdk.DisplaySettings.1.getAudioFormat"
-    });
-    send_thunder_call_message!(server_url.to_string(), request).await;
+    send_thunder_call_message!(
+        url::Url::parse(mock_server.path("/jsonrpc").as_str())
+            .unwrap()
+            .to_string(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "org.rdk.DisplaySettings.1.getAudioFormat"
+        })
+    )
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -311,13 +331,17 @@ async fn test_device_get_hdcp_supported() {
         .start_mock_server_async(Some("websockets/transport/websockets"))
         .await;
 
-    let server_url = url::Url::parse(mock_server.path("/jsonrpc").as_str()).unwrap();
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 0,
-        "method": "org.rdk.HdcpProfile.1.getSettopHDCPSupport"
-    });
-    send_thunder_call_message!(server_url.to_string(), request).await;
+    send_thunder_call_message!(
+        url::Url::parse(mock_server.path("/jsonrpc").as_str())
+            .unwrap()
+            .to_string(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "org.rdk.HdcpProfile.1.getSettopHDCPSupport"
+        })
+    )
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -358,13 +382,17 @@ async fn test_device_get_hdcp_status() {
         .start_mock_server_async(Some("websockets/transport/websockets"))
         .await;
 
-    let server_url = url::Url::parse(mock_server.path("/jsonrpc").as_str()).unwrap();
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 0,
-        "method": "org.rdk.HdcpProfile.1.getHDCPStatus"
-    });
-    send_thunder_call_message!(server_url.to_string(), request).await;
+    send_thunder_call_message!(
+        url::Url::parse(mock_server.path("/jsonrpc").as_str())
+            .unwrap()
+            .to_string(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "org.rdk.HdcpProfile.1.getHDCPStatus"
+        })
+    )
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -395,13 +423,17 @@ async fn test_device_get_hdr() {
         .start_mock_server_async(Some("websockets/transport/websockets"))
         .await;
 
-    let server_url = url::Url::parse(mock_server.path("/jsonrpc").as_str()).unwrap();
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 0,
-        "method": "org.rdk.DisplaySettings.1.getTVHDRCapabilities"
-    });
-    send_thunder_call_message!(server_url.to_string(), request).await;
+    send_thunder_call_message!(
+        url::Url::parse(mock_server.path("/jsonrpc").as_str())
+            .unwrap()
+            .to_string(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "org.rdk.DisplaySettings.1.getTVHDRCapabilities"
+        })
+    )
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -434,13 +466,17 @@ async fn test_device_get_screen_resolution_without_port() {
         .start_mock_server_async(Some("websockets/transport/websockets"))
         .await;
 
-    let server_url = url::Url::parse(mock_server.path("/jsonrpc").as_str()).unwrap();
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 0,
-        "method": "org.rdk.DisplaySettings.1.getCurrentResolution"
-    });
-    send_thunder_call_message!(server_url.to_string(), request).await;
+    send_thunder_call_message!(
+        url::Url::parse(mock_server.path("/jsonrpc").as_str())
+            .unwrap()
+            .to_string(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "org.rdk.DisplaySettings.1.getCurrentResolution"
+        })
+    )
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -467,13 +503,17 @@ async fn test_device_get_make() {
         .start_mock_server_async(Some("websockets/transport/websockets"))
         .await;
 
-    let server_url = url::Url::parse(mock_server.path("/jsonrpc").as_str()).unwrap();
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 0,
-        "method": "org.rdk.System.1.getDeviceInfo"
-    });
-    send_thunder_call_message!(server_url.to_string(), request).await;
+    send_thunder_call_message!(
+        url::Url::parse(mock_server.path("/jsonrpc").as_str())
+            .unwrap()
+            .to_string(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "org.rdk.System.1.getDeviceInfo"
+        })
+    )
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -517,13 +557,17 @@ async fn test_device_get_video_resolution() {
         .start_mock_server_async(Some("websockets/transport/websockets"))
         .await;
 
-    let server_url = url::Url::parse(mock_server.path("/jsonrpc").as_str()).unwrap();
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 0,
-        "method": "org.rdk.DisplaySettings.1.getCurrentResolution"
-    });
-    send_thunder_call_message!(server_url.to_string(), request).await;
+    send_thunder_call_message!(
+        url::Url::parse(mock_server.path("/jsonrpc").as_str())
+            .unwrap()
+            .to_string(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "org.rdk.DisplaySettings.1.getCurrentResolution"
+        })
+    )
+    .await;
 }
 
 // #[tokio::test(flavor = "multi_thread")]
@@ -612,13 +656,17 @@ async fn test_device_get_timezone() {
         .start_mock_server_async(Some("websockets/transport/websockets"))
         .await;
 
-    let server_url = url::Url::parse(mock_server.path("/jsonrpc").as_str()).unwrap();
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 0,
-        "method": "org.rdk.System.1.getTimeZoneDST"
-    });
-    send_thunder_call_message!(server_url.to_string(), request).await;
+    send_thunder_call_message!(
+        url::Url::parse(mock_server.path("/jsonrpc").as_str())
+            .unwrap()
+            .to_string(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "org.rdk.System.1.getTimeZoneDST"
+        })
+    )
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -669,13 +717,17 @@ async fn test_device_get_available_timezone() {
         .start_mock_server_async(Some("websockets/transport/websockets"))
         .await;
 
-    let server_url = url::Url::parse(mock_server.path("/jsonrpc").as_str()).unwrap();
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 0,
-        "method": "org.rdk.System.1.getTimeZones"
-    });
-    send_thunder_call_message!(server_url.to_string(), request).await;
+    send_thunder_call_message!(
+        url::Url::parse(mock_server.path("/jsonrpc").as_str())
+            .unwrap()
+            .to_string(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "org.rdk.System.1.getTimeZones"
+        })
+    )
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -710,13 +762,17 @@ async fn test_device_get_voice_guidance_enabled() {
         .start_mock_server_async(Some("websockets/transport/websockets"))
         .await;
 
-    let server_url = url::Url::parse(mock_server.path("/jsonrpc").as_str()).unwrap();
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 0,
-        "method": "org.rdk.TextToSpeech.1.isttsenabled"
-    });
-    send_thunder_call_message!(server_url.to_string(), request).await;
+    send_thunder_call_message!(
+        url::Url::parse(mock_server.path("/jsonrpc").as_str())
+            .unwrap()
+            .to_string(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "org.rdk.TextToSpeech.1.isttsenabled"
+        })
+    )
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -774,13 +830,17 @@ async fn test_device_get_voice_guidance_speed() {
         .start_mock_server_async(Some("websockets/transport/websockets"))
         .await;
 
-    let server_url = url::Url::parse(mock_server.path("/jsonrpc").as_str()).unwrap();
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 0,
-        "method": "org.rdk.TextToSpeech.1.getttsconfiguration"
-    });
-    send_thunder_call_message!(server_url.to_string(), request).await;
+    send_thunder_call_message!(
+        url::Url::parse(mock_server.path("/jsonrpc").as_str())
+            .unwrap()
+            .to_string(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "org.rdk.TextToSpeech.1.getttsconfiguration"
+        })
+    )
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -817,16 +877,20 @@ async fn test_device_set_timezone() {
         .start_mock_server_async(Some("websockets/transport/websockets"))
         .await;
 
-    let server_url = url::Url::parse(mock_server.path("/jsonrpc").as_str()).unwrap();
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 0,
-        "method": "org.rdk.System.1.setTimeZoneDST",
-        "params": json!({
-            "timeZone": "America/New_York"
+    send_thunder_call_message!(
+        url::Url::parse(mock_server.path("/jsonrpc").as_str())
+            .unwrap()
+            .to_string(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "org.rdk.System.1.setTimeZoneDST",
+            "params": json!({
+                "timeZone": "America/New_York"
+            })
         })
-    });
-    send_thunder_call_message!(server_url.to_string(), request).await;
+    )
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -861,16 +925,20 @@ async fn test_device_set_voice_guidance() {
         .start_mock_server_async(Some("websockets/transport/websockets"))
         .await;
 
-    let server_url = url::Url::parse(mock_server.path("/jsonrpc").as_str()).unwrap();
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 0,
-        "method": "org.rdk.TextToSpeech.1.enabletts",
-        "params": json!({
-            "enabletts": false
+    send_thunder_call_message!(
+        url::Url::parse(mock_server.path("/jsonrpc").as_str())
+            .unwrap()
+            .to_string(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "org.rdk.TextToSpeech.1.enabletts",
+            "params": json!({
+                "enabletts": false
+            })
         })
-    });
-    send_thunder_call_message!(server_url.to_string(), request).await;
+    )
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -905,16 +973,20 @@ async fn test_device_set_voice_guidance_speed() {
         .start_mock_server_async(Some("websockets/transport/websockets"))
         .await;
 
-    let server_url = url::Url::parse(mock_server.path("/jsonrpc").as_str()).unwrap();
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 0,
-        "method": "org.rdk.TextToSpeech.1.setttsconfiguration",
-        "params": json!({
-            "rate": 50
+    send_thunder_call_message!(
+        url::Url::parse(mock_server.path("/jsonrpc").as_str())
+            .unwrap()
+            .to_string(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "org.rdk.TextToSpeech.1.setttsconfiguration",
+            "params": json!({
+                "rate": 50
+            })
         })
-    });
-    send_thunder_call_message!(server_url.to_string(), request).await;
+    )
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -948,11 +1020,15 @@ async fn test_device_get_internet() {
         .start_mock_server_async(Some("websockets/transport/websockets"))
         .await;
 
-    let server_url = url::Url::parse(mock_server.path("/jsonrpc").as_str()).unwrap();
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 0,
-        "method": "org.rdk.Network.1.isConnectedToInternet"
-    });
-    send_thunder_call_message!(server_url.to_string(), request).await;
+    send_thunder_call_message!(
+        url::Url::parse(mock_server.path("/jsonrpc").as_str())
+            .unwrap()
+            .to_string(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "org.rdk.Network.1.isConnectedToInternet"
+        })
+    )
+    .await;
 }

--- a/device/thunder_ripple_sdk/src/tests/contracts/thunder_persistent_store_pacts.rs
+++ b/device/thunder_ripple_sdk/src/tests/contracts/thunder_persistent_store_pacts.rs
@@ -91,22 +91,26 @@ async fn test_device_set_persistent_value(with_scope: bool) {
         .start_mock_server_async(Some("websockets/transport/websockets"))
         .await;
 
-    let server_url = url::Url::parse(mock_server.path("/jsonrpc").as_str()).unwrap();
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 0,
-        "method": "org.rdk.PersistentStore.1.setValue",
-        "params": json!({
-            "namespace": "testNameSpace",
-            "key": "testKey",
-            "value": {
-                "update_time": Utc::now().to_rfc3339(),
-                "value": "testValue1"
-            },
-            "scope": "device"
+    send_thunder_call_message!(
+        url::Url::parse(mock_server.path("/jsonrpc").as_str())
+            .unwrap()
+            .to_string(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "org.rdk.PersistentStore.1.setValue",
+            "params": json!({
+                "namespace": "testNameSpace",
+                "key": "testKey",
+                "value": {
+                    "update_time": Utc::now().to_rfc3339(),
+                    "value": "testValue1"
+                },
+                "scope": "device"
+            })
         })
-    });
-    send_thunder_call_message!(server_url.to_string(), request).await;
+    )
+    .await;
 }
 
 #[rstest(with_scope, case(true), case(false))]
@@ -161,18 +165,22 @@ async fn test_device_get_persistent_value(with_scope: bool) {
         .start_mock_server_async(Some("websockets/transport/websockets"))
         .await;
 
-    let server_url = url::Url::parse(mock_server.path("/jsonrpc").as_str()).unwrap();
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 0,
-        "method": "org.rdk.PersistentStore.1.getValue",
-        "params": json!({
-            "namespace": "testNamespace",
-            "key": "testKey",
-            "scope": "device"
+    send_thunder_call_message!(
+        url::Url::parse(mock_server.path("/jsonrpc").as_str())
+            .unwrap()
+            .to_string(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "org.rdk.PersistentStore.1.getValue",
+            "params": json!({
+                "namespace": "testNamespace",
+                "key": "testKey",
+                "scope": "device"
+            })
         })
-    });
-    send_thunder_call_message!(server_url.to_string(), request).await;
+    )
+    .await;
 }
 
 #[rstest(with_scope, case(true), case(false))]
@@ -225,16 +233,20 @@ async fn test_device_delete_persistent_value_by_key(with_scope: bool) {
         .start_mock_server_async(Some("websockets/transport/websockets"))
         .await;
 
-    let server_url = url::Url::parse(mock_server.path("/jsonrpc").as_str()).unwrap();
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 0,
-        "method": "org.rdk.PersistentStore.1.deleteKey",
-        "params": json!({
-            "namespace": "testNamespace",
-            "key": "testKey",
-            "scope": "device"
+    send_thunder_call_message!(
+        url::Url::parse(mock_server.path("/jsonrpc").as_str())
+            .unwrap()
+            .to_string(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "org.rdk.PersistentStore.1.deleteKey",
+            "params": json!({
+                "namespace": "testNamespace",
+                "key": "testKey",
+                "scope": "device"
+            })
         })
-    });
-    send_thunder_call_message!(server_url.to_string(), request).await;
+    )
+    .await;
 }

--- a/device/thunder_ripple_sdk/src/tests/contracts/thunder_remote_pacts.rs
+++ b/device/thunder_ripple_sdk/src/tests/contracts/thunder_remote_pacts.rs
@@ -15,8 +15,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use crate::{get_pact_with_params, send_thunder_call_message};
 use crate::tests::contracts::contract_utils::*;
+use crate::{get_pact_with_params, send_thunder_call_message};
 use crate::{
     ripple_sdk::serde_json::{self},
     thunder_state::ThunderState,
@@ -65,17 +65,21 @@ async fn test_device_remote_start_pairing() {
         .start_mock_server_async(Some("websockets/transport/websockets"))
         .await;
 
-    let server_url = url::Url::parse(mock_server.path("/jsonrpc").as_str()).unwrap();
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 0,
-        "method": "org.rdk.RemoteControl.1.startPairing",
-        "params": json!({
-            "netType": 21,
-            "timeout": 30
+    send_thunder_call_message!(
+        url::Url::parse(mock_server.path("/jsonrpc").as_str())
+            .unwrap()
+            .to_string(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "org.rdk.RemoteControl.1.startPairing",
+            "params": json!({
+                "netType": 21,
+                "timeout": 30
+            })
         })
-    });
-    send_thunder_call_message!(server_url.to_string(), request).await;
+    )
+    .await;
 }
 
 // #[tokio::test(flavor = "multi_thread")]
@@ -144,14 +148,18 @@ async fn test_device_remote_network_status() {
     let protocol: Option<AccessoryProtocolListType> = Some(AccessoryProtocolListType::All);
     let list_params = AccessoryListRequest { _type, protocol };
 
-    let server_url = url::Url::parse(mock_server.path("/jsonrpc").as_str()).unwrap();
-    let request = json!({
-        "jsonrpc": "2.0",
-        "id": 0,
-        "method": "org.rdk.RemoteControl.1.getNetStatus",
-        "params": json!({
-            "netType": 21
+    send_thunder_call_message!(
+        url::Url::parse(mock_server.path("/jsonrpc").as_str())
+            .unwrap()
+            .to_string(),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "org.rdk.RemoteControl.1.getNetStatus",
+            "params": json!({
+                "netType": 21
+            })
         })
-    });
-    send_thunder_call_message!(server_url.to_string(), request).await;    
+    )
+    .await;
 }

--- a/device/thunder_ripple_sdk/src/tests/contracts/thunder_remote_pacts.rs
+++ b/device/thunder_ripple_sdk/src/tests/contracts/thunder_remote_pacts.rs
@@ -15,24 +15,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use crate::client::thunder_client_pool::ThunderClientPool;
-use crate::get_pact_with_params;
-use crate::processors::thunder_remote::ThunderRemoteAccessoryRequestProcessor;
-use crate::ripple_sdk::extn::client::extn_processor::ExtnRequestProcessor;
+use crate::{get_pact_with_params, send_thunder_call_message};
 use crate::tests::contracts::contract_utils::*;
-use crate::thunder_state::ThunderConnectionState;
 use crate::{
-    ripple_sdk::{
-        api::device::{
-            device_accessory::{
-                AccessoryPairRequest, AccessoryProtocol, AccessoryType, RemoteAccessoryRequest,
-            },
-            device_request::DeviceRequest,
-        },
-        async_channel::unbounded,
-        extn::extn_client_message::{ExtnPayload, ExtnRequest},
-        serde_json::{self},
-    },
+    ripple_sdk::serde_json::{self},
     thunder_state::ThunderState,
 };
 use pact_consumer::mock_server::StartMockServerAsync;
@@ -41,8 +27,11 @@ use ripple_sdk::api::device::device_accessory::AccessoryListType;
 use ripple_sdk::api::device::device_accessory::AccessoryProtocolListType;
 use serde_json::json;
 use std::collections::HashMap;
-use std::sync::Arc;
 
+use futures_util::{SinkExt, StreamExt};
+use tokio::time::{timeout, Duration};
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::protocol::Message;
 // #[tokio::test(flavor = "multi_thread")]
 // #[cfg_attr(not(feature = "contract_tests"), ignore)]
 #[allow(dead_code)]
@@ -76,36 +65,17 @@ async fn test_device_remote_start_pairing() {
         .start_mock_server_async(Some("websockets/transport/websockets"))
         .await;
 
-    let _type = AccessoryType::Remote;
-    let timeout = 1;
-    let protocol = AccessoryProtocol::BluetoothLE;
-    let pair_params = AccessoryPairRequest {
-        _type,
-        timeout,
-        protocol,
-    };
-    let payload = ExtnPayload::Request(ExtnRequest::Device(DeviceRequest::Accessory(
-        RemoteAccessoryRequest::Pair(pair_params.clone()),
-    )));
-    let msg = get_extn_msg(payload);
-
-    let url = url::Url::parse(mock_server.path("/jsonrpc").as_str()).unwrap();
-    let thunder_client =
-        ThunderClientPool::start(url, None, Some(Arc::new(ThunderConnectionState::new())), 1)
-            .await
-            .unwrap();
-
-    let (s, r) = unbounded();
-    let extn_client = get_extn_client(s.clone(), r.clone());
-
-    let state: ThunderState = ThunderState::new(extn_client, thunder_client);
-
-    let _ = ThunderRemoteAccessoryRequestProcessor::process_request(
-        state,
-        msg,
-        RemoteAccessoryRequest::Pair(pair_params.clone()),
-    )
-    .await;
+    let server_url = url::Url::parse(mock_server.path("/jsonrpc").as_str()).unwrap();
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 0,
+        "method": "org.rdk.RemoteControl.1.startPairing",
+        "params": json!({
+            "netType": 21,
+            "timeout": 30
+        })
+    });
+    send_thunder_call_message!(server_url.to_string(), request).await;
 }
 
 // #[tokio::test(flavor = "multi_thread")]
@@ -173,26 +143,15 @@ async fn test_device_remote_network_status() {
     let _type: Option<AccessoryListType> = Some(AccessoryListType::All);
     let protocol: Option<AccessoryProtocolListType> = Some(AccessoryProtocolListType::All);
     let list_params = AccessoryListRequest { _type, protocol };
-    let payload = ExtnPayload::Request(ExtnRequest::Device(DeviceRequest::Accessory(
-        RemoteAccessoryRequest::List(list_params.clone()),
-    )));
-    let msg = get_extn_msg(payload);
 
-    let url = url::Url::parse(mock_server.path("/jsonrpc").as_str()).unwrap();
-    let thunder_client =
-        ThunderClientPool::start(url, None, Some(Arc::new(ThunderConnectionState::new())), 1)
-            .await
-            .unwrap();
-
-    let (s, r) = unbounded();
-    let extn_client = get_extn_client(s.clone(), r.clone());
-
-    let state: ThunderState = ThunderState::new(extn_client, thunder_client);
-
-    let _ = ThunderRemoteAccessoryRequestProcessor::process_request(
-        state,
-        msg,
-        RemoteAccessoryRequest::List(list_params.clone()),
-    )
-    .await;
+    let server_url = url::Url::parse(mock_server.path("/jsonrpc").as_str()).unwrap();
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 0,
+        "method": "org.rdk.RemoteControl.1.getNetStatus",
+        "params": json!({
+            "netType": 21
+        })
+    });
+    send_thunder_call_message!(server_url.to_string(), request).await;    
 }


### PR DESCRIPTION
## What

Use a thin websocket client to send thunder call message to pact server instead of using thunder extension processor and Thunder client pool 
## Why

Many of the thunder extension processing functions are removed as Ripple is now using Rule Engine.
Rippple is migrating to AsyncThunderClient and will be removing the usage of Thunder ClientPool  
## How

How do these changes achieve the goal?

## Test

How has this been tested? How can a reviewer test it?

## Checklist

- [ ] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
