### PR TITLE
RPPL-3292: Extn manifest update

### DIFF
--- a/examples/reference-manifest/IpStb/firebolt-extn-manifest.json
+++ b/examples/reference-manifest/IpStb/firebolt-extn-manifest.json
@@ -3,91 +3,10 @@
     "default_extension": "so",
     "timeout": 2000,
     "extns": [
-        {
-            "path": "libthunder",
-            "symbols": [
-                {
-                    "id": "ripple:channel:device:thunder",
-                    "uses": [
-                        "config",
-                        "ripple_context",
-                        "app_events",
-                        "rpc"
-                    ],
-                    "fulfills": [
-                        "ripple_context",
-                        "window_manager",
-                        "browser",
-                        "device_info",
-                        "wifi",
-                        "local.storage",
-                        "remote_accessory",
-                        "app_events",
-                        "input.device_events",
-                        "voice_guidance.device_events",
-                        "audio.device_events"
-                    ]
-                }
-            ]
-        },
-        {
-            "path": "liblauncher",
-            "symbols": [
-                {
-                    "id": "ripple:channel:launcher:internal",
-                    "uses": [
-                        "config",
-                        "lifecycle_management",
-                        "device_info",
-                        "window_manager",
-                        "browser"
-                    ],
-                    "fulfills": [
-                        "launcher"
-                    ]
-                }
-            ]
-        },
-        {
-            "path": "libdistributor_general",
-            "symbols": [
-                {
-                    "id": "ripple:channel:distributor:general",
-                    "uses": [
-                        "config"
-                    ],
-                    "fulfills": [
-                        "permissions",
-                        "account.session",
-                        "device.session",
-                        "root.session",
-                        "advertising",
-                        "behavior_metrics"
-                    ]
-                }
-            ]
-        }
     ],
     "required_contracts": [
-        "rpc",
-        "lifecycle_management",
-        "device_info",
-        "window_manager",
-        "browser",
-        "permissions",
-        "wifi",
-        "local.storage",
-        "remote_accessory",
-        "privacy_settings",
-        "account.session",
-        "device.session",
-        "behavior_metrics"
     ],
-    "rpc_aliases": {
-        "device.model": [
-            "custom.model"
-        ]
-    },
+    "rpc_aliases": {},
     "rules_path": [
         "/etc/ripple.common.rules.json"
     ]


### PR DESCRIPTION
With JQ rules in place, there is no need for extension manifest anymore. Keeping the structure in place until this file can be removed.

## What

Removed the extensions no longer present

## Why

Ripple is crashing in community builds

## How

Removing dependency to invalid libraries

## Test

Make sure ripple runs without issues.

## Checklist

- [ x] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
