### PR TITLE
fix : reverting session id cleanup due to VG issue.

### DIFF
--- a/core/main/src/firebolt/firebolt_gateway.rs
+++ b/core/main/src/firebolt/firebolt_gateway.rs
@@ -141,7 +141,7 @@ impl FireboltGateway {
                     self.state
                         .platform_state
                         .endpoint_state
-                        .cleanup_for_app(&session_id)
+                        .cleanup_for_app(&cid)
                         .await;
                     self.state.platform_state.session_state.clear_session(&cid);
                 }


### PR DESCRIPTION
## What
reverting session id cleanup due to VG issue.

## Why
cid changed into sessionid as part of cleanup.

## How
reverted the change

## Test
VG in amazon

## Checklist

- [ ] I have self-reviewed this PR
- [ ] I have added tests that prove the feature works or the fix is effective
