### PR TITLE
Changing Metrics.mediaRenditionChange rate field into json Number type.

### DIFF
--- a/core/main/src/firebolt/handlers/metrics_rpc.rs
+++ b/core/main/src/firebolt/handlers/metrics_rpc.rs
@@ -20,6 +20,7 @@ use jsonrpsee::{
     proc_macros::rpc,
     RpcModule,
 };
+use serde_json::Number;
 use std::collections::HashMap;
 
 use ripple_sdk::{
@@ -175,7 +176,7 @@ pub struct MediaRateChangeParams {
 pub struct MediaRenditionChangeParams {
     #[serde(rename = "entityId")]
     pub entity_id: String,
-    pub bitrate: u32,
+    pub bitrate: Number,
     pub width: u32,
     pub height: u32,
     pub profile: Option<String>,

--- a/core/main/src/firebolt/handlers/metrics_rpc.rs
+++ b/core/main/src/firebolt/handlers/metrics_rpc.rs
@@ -170,7 +170,7 @@ pub struct MediaSeekedParams {
 pub struct MediaRateChangeParams {
     #[serde(rename = "entityId")]
     pub entity_id: String,
-    pub rate: u32,
+    pub rate: Number,
 }
 #[derive(Deserialize, Debug, Clone)]
 pub struct MediaRenditionChangeParams {

--- a/core/sdk/src/api/firebolt/fb_metrics.rs
+++ b/core/sdk/src/api/firebolt/fb_metrics.rs
@@ -349,7 +349,7 @@ impl From<&MediaSeeked> for Option<f32> {
 pub struct MediaRateChanged {
     pub context: BehavioralMetricContext,
     pub entity_id: String,
-    pub rate: u32,
+    pub rate: Number,
 }
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct MediaRenditionChanged {

--- a/core/sdk/src/api/firebolt/fb_metrics.rs
+++ b/core/sdk/src/api/firebolt/fb_metrics.rs
@@ -19,7 +19,7 @@ use std::collections::{HashMap, HashSet};
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{Number, Value};
 
 use crate::{
     api::{gateway::rpc_gateway_api::CallContext, session::AccountSession},
@@ -355,7 +355,7 @@ pub struct MediaRateChanged {
 pub struct MediaRenditionChanged {
     pub context: BehavioralMetricContext,
     pub entity_id: String,
-    pub bitrate: u32,
+    pub bitrate: Number,
     pub width: u32,
     pub height: u32,
     pub profile: Option<String>,


### PR DESCRIPTION
## What

Changing Metrics.mediaRenditionChange rate field into json Number type

## Why

spec define the field is number, that either a integer or float

## How

changes rate field into json Number type
## Test

invoke Metrics.mediaRenditionChange api.
## Checklist

- [ ] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
