### PR TITLE
feat: Move the openRPC schema validation crate under a feature flag and disable it by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,11 @@ members = [
     "core/tdk",
     "device/thunder_ripple_sdk",
     "core/main",
-    "device/mock_device",
-    "openrpc_validator"]
+    "device/mock_device"]
+
+# openrpc_validator is excluded from the default workspace build
+# It will only be included when the openrpc_validation feature is enabled
+exclude = ["openrpc_validator"]
 
 [workspace.package]
 version = "1.1.0"

--- a/core/main/Cargo.toml
+++ b/core/main/Cargo.toml
@@ -32,6 +32,7 @@ path = "src/main.rs"
 local_dev = []
 sysd = ["sd-notify"]
 pre_prod = []
+openrpc_validation = ["dep:openrpc_validator"]
 http_contract_tests = [
 ]
 
@@ -69,7 +70,9 @@ jaq-std = { version = "1.5.1", default-features = false }
 strum = { version = "0.24", default-features = false }
 strum_macros = "0.24"
 
-openrpc_validator = { path = "../../openrpc_validator" }
+# openrpc_validator is optional and not part of the default workspace
+# Only included when openrpc_validation feature is enabled
+openrpc_validator = { path = "../../openrpc_validator", optional = true, default-features = false }
 proc-macro2.workspace = true
 
 [build-dependencies]

--- a/core/main/src/state/openrpc_state.rs
+++ b/core/main/src/state/openrpc_state.rs
@@ -15,7 +15,85 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#[cfg(feature = "openrpc_validation")]
 use openrpc_validator::jsonschema::JSONSchema;
+#[cfg(feature = "openrpc_validation")]
+use openrpc_validator::{FireboltOpenRpc as FireboltOpenRpcValidator, RpcMethodValidator};
+
+#[cfg(not(feature = "openrpc_validation"))]
+pub mod openrpc_validator {
+    pub mod jsonschema {
+        #[derive(Debug, Clone)]
+        pub struct JSONSchema;
+
+        impl JSONSchema {
+            pub fn validate(&self, _value: &serde_json::Value) -> Result<(), Vec<String>> {
+                Ok(())
+            }
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    pub struct RpcMethodValidator;
+
+    impl RpcMethodValidator {
+        pub fn new() -> Self {
+            RpcMethodValidator
+        }
+
+        pub fn add_schema(&mut self, _schema: super::FireboltOpenRpcValidator) {
+            // No-op when validation is disabled
+        }
+
+        pub fn get_method(&self, _name: &str) -> Option<super::RpcMethod> {
+            None
+        }
+
+        pub fn get_closest_result_properties_schema(
+            &self,
+            _name: &str,
+            _sample_map: &serde_json::Map<String, serde_json::Value>,
+        ) -> Option<serde_json::Map<String, serde_json::Value>> {
+            None
+        }
+
+        pub fn get_result_ref_schema(
+            &self,
+            _reference_path: &str,
+        ) -> Option<serde_json::Map<String, serde_json::Value>> {
+            None
+        }
+
+        pub fn params_validator(
+            &self,
+            _version: String,
+            _method: &str,
+        ) -> Result<jsonschema::JSONSchema, super::ValidationError> {
+            Ok(jsonschema::JSONSchema)
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    pub struct FireboltOpenRpcValidator;
+
+    #[derive(Debug)]
+    pub enum ValidationError {
+        SpecVersionNotFound,
+    }
+
+    #[derive(Debug, Clone)]
+    pub struct RpcMethod {
+        pub name: String,
+    }
+}
+
+#[cfg(not(feature = "openrpc_validation"))]
+use openrpc_validator::jsonschema::JSONSchema;
+#[cfg(not(feature = "openrpc_validation"))]
+use openrpc_validator::{RpcMethod, RpcMethodValidator, ValidationError};
+#[cfg(not(feature = "openrpc_validation"))]
+type FireboltOpenRpcValidator = openrpc_validator::FireboltOpenRpcValidator;
+
 use ripple_sdk::log::{debug, error, info};
 use ripple_sdk::{api::firebolt::fb_openrpc::CapabilityPolicy, serde_json};
 use ripple_sdk::{
@@ -37,8 +115,6 @@ use std::{
     collections::HashMap,
     sync::{Arc, RwLock},
 };
-
-use openrpc_validator::{FireboltOpenRpc as FireboltOpenRpcValidator, RpcMethodValidator};
 
 #[derive(Debug, Clone)]
 pub enum ApiSurface {
@@ -77,6 +153,7 @@ pub struct OpenRpcState {
     provider_relation_map: Arc<RwLock<HashMap<String, ProviderRelationSet>>>,
     openrpc_validator: Arc<RwLock<RpcMethodValidator>>,
     provider_registrations: Arc<Vec<String>>,
+    #[cfg(feature = "openrpc_validation")]
     json_schema_cache: Arc<RwLock<HashMap<String, JSONSchema>>>,
 }
 
@@ -125,10 +202,19 @@ impl OpenRpcState {
             .expect("Failed parsing FireboltVersionManifest from open RPC file");
         let firebolt_open_rpc: FireboltOpenRpc = version_manifest.clone().into();
         let ripple_open_rpc: FireboltOpenRpc = FireboltOpenRpc::default();
-        let openrpc_validator: FireboltOpenRpcValidator = serde_json::from_str(&open_rpc_path)
-            .expect("Failed parsing FireboltOpenRpcValidator from open RPC file");
-        let mut rpc_method_validator = RpcMethodValidator::new();
-        rpc_method_validator.add_schema(openrpc_validator);
+
+        #[cfg(feature = "openrpc_validation")]
+        let rpc_method_validator = {
+            let openrpc_validator: FireboltOpenRpcValidator = serde_json::from_str(&open_rpc_path)
+                .expect("Failed parsing FireboltOpenRpcValidator from open RPC file");
+            let mut validator = RpcMethodValidator::new();
+            validator.add_schema(openrpc_validator);
+            validator
+        };
+
+        #[cfg(not(feature = "openrpc_validation"))]
+        let rpc_method_validator = RpcMethodValidator::new();
+
         let v = OpenRpcState {
             firebolt_cap_map: Arc::new(RwLock::new(firebolt_open_rpc.get_methods_caps())),
             ripple_cap_map: Arc::new(RwLock::new(ripple_open_rpc.get_methods_caps())),
@@ -139,6 +225,7 @@ impl OpenRpcState {
             provider_relation_map: Arc::new(RwLock::new(HashMap::new())),
             openrpc_validator: Arc::new(RwLock::new(rpc_method_validator)),
             provider_registrations: Arc::new(provider_registrations),
+            #[cfg(feature = "openrpc_validation")]
             json_schema_cache: Arc::new(RwLock::new(HashMap::new())),
         };
         v.build_provider_relation_sets(&firebolt_open_rpc.methods);
@@ -172,21 +259,29 @@ impl OpenRpcState {
 
     // Add extension open rpc to the validator
     pub fn add_extension_open_rpc_to_validator(&self, path: String) -> Result<(), RippleError> {
-        let extension_open_rpc_string = load_extension_open_rpc(path);
-        if let Some(open_rpc) = extension_open_rpc_string {
-            return match serde_json::from_str::<FireboltOpenRpcValidator>(&open_rpc) {
-                Ok(additional_open_rpc_validator) => {
-                    let mut validator = self.openrpc_validator.write().unwrap();
-                    validator.add_schema(additional_open_rpc_validator);
-                    return Ok(());
-                }
-                Err(e) => {
-                    error!("Error parsing openrpc validator from e={:?}", e);
-                    Err(RippleError::ParseError)
-                }
+        #[cfg(feature = "openrpc_validation")]
+        {
+            let extension_open_rpc_string = load_extension_open_rpc(path);
+            if let Some(open_rpc) = extension_open_rpc_string {
+                return match serde_json::from_str::<FireboltOpenRpcValidator>(&open_rpc) {
+                    Ok(additional_open_rpc_validator) => {
+                        let mut validator = self.openrpc_validator.write().unwrap();
+                        validator.add_schema(additional_open_rpc_validator);
+                        return Ok(());
+                    }
+                    Err(e) => {
+                        error!("Error parsing openrpc validator from e={:?}", e);
+                        Err(RippleError::ParseError)
+                    }
+                };
             };
-        };
-        Err(RippleError::ParseError)
+            Err(RippleError::ParseError)
+        }
+        #[cfg(not(feature = "openrpc_validation"))]
+        {
+            let _ = path; // Suppress unused variable warning
+            Ok(()) // No-op when validation is disabled
+        }
     }
 
     pub fn is_excluded(&self, method: String, app_id: String) -> bool {
@@ -434,11 +529,18 @@ impl OpenRpcState {
             .extend(provider_relation_sets)
     }
 
+    #[cfg(feature = "openrpc_validation")]
     pub fn add_json_schema_cache(&self, method: String, schema: JSONSchema) {
         let mut json_cache = self.json_schema_cache.write().unwrap();
         let _ = json_cache.insert(method, schema);
     }
 
+    #[cfg(not(feature = "openrpc_validation"))]
+    pub fn add_json_schema_cache(&self, method: String, schema: JSONSchema) {
+        let _ = (method, schema); // Suppress unused variable warnings
+    }
+
+    #[cfg(feature = "openrpc_validation")]
     pub fn validate_schema(&self, method: &str, value: &Value) -> Result<(), Option<String>> {
         let json_cache = self.json_schema_cache.read().unwrap();
         if let Some(schema) = json_cache.get(method) {
@@ -454,6 +556,12 @@ impl OpenRpcState {
         } else {
             Err(None)
         }
+    }
+
+    #[cfg(not(feature = "openrpc_validation"))]
+    pub fn validate_schema(&self, method: &str, value: &Value) -> Result<(), Option<String>> {
+        let _ = (method, value); // Suppress unused variable warnings
+        Err(None) // Always return "not found" when validation is disabled
     }
 }
 
@@ -516,6 +624,7 @@ fn load_firebolt_open_rpc_path() -> Result<String, RippleError> {
     load_firebolt_open_rpc_from_file("/etc/ripple/openrpc/firebolt-open-rpc.json")
 }
 
+#[allow(dead_code)]
 fn load_extension_open_rpc(path: String) -> Option<String> {
     match std::fs::read_to_string(&path) {
         Ok(content) => {

--- a/openrpc_validator/Cargo.toml
+++ b/openrpc_validator/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 
 [dependencies]
 jsonschema = { version = "0.17.1", default-features = false }
-serde_json.workspace = true
-serde.workspace = true
-clap = {version = "=4.0", features = ["std"], default-features = false} # std required during ripple start
+serde_json = { version = "1.0", default-features = false }
+serde = { version = "1.0", features = ["derive"], default-features = false }
+clap = { version = "=4.0", features = ["std"], default-features = false }


### PR DESCRIPTION
## What

1. Made OpenRPC validation support optional in the Ripple repository.
2. Added the openrpc_validation feature flag in Cargo.toml to conditionally include the openrpc_validator dependency.
3. Marked openrpc_validator as an optional dependency, only enabled when the feature is specified.
4. Updated the workspace Cargo.toml to exclude openrpc_validator from the default build.
5. Refactored openrpc_state.rs to use conditional compilation:

When the openrpc_validation feature is enabled, real validation logic is used.
When disabled, dummy types and no-op methods are provided, allowing the code to compile and run without validation.
This change reduces build size and dependencies for default builds, while still allowing full OpenRPC validation when needed.

## Why

Why are these changes needed?

## How

How do these changes achieve the goal?

## Test

How has this been tested? How can a reviewer test it?

## Checklist

- [x] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
