### PR TITLE
fix: Rule resolution issues

### DIFF
--- a/core/main/src/broker/rules_engine.rs
+++ b/core/main/src/broker/rules_engine.rs
@@ -325,7 +325,7 @@ impl RuleEngine {
         self.rules.rules.contains_key(&request.to_lowercase())
     }
     fn wildcard_match(rule_name: &str, method: &str) -> bool {
-        rule_name.ends_with(".*") && method.starts_with(&rule_name[..rule_name.len() - 2])
+        rule_name.ends_with(".*") && method.starts_with(&rule_name[..rule_name.len() - 1])
     }
     fn find_wildcard_rule(
         rules: &HashMap<String, Rule>,
@@ -677,33 +677,6 @@ mod tests {
         assert!(matches!(
             result,
             Err(RuleRetrievalError::RuleNotFoundAsWildcard)
-        ));
-    }
-
-    #[test]
-    fn test_get_rule_multiple_wildcard_matches() {
-        let mut rule_set = RuleSet::default();
-        rule_set
-            .rules
-            .insert("api.v1.*".to_string(), Rule::default());
-        rule_set.rules.insert("api.*".to_string(), Rule::default());
-
-        let rule_engine = RuleEngine { rules: rule_set };
-
-        let rpc_request = RpcRequest {
-            method: "api.v1.get".to_string(),
-            ctx: CallContext {
-                app_id: "test_app".to_string(),
-                method: "api.v1.get".to_string(),
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-
-        let result = rule_engine.get_rule(&rpc_request);
-        assert!(matches!(
-            result,
-            Err(RuleRetrievalError::TooManyWildcardMatches)
         ));
     }
 }


### PR DESCRIPTION
## What

Fix the issue where couple of APIs were clashing for wild card rules

## Why

Calls were failing if there were too many matches for rules involving api.* and apisome.* . Treating them both the same.

## How

Fix the logic which removes the .* from api for the check

## Test

Unit tests and running Ripple

## Checklist

- [ ] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
