### PR TITLE
fix: if no provider there sending error response.

### DIFF
--- a/core/main/src/service/apps/provider_broker.rs
+++ b/core/main/src/service/apps/provider_broker.rs
@@ -287,7 +287,7 @@ impl ProviderBroker {
                 .tx
                 .send(ProviderResponsePayload::GenericError(
                     GenericProviderError {
-                        code: 320001,
+                        code: 32001,
                         message: format!("Provider not found for {}", request.method),
                         data: None,
                     },

--- a/core/main/src/service/apps/provider_broker.rs
+++ b/core/main/src/service/apps/provider_broker.rs
@@ -288,7 +288,7 @@ impl ProviderBroker {
                 .send(ProviderResponsePayload::GenericError(
                     GenericProviderError {
                         code: 320001,
-                        message: "Provider not found".into(),
+                        message: format!("Provider not found for {}", request.method),
                         data: None,
                     },
                 ))

--- a/core/main/src/service/apps/provider_broker.rs
+++ b/core/main/src/service/apps/provider_broker.rs
@@ -26,8 +26,8 @@ use ripple_sdk::{
             },
             fb_openrpc::FireboltOpenRpcMethod,
             provider::{
-                FocusRequest, ProviderRequest, ProviderRequestPayload, ProviderResponse,
-                ProviderResponsePayload,
+                FocusRequest, GenericProviderError, ProviderRequest, ProviderRequestPayload,
+                ProviderResponse, ProviderResponsePayload,
             },
         },
         gateway::rpc_gateway_api::{CallContext, CallerSession},
@@ -282,8 +282,17 @@ impl ProviderBroker {
                 provider_app_id = Some(provider_method.provider.app_id);
             }
         } else {
-            debug!("queuing provider request");
-            ProviderBroker::queue_provider_request(pst, request);
+            // If no provider found, send error response
+            request
+                .tx
+                .send(ProviderResponsePayload::GenericError(
+                    GenericProviderError {
+                        code: 320001,
+                        message: "Provider not found".into(),
+                        data: None,
+                    },
+                ))
+                .unwrap();
         }
 
         provider_app_id
@@ -310,18 +319,6 @@ impl ProviderBroker {
             },
         );
         c_id
-    }
-
-    fn queue_provider_request(pst: &PlatformState, request: ProviderBrokerRequest) {
-        // Remove any duplicate requests.
-        ProviderBroker::remove_request(pst, &request.capability);
-
-        let mut request_queue = pst.provider_broker_state.request_queue.write().unwrap();
-        if request_queue.is_full() {
-            warn!("invoke_method: Request queue full, removing oldest request");
-            request_queue.remove(0);
-        }
-        request_queue.push(request);
     }
 
     pub async fn provider_response(pst: &PlatformState, resp: ProviderResponse) {


### PR DESCRIPTION
## What
There is no provider subscribed we are waiting for a timeout error instead we should be erroring immediately stating no provider.

## Why
As expect immediately respond back as error.

## How
instead of waiting responded back as error.

## Test
integrated players tests

## Checklist

- [x] I have self-reviewed this PR
- [x] I have added tests that prove the feature works or the fix is effective
